### PR TITLE
Small fix for GL stuff

### DIFF
--- a/lisp/gl.carp
+++ b/lisp/gl.carp
@@ -1,9 +1,15 @@
+(if (linux?)
+    (do
+       (def *LIBNAME* "libglfw.so.3")
+       (def gl (load-dylib "libGL.so.1"))) "")
 
-(if (osx?) (def *LIBNAME* "libglfw3.dylib") "")
-(if (linux?) (def *LIBNAME* "libglfw.so.3") "")
+(if (osx?)
+    (do
+       (def *LIBNAME* "libglfw3.dylib")
+       (def gl glfw)) "")
+
 
 (def glfw (load-dylib *LIBNAME*))
-(def gl (load-dylib "libGL.so.1"))
 
 (reset! extra-header-deps (cons "<GLFW/glfw3.h>" extra-header-deps))
 

--- a/lisp/gl.carp
+++ b/lisp/gl.carp
@@ -1,8 +1,9 @@
 
 (if (osx?) (def *LIBNAME* "libglfw3.dylib") "")
-(if (linux?) (def *LIBNAME* "libglfw.so") "")
+(if (linux?) (def *LIBNAME* "libglfw.so.3") "")
 
 (def glfw (load-dylib *LIBNAME*))
+(def gl (load-dylib "libGL.so.1"))
 
 (reset! extra-header-deps (cons "<GLFW/glfw3.h>" extra-header-deps))
 
@@ -23,14 +24,14 @@
 (def glfw-cursor-callback-type '(:fn ((:ref :GLFWwindow) :double :double) :void))
 (register glfw "glfwSetCursorPosCallback" (list '(:ref :GLFWwindow) glfw-cursor-callback-type) :void)
 
-(register glfw "glClearColor" '(:float :float :float :float) :void)
-(register glfw "glClear" '(:int) :void)
-(register glfw "glColor3f" '(:float :float :float) :void)
-(register glfw "glBegin" '(:int) :void)
-(register glfw "glEnd" '() :void)
-(register glfw "glVertex3f" '(:float, :float, :float) :void)
-(register glfw "glOrtho" '(:double :double :double :double :double :double) :void)
-(register glfw "glLoadIdentity" '() :void)
+(register gl "glClearColor" '(:float :float :float :float) :void)
+(register gl "glClear" '(:int) :void)
+(register gl "glColor3f" '(:float :float :float) :void)
+(register gl "glBegin" '(:int) :void)
+(register gl "glEnd" '() :void)
+(register gl "glVertex3f" '(:float, :float, :float) :void)
+(register gl "glOrtho" '(:double :double :double :double :double :double) :void)
+(register gl "glLoadIdentity" '() :void)
 
 (def carp-gl-color-buffer-bit 16384)
 (def carp-gl-lines 1)

--- a/lisp/gl.carp
+++ b/lisp/gl.carp
@@ -1,15 +1,18 @@
+(def glfw nil)
+(def gl nil)
+
 (if (linux?)
     (do
-       (def *LIBNAME* "libglfw.so.3")
+       (def glfw (load-dylib "libglfw.so.3"))
        (def gl (load-dylib "libGL.so.1"))) "")
 
 (if (osx?)
     (do
-       (def *LIBNAME* "libglfw3.dylib")
+       (def glfw (load-dylib "libglfw3.dylib"))
        (def gl glfw)) "")
 
 
-(def glfw (load-dylib *LIBNAME*))
+
 
 (reset! extra-header-deps (cons "<GLFW/glfw3.h>" extra-header-deps))
 


### PR DESCRIPTION
So I updated from Ubuntu 15.10 to 16.04 and realized that spin and other GL examples would not run, but they compiled fine. On startup you would get a complain that glClearColor etc could not be found. The patch now loads glClearColor etc... (all GL functions you would register in gl.carp from  line 37 on) from the library libGL.so.1. This is very linux specific I cross tested with my mac, and the code there still compiles and runs fine.