### PR TITLE
Fix build errors on Linux (Ubuntu 14.04)

### DIFF
--- a/lisp/cc.carp
+++ b/lisp/cc.carp
@@ -28,7 +28,7 @@
   (cond
       (windows?) ""
       (osx?)     (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -lglfw3")
-      (linux?)   (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -lglfw")))
+      (linux?)   (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -lglfw -lm -pthread -ldl")))
 
 (defn framework-paths ()
   (if (or (windows?) (linux?))

--- a/shared/platform.h
+++ b/shared/platform.h
@@ -17,6 +17,10 @@
 #define _GNU_SOURCE
 #endif
 
+#ifndef __USE_GNU
+#define __USE_GNU
+#endif
+
 #include <dlfcn.h>
 #include <unistd.h>
 


### PR DESCRIPTION
These changes fixes a compilation error and several linking errors on Ubuntu 14.04, when running `(bake-exe ...)` to build a program. On my setup I have installed all dependencies (libffi, libfw3, rlwrap) using `apt-get`.

On this operating system definition of `RTLD_DEFAULT` is protected by `__USE_GNU` so it is added as definition.

In addition, `m`, `pthread` and `dl` need to be linked in order to build successfully.