### PR TITLE
src/main doesn't need to include shared/platform.h since this is incl…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,3 @@
-#include "../shared/platform.h"
 #include "../shared/shared.h"
 #include "repl.h"
 #include "eval.h"


### PR DESCRIPTION
…uded via shared/shared.h - better to have shared/shared.h be the only thing needed to get all of shared

The argument here is basically that `src/main` serves as an example of how to include the shared header files, and `shared/shared.h` should be the single interface to them all.