### PR TITLE
Minimal readline support in REPL

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -46,6 +46,7 @@ executable carp
                      , CarpHask
                      , containers
                      , process
+                     , readline
   default-language:    Haskell2010
 
 test-suite CarpHask-test


### PR DESCRIPTION
Allows to move in the input line with cursors and also keeps an in-process history. Not perfect, but it helps a lot, especially typing up arrow to repeat the last command.