### PR TITLE
Use haskeline for REPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /out/main.c
 /.DS_Store
 /Carp.prof
+dist/

--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -17,7 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Obj,
                        Parsing,
-                       Infer,                       
+                       Infer,
                        Emit,
                        ColorText,
                        Constraints,
@@ -35,7 +35,7 @@ library
                        Polymorphism,
                        Concretize,
                        ArrayTemplates
-                        
+
   build-depends:       base >= 4.7 && < 5
                      , parsec == 3.1.*
                      , mtl
@@ -43,7 +43,7 @@ library
                      , process
                      , directory
                      , split
-                       
+
   default-language:    Haskell2010
 
 executable carp
@@ -53,6 +53,7 @@ executable carp
   build-depends:       base
                      , CarpHask
                      , containers
+                     , haskeline
                      , process
   default-language:    Haskell2010
 


### PR DESCRIPTION
This PR introduces Haskeline, a pure Haskell implementation fo editline, into Carp’s REPL. This means we have regular editline capabilities now, including history. Should we want to tweak the settings, we will have to move from `defaultSettings` to something more advanced, but I suggest we stick to this for now, as it is already better than what we used to have.

Cheers