### PR TITLE
Added simple completion and history file

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -53,6 +53,7 @@ executable carp
   build-depends:       base
                      , CarpHask
                      , containers
+                     , directory
                      , haskeline
                      , process
   default-language:    Haskell2010


### PR DESCRIPTION
This PR adds simple completion and a history file to carp. The completion is purely for keywords–and the list is currently hardcoded—, and the history file is assumed to be `"~/.carp_history"`.

Cheers