### PR TITLE
Vector module

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -157,6 +157,7 @@ preludeModules carpDir = map (\s -> carpDir ++ "/core/" ++ s ++ ".carp") [ "Macr
                                                                          , "IO"
                                                                          , "System"
                                                                          , "Test"
+                                                                         , "Vector"
                                                                          ]
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -158,6 +158,7 @@ preludeModules carpDir = map (\s -> carpDir ++ "/core/" ++ s ++ ".carp") [ "Macr
                                                                          , "System"
                                                                          , "Test"
                                                                          , "Vector"
+                                                                         , "Geometry"
                                                                          ]
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -156,9 +156,9 @@ preludeModules carpDir = map (\s -> carpDir ++ "/core/" ++ s ++ ".carp") [ "Macr
                                                                          , "Bool"
                                                                          , "IO"
                                                                          , "System"
-                                                                         , "Test"
                                                                          , "Vector"
                                                                          , "Geometry"
+                                                                         , "Test"
                                                                          ]
 
 main :: IO ()

--- a/core/Double.carp
+++ b/core/Double.carp
@@ -1,5 +1,7 @@
 (defmodule Double
   (def π 3.1415926536)
+  (register < (Fn [Double Double] Bool))
+  (register > (Fn [Double Double] Bool))
   (register + (Fn [Double Double] Double))
   (register - (Fn [Double Double] Double))
   (register * (Fn [Double Double] Double))
@@ -8,6 +10,8 @@
   (register from-int (Fn [Int] Double))
   (register sin (Fn [Double] Double))
   (register cos (Fn [Double] Double))
+  (register atan2 (Fn [Double Double] Double))
+  (register sqrt (Fn [Double] Double))
   (register str (Fn [Double] String))
   (register copy (Fn [(Ref Double)] Double))
   )

--- a/core/Double.carp
+++ b/core/Double.carp
@@ -1,5 +1,6 @@
 (defmodule Double
   (def π 3.1415926536)
+  (register = (Fn [Double Double] Bool))
   (register < (Fn [Double Double] Bool))
   (register > (Fn [Double Double] Bool))
   (register + (Fn [Double Double] Double))
@@ -22,4 +23,10 @@
       (if (< val min)
         min
         val)))
-  )
+
+  (defn approx [x y]
+    (if (> x y)
+      (< (- x y) 0.00001)
+      (< (- y x) 0.00001)))
+
+)

--- a/core/Double.carp
+++ b/core/Double.carp
@@ -10,8 +10,16 @@
   (register from-int (Fn [Int] Double))
   (register sin (Fn [Double] Double))
   (register cos (Fn [Double] Double))
+  (register acos (Fn [Double] Double))
   (register atan2 (Fn [Double Double] Double))
   (register sqrt (Fn [Double] Double))
   (register str (Fn [Double] String))
   (register copy (Fn [(Ref Double)] Double))
+
+  (defn clamp [min, max, val]
+    (if (> val max)
+      max
+      (if (< val min)
+        min
+        val)))
   )

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -1,7 +1,3 @@
-(use Bool)
-(use Int)
-(use String)
-
 (defmodule IO
   (defn color-table []
     [[@"black" @"30"]
@@ -47,7 +43,7 @@
 (defmodule Test
   (deftype State [passed Int, failed Int])
 
-  (defn handler [state expected actual descr what op]
+  (defn handler [state expected actual descr what op str]
     (if (op expected actual)
       (do
         (IO.color "green")
@@ -62,29 +58,29 @@
         (IO.color "reset")
         (State.update-failed (State.copy state) Int.inc))))
 
-  (defn assert-equal [state x y descr op]
-    (handler state x y descr "value" op))
+  (defn assert-equal [state x y descr op str]
+    (handler state x y descr "value" op str))
 
   (defn assert-str-equal [state x y descr]
-    (assert-equal state x y descr String.=))
+    (assert-equal state x y descr String.= String.str))
 
   (defn assert-int-equal [state x y descr]
-    (assert-equal state x y descr Int.=))
+    (assert-equal state x y descr Int.= Int.str))
 
   (defn assert-bool-equal [state x y descr]
-    (assert-equal state x y descr Bool.=))
+    (assert-equal state x y descr Bool.= Bool.str))
 
-  (defn assert-not-equal [state x y descr op]
-    (handler state x y descr "not value" op))
+  (defn assert-not-equal [state x y descr op str]
+    (handler state x y descr "not value" op str))
 
   (defn assert-bool-not-equal [state x y descr]
-    (assert-equal state x y descr Bool./=))
+    (assert-equal state x y descr Bool./= Bool.str))
 
   (defn assert-str-not-equal [state x y descr]
-    (assert-equal state x y descr String./=))
+    (assert-equal state x y descr String./= String.str))
 
   (defn assert-int-not-equal [state x y descr]
-    (assert-equal state x y descr Int./=))
+    (assert-equal state x y descr Int./= Int.str))
 
   (defn assert-true [state x descr]
     (assert-bool-equal state true x descr))

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -101,6 +101,13 @@
     (string-join @"Vector2(" (Double.str (V3.x o)) @", " (Double.str (V3.y o))
                  @", " (Double.str (V3.z o)) @")"))
 
+  (defn = [a b]
+    (and (Double.= (V3.x a) (V3.x b))
+         (and (Double.= (V3.y a) (V3.y b))
+              (Double.= (V3.z a) (V3.z b)))))
+
+  (defn /= [a b]
+    (not (= a b)))
   (defn + [a b]
     (V3.init (Double.+ (V3.x a) (V3.x b))
             (Double.+ (V3.y a) (V3.y b))
@@ -167,7 +174,7 @@
     (VN.init n v))
 
   (defn str [o]
-    (string-join @"VectorN(dim=" (Int.str (VN.n o)) ;", vals=" (Array.str (VN.v o))
+    (string-join @"VectorN(dim=" (Int.str (VN.n o)) @", vals=" (Array.str (VN.v o))
                   @")"))
 
   (defn zip- [f a b]
@@ -183,6 +190,20 @@
       (do
         (IO.println "Error: vectors are of wrong dimensionality")
         (VN.copy a))))
+
+  (defn all-eq [a b]
+    (let [e true]
+      (do
+        (for [i 0 (Array.count a)]
+          (set! &e (and e (Double.= (Double.copy (Array.nth a i)) (Double.copy (Array.nth b i))))))
+        e)))
+
+  (defn = [a b]
+    (and (Int.= (VN.n a) (VN.n b))
+         (all-eq (VN.v a) (VN.v b))))
+
+  (defn /= [a b]
+    (not (= a b)))
 
   (defn + [a b]
     (zip Double.+ a b))
@@ -221,8 +242,12 @@
   (defn dot [x y]
     (Array.reduce add- 0.0 (VN.v &(zip Double.* x y))))
 
+  (defn angle-between [a b]
+    (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
+      (Double.acos (Double.clamp -1.0 1.0 dmm))))
+
   (defn lerp [a b amnt]
     (init (VN.n a) (Array.copy (VN.v &(zip- Double.*
-                                            &(Array.replicate (VN.n a) amnt)
+                                            &(Array.replicate (VN.n a) &amnt)
                                             (VN.v &(zip Double.- b a)))))))
 )

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -1,0 +1,113 @@
+; missing: heading, rotation, angle between two vectors, lerp, equals
+
+
+(defdynamic append-multi- [strs]
+  (if (= (count strs) 0)
+    '@""
+    (list 'String.append (car strs) (append-multi- (cdr strs)))))
+
+(defmacro append-multi [:rest strs]
+  (append-multi- strs))
+
+(defmodule Vector2
+  (deftype V [x Double, y Double])
+
+  (defn init [x, y]
+    (V.init x y))
+
+  (defn str [o]
+    (append-multi @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o)) @")"))
+
+  (defn + [a, b]
+    (V.init (Double.+ (V.x a) (V.x b))
+            (Double.+ (V.y a) (V.y b))))
+
+  (defn - [a, b]
+    (V.init (Double.- (V.x a) (V.x b))
+            (Double.- (V.y a) (V.y b))))
+
+  (defn * [a, n]
+    (V.init (Double.* (V.x a) n)
+            (Double.* (V.y a) n)))
+
+  (defn / [a, n]
+    (V.init (Double./ (V.x a) n)
+            (Double./ (V.y a) n)))
+
+  (defn mag-sq [o]
+    (let [x (V.x o)
+          y (V.y o)]
+      (Double.+ (Double.* x x) (Double.* y y))))
+
+  ;(defn mag [o]
+  ;  (Double.sqrt (mag-sq o)))
+
+  ;(defn normalize [o]
+  ;  (let [m (mag o)]
+  ;    (if (= m 0)
+  ;      o
+  ;      (div o n))))
+
+  (defn dot [x, y]
+    (Double.+ (Double.* (V.x x) (V.x y))
+              (Double.* (V.y x) (V.y y))))
+)
+
+(defmodule Vector3
+  (deftype V [x Double, y Double, z Double])
+
+  (defn init [x, y, z]
+    (V.init x y z))
+
+  (defn str [o]
+    (append-multi @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o)) @", " (Double.str (V.z o)) @")"))
+
+  (defn + [a, b]
+    (V.init (Double.+ (V.x a) (V.x b))
+            (Double.+ (V.y a) (V.y b))
+            (Double.+ (V.z a) (V.z b))))
+
+  (defn - [a, b]
+    (V.init (Double.- (V.x a) (V.x b))
+            (Double.- (V.y a) (V.y b))
+            (Double.- (V.z a) (V.z b))))
+
+  (defn * [a, n]
+    (V.init (Double.* (V.x a) n)
+            (Double.* (V.y a) n)
+            (Double.* (V.z a) n)))
+
+  (defn / [a, n]
+    (V.init (Double./ (V.x a) n)
+            (Double./ (V.y a) n)
+            (Double./ (V.z a) n)))
+
+  (defn mag-sq [o]
+    (let [x (V.x o)
+          y (V.y o)
+          z (V.z o)]
+      (Double.+ (Double.* x x) (Double.+ (Double.* y y) (Double.* z z)))))
+
+  ;(defn mag [o]
+  ;  (Double.sqrt (mag-sq o)))
+
+  ;(defn normalize [o]
+  ;  (let [m (mag o)]
+  ;    (if (= m 0)
+  ;      o
+  ;      (div o n))))
+
+  (defn cross [x, y]
+    (V.init
+      (Double.- (Double.* (V.y x) (V.z y))
+                (Double.* (V.z x) (V.y y)))
+      (Double.- (Double.* (V.z x) (V.x y))
+                (Double.* (V.x x) (V.z y)))
+      (Double.- (Double.* (V.x x) (V.y y))
+                (Double.* (V.y x) (V.x y))))))
+
+  (defn dot [x, y]
+    (Double.+ (Double.* (V.x x) (V.x y))
+              (Double.* (V.y x) (V.y y))
+              (Double.* (V.z x) (V.z y))))))
+)

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -1,4 +1,4 @@
-; missing: heading, rotation, angle between two vectors, lerp, equals
+; missing: lerp
 
 
 (defdynamic append-multi- [strs]
@@ -57,9 +57,25 @@
   ;      o
   ;      (div o n))))
 
+  ;(defn dist [a, b]
+  ;  (let [b (- b a)]
+  ;    (mag b)))
+
+  ;(defn heading [a]
+  ;  (Double.atan2 (V.y a) (V.x a)))
+
+  ;(defn rotate [a n]
+  ;  (let [h (Double.+ (heading a) n)
+  ;        m (mag a)]
+  ;    (V.init (Double.* (Double.cos h) m) (Double.* (Double.sin h) m))))
+
   (defn dot [x, y]
     (Double.+ (Double.* (V.x x) (V.x y))
               (Double.* (V.y x) (V.y y))))
+
+  ;(defn angle-between [a b]
+  ;  (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
+  ;    (Double.acos (Double.clamp -1.0 1.0 dmm))))
 )
 
 (defmodule Vector3
@@ -119,6 +135,10 @@
     (Double.+ (Double.* (V.x x) (V.x y))
               (Double.+ (Double.* (V.y x) (V.y y))
                         (Double.* (V.z x) (V.z y)))))
+
+  ;(defn angle-between [a b]
+  ;  (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
+  ;    (Double.acos (Double.clamp -1.0 1.0 dmm))))
 )
 
 ;(defmodule VectorN
@@ -170,6 +190,11 @@
 ;
 ;  ;(defn mag [o]
 ;  ;  (Double.sqrt (mag-sq o)))
+;
+;  ;(defn dist [a, b]
+;  ;  (let [b (- b a)]
+;  ;    (mag b)))
+;
 ;
 ;  ;(defn normalize [o]
 ;  ;  (let [m (mag o)]

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -104,10 +104,10 @@
       (Double.- (Double.* (V.z x) (V.x y))
                 (Double.* (V.x x) (V.z y)))
       (Double.- (Double.* (V.x x) (V.y y))
-                (Double.* (V.y x) (V.x y))))))
+                (Double.* (V.y x) (V.x y)))))
 
   (defn dot [x, y]
     (Double.+ (Double.* (V.x x) (V.x y))
-              (Double.* (V.y x) (V.y y))
-              (Double.* (V.z x) (V.z y))))))
+              (Double.+ (Double.* (V.y x) (V.y y))
+                        (Double.* (V.z x) (V.z y)))))
 )

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -1,6 +1,5 @@
 ; missing: lerp
 
-
 (defdynamic append-multi- [strs]
   (if (= (count strs) 0)
     '@""
@@ -8,6 +7,11 @@
 
 (defmacro append-multi [:rest strs]
   (append-multi- strs))
+
+(defn doubleq [a, b]
+  (if (Double.> a b)
+    (Double.< (Double.- a b) 0.00001)
+    (Double.< (Double.- b a) 0.00001)))
 
 (defmodule Vector2
   (deftype V [x Double, y Double])
@@ -33,11 +37,6 @@
   (defn / [a, n]
     (V.init (Double./ (V.x a) n)
             (Double./ (V.y a) n)))
-
-  (defn doubleq [a, b]
-    (if (Double.> a b)
-      (Double.< (Double.- a b) 0.00001)
-      (Double.< (Double.- b a) 0.00001)))
 
   (defn = [a, b]
     (and (doubleq (V.x a) (V.x b))
@@ -73,9 +72,9 @@
     (Double.+ (Double.* (V.x x) (V.x y))
               (Double.* (V.y x) (V.y y))))
 
-  ;(defn angle-between [a b]
-  ;  (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
-  ;    (Double.acos (Double.clamp -1.0 1.0 dmm))))
+  (defn angle-between [a b]
+    (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
+      (Double.acos (Double.clamp -1.0 1.0 dmm))))
 )
 
 (defmodule Vector3
@@ -113,14 +112,14 @@
           z (V.z o)]
       (Double.+ (Double.* x x) (Double.+ (Double.* y y) (Double.* z z)))))
 
-  ;(defn mag [o]
-  ;  (Double.sqrt (mag-sq o)))
+  (defn mag [o]
+    (Double.sqrt (mag-sq o)))
 
-  ;(defn normalize [o]
-  ;  (let [m (mag o)]
-  ;    (if (= m 0)
-  ;      o
-  ;      (div o n))))
+  (defn normalize [o]
+    (let [m (mag o)]
+      (if (doubleq m 0.0)
+        (V.copy o)
+        (/ o m))))
 
   (defn cross [x, y]
     (V.init
@@ -136,9 +135,9 @@
               (Double.+ (Double.* (V.y x) (V.y y))
                         (Double.* (V.z x) (V.z y)))))
 
-  ;(defn angle-between [a b]
-  ;  (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
-  ;    (Double.acos (Double.clamp -1.0 1.0 dmm))))
+  (defn angle-between [a b]
+    (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
+      (Double.acos (Double.clamp -1.0 1.0 dmm))))
 )
 
 ;(defmodule VectorN

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -1,5 +1,3 @@
-; missing: lerp
-
 (defmodule Vector2
   (deftype V2 [x Double, y Double])
 
@@ -84,6 +82,10 @@
   (defn angle-between [a b]
     (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
       (Double.acos (Double.clamp -1.0 1.0 dmm))))
+
+  (defn lerp [a b amnt]
+    (init (Double.* (Double.- (V2.x b) (V2.x a)) amnt)
+          (Double.* (Double.- (V2.y b) (V2.y a)) amnt)))
 )
 
 (defmodule Vector3
@@ -151,6 +153,11 @@
   (defn angle-between [a b]
     (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
       (Double.acos (Double.clamp -1.0 1.0 dmm))))
+
+  (defn lerp [a b amnt]
+    (init (Double.* (Double.- (V3.x b) (V3.x a)) amnt)
+          (Double.* (Double.- (V3.y b) (V3.y a)) amnt)
+          (Double.* (Double.- (V3.z b) (V3.z a)) amnt)))
 )
 
 (defmodule VectorN
@@ -213,4 +220,9 @@
 
   (defn dot [x y]
     (Array.reduce add- 0.0 (VN.v &(zip Double.* x y))))
+
+  (defn lerp [a b amnt]
+    (init (VN.n a) (Array.copy (VN.v &(zip- Double.*
+                                            &(Array.replicate (VN.n a) amnt)
+                                            (VN.v &(zip Double.- b a)))))))
 )

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -34,40 +34,40 @@
     (V.init (Double./ (V.x a) n)
             (Double./ (V.y a) n)))
 
-  (defn doubeq [a, b]
+  (defn doubleq [a, b]
     (if (Double.> a b)
       (Double.< (Double.- a b) 0.00001)
       (Double.< (Double.- b a) 0.00001)))
 
   (defn = [a, b]
-    (and (doubeq (V.x a) (V.x b))
-         (doubeq (V.y a) (V.y b))))
+    (and (doubleq (V.x a) (V.x b))
+         (doubleq (V.y a) (V.y b))))
 
   (defn mag-sq [o]
     (let [x (V.x o)
           y (V.y o)]
       (Double.+ (Double.* x x) (Double.* y y))))
 
-  ;(defn mag [o]
-  ;  (Double.sqrt (mag-sq o)))
+  (defn mag [o]
+    (Double.sqrt (mag-sq o)))
 
-  ;(defn normalize [o]
-  ;  (let [m (mag o)]
-  ;    (if (= m 0)
-  ;      o
-  ;      (div o n))))
+  (defn normalize [o]
+    (let [m (mag o)]
+      (if (doubleq m 0.0)
+        (V.copy o)
+        (/ o m))))
 
-  ;(defn dist [a, b]
-  ;  (let [b (- b a)]
-  ;    (mag b)))
+  (defn dist [a, b]
+    (let [s (- &b &a)]
+      (mag &s)))
 
-  ;(defn heading [a]
-  ;  (Double.atan2 (V.y a) (V.x a)))
+  (defn heading [a]
+    (Double.atan2 (V.y a) (V.x a)))
 
-  ;(defn rotate [a n]
-  ;  (let [h (Double.+ (heading a) n)
-  ;        m (mag a)]
-  ;    (V.init (Double.* (Double.cos h) m) (Double.* (Double.sin h) m))))
+  (defn rotate [a n]
+    (let [h (Double.+ (heading a) n)
+          m (mag a)]
+      (V.init (Double.* (Double.cos h) m) (Double.* (Double.sin h) m))))
 
   (defn dot [x, y]
     (Double.+ (Double.* (V.x x) (V.x y))

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -34,6 +34,15 @@
     (V.init (Double./ (V.x a) n)
             (Double./ (V.y a) n)))
 
+  (defn doubeq [a, b]
+    (if (Double.> a b)
+      (Double.< (Double.- a b) 0.00001)
+      (Double.< (Double.- b a) 0.00001)))
+
+  (defn = [a, b]
+    (and (doubeq (V.x a) (V.x b))
+         (doubeq (V.y a) (V.y b))))
+
   (defn mag-sq [o]
     (let [x (V.x o)
           y (V.y o)]
@@ -111,3 +120,60 @@
               (Double.+ (Double.* (V.y x) (V.y y))
                         (Double.* (V.z x) (V.z y)))))
 )
+
+;(defmodule VectorN
+;  (deftype V [n Int, v (Array Double)])
+;
+;  (defn init [n, v]
+;    (V.init n v))
+;
+;  (defn str [o]
+;    (append-multi @"VectorN(dim=" (Int.str (V.n o)) ;", vals=" (Array.str (V.v o))
+;                  @")"))
+;
+;  (register zip- (Fn [(Fn [Double, Double] Double) &(Array Double) &(Array Double)] V))
+;  (defn zip- [f, a, b]
+;    (let [total []]
+;      (do
+;        (for [i 0 (Array.count a)]
+;          (set! &total (Array.push-back (Array.copy &total) (f (Array.nth a i) (Array.nth b i)))))
+;        (V.init (Array.count a) total))))
+;
+;  (register zip (Fn [(Fn [Double, Double] Double) &V &V] V))
+;  (defn zip [f, a, b]
+;    (if (Int.= (V.n a) (V.n b))
+;      (zip- f (V.v a) (V.v b))
+;      (do
+;        (IO.println "Error: vectors are of wrong dimensionality")
+;        (V.copy a))))
+;
+;  (defn + [a, b]
+;    (zip add- a b))
+;
+;  (defn - [a, b]
+;    (zip Double.- a b))
+;
+;  (defn * [a, n]
+;    (zip- Double.* (V.v a) &(Array.repeat (V.n a) n)))
+;
+;  (defn / [a, n]
+;    (zip- Double./ (V.v a) &(Array.repeat (V.n a) n)))
+;
+;  (defn square- [n]
+;    (Double.* (Double.copy n) (Double.copy n)))
+;
+;  (defn add- [x, y]
+;    (Double.+ (Double.copy x) (Double.copy y)))
+;
+;  (defn mag-sq [o]
+;    (Array.reduce add- 0.0 &(Array.copy-map square- (V.v o))))
+;
+;  ;(defn mag [o]
+;  ;  (Double.sqrt (mag-sq o)))
+;
+;  ;(defn normalize [o]
+;  ;  (let [m (mag o)]
+;  ;    (if (= m 0)
+;  ;      o
+;  ;      (div o n))))
+;)

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -1,46 +1,55 @@
 ; missing: lerp
 
-(defdynamic append-multi- [strs]
-  (if (= (count strs) 0)
-    '@""
-    (list 'String.append (car strs) (append-multi- (cdr strs)))))
-
-(defmacro append-multi [:rest strs]
-  (append-multi- strs))
-
-(defn doubleq [a, b]
-  (if (Double.> a b)
-    (Double.< (Double.- a b) 0.00001)
-    (Double.< (Double.- b a) 0.00001)))
-
 (defmodule Vector2
   (deftype V [x Double, y Double])
 
-  (defn init [x, y]
+  (defn init [x y]
     (V.init x y))
 
-  (defn str [o]
-    (append-multi @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o)) @")"))
+  (defn copy [v]
+    (V.copy v))
 
-  (defn + [a, b]
+  (defn get-x [o]
+    (V.x o))
+
+  (defn get-y [o]
+    (V.y o))
+
+  (defn set-x [o v]
+    (V.set-x o v))
+
+  (defn set-y [o v]
+    (V.set-y o v))
+
+  (defn str [o]
+    (string-join @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o)) @")"))
+
+  (defn + [a b]
     (V.init (Double.+ (V.x a) (V.x b))
             (Double.+ (V.y a) (V.y b))))
 
-  (defn - [a, b]
+  (defn - [a b]
     (V.init (Double.- (V.x a) (V.x b))
             (Double.- (V.y a) (V.y b))))
 
-  (defn * [a, n]
+  (defn * [a n]
     (V.init (Double.* (V.x a) n)
             (Double.* (V.y a) n)))
 
-  (defn / [a, n]
+  (defn / [a n]
     (V.init (Double./ (V.x a) n)
             (Double./ (V.y a) n)))
 
-  (defn = [a, b]
-    (and (doubleq (V.x a) (V.x b))
-         (doubleq (V.y a) (V.y b))))
+  (defn = [a b]
+    (and (Double.= (V.x a) (V.x b))
+         (Double.= (V.y a) (V.y b))))
+
+  (defn /= [a b]
+    (not (= a b)))
+
+  (defn approx [a b]
+    (and (Double.approx (V.x a) (V.x b))
+         (Double.approx (V.y a) (V.y b))))
 
   (defn mag-sq [o]
     (let [x (V.x o)
@@ -52,12 +61,12 @@
 
   (defn normalize [o]
     (let [m (mag o)]
-      (if (doubleq m 0.0)
+      (if (Double.= m 0.0)
         (V.copy o)
         (/ o m))))
 
-  (defn dist [a, b]
-    (let [s (- &b &a)]
+  (defn dist [a b]
+    (let [s (- b a)]
       (mag &s)))
 
   (defn heading [a]
@@ -68,7 +77,7 @@
           m (mag a)]
       (V.init (Double.* (Double.cos h) m) (Double.* (Double.sin h) m))))
 
-  (defn dot [x, y]
+  (defn dot [x y]
     (Double.+ (Double.* (V.x x) (V.x y))
               (Double.* (V.y x) (V.y y))))
 
@@ -80,28 +89,32 @@
 (defmodule Vector3
   (deftype V [x Double, y Double, z Double])
 
-  (defn init [x, y, z]
+  (defn init [x y z]
     (V.init x y z))
 
-  (defn str [o]
-    (append-multi @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o)) @", " (Double.str (V.z o)) @")"))
+  (defn copy [v]
+    (V.copy v))
 
-  (defn + [a, b]
+  (defn str [o]
+    (string-join @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o))
+                 @", " (Double.str (V.z o)) @")"))
+
+  (defn + [a b]
     (V.init (Double.+ (V.x a) (V.x b))
             (Double.+ (V.y a) (V.y b))
             (Double.+ (V.z a) (V.z b))))
 
-  (defn - [a, b]
+  (defn - [a b]
     (V.init (Double.- (V.x a) (V.x b))
             (Double.- (V.y a) (V.y b))
             (Double.- (V.z a) (V.z b))))
 
-  (defn * [a, n]
+  (defn * [a n]
     (V.init (Double.* (V.x a) n)
             (Double.* (V.y a) n)
             (Double.* (V.z a) n)))
 
-  (defn / [a, n]
+  (defn / [a n]
     (V.init (Double./ (V.x a) n)
             (Double./ (V.y a) n)
             (Double./ (V.z a) n)))
@@ -117,11 +130,11 @@
 
   (defn normalize [o]
     (let [m (mag o)]
-      (if (doubleq m 0.0)
+      (if (Double.= m 0.0)
         (V.copy o)
         (/ o m))))
 
-  (defn cross [x, y]
+  (defn cross [x y]
     (V.init
       (Double.- (Double.* (V.y x) (V.z y))
                 (Double.* (V.z x) (V.y y)))
@@ -130,7 +143,7 @@
       (Double.- (Double.* (V.x x) (V.y y))
                 (Double.* (V.y x) (V.x y)))))
 
-  (defn dot [x, y]
+  (defn dot [x y]
     (Double.+ (Double.* (V.x x) (V.x y))
               (Double.+ (Double.* (V.y x) (V.y y))
                         (Double.* (V.z x) (V.z y)))))
@@ -143,15 +156,15 @@
 ;(defmodule VectorN
 ;  (deftype V [n Int, v (Array Double)])
 ;
-;  (defn init [n, v]
+;  (defn init [n v]
 ;    (V.init n v))
 ;
 ;  (defn str [o]
-;    (append-multi @"VectorN(dim=" (Int.str (V.n o)) ;", vals=" (Array.str (V.v o))
+;    (string-join @"VectorN(dim=" (Int.str (V.n o)) ;", vals=" (Array.str (V.v o))
 ;                  @")"))
 ;
 ;  (register zip- (Fn [(Fn [Double, Double] Double) &(Array Double) &(Array Double)] V))
-;  (defn zip- [f, a, b]
+;  (defn zip- [f a b]
 ;    (let [total []]
 ;      (do
 ;        (for [i 0 (Array.count a)]
@@ -159,29 +172,29 @@
 ;        (V.init (Array.count a) total))))
 ;
 ;  (register zip (Fn [(Fn [Double, Double] Double) &V &V] V))
-;  (defn zip [f, a, b]
+;  (defn zip [f a b]
 ;    (if (Int.= (V.n a) (V.n b))
 ;      (zip- f (V.v a) (V.v b))
 ;      (do
 ;        (IO.println "Error: vectors are of wrong dimensionality")
 ;        (V.copy a))))
 ;
-;  (defn + [a, b]
+;  (defn + [a b]
 ;    (zip add- a b))
 ;
-;  (defn - [a, b]
+;  (defn - [a b]
 ;    (zip Double.- a b))
 ;
-;  (defn * [a, n]
+;  (defn * [a n]
 ;    (zip- Double.* (V.v a) &(Array.repeat (V.n a) n)))
 ;
-;  (defn / [a, n]
+;  (defn / [a n]
 ;    (zip- Double./ (V.v a) &(Array.repeat (V.n a) n)))
 ;
 ;  (defn square- [n]
 ;    (Double.* (Double.copy n) (Double.copy n)))
 ;
-;  (defn add- [x, y]
+;  (defn add- [x y]
 ;    (Double.+ (Double.copy x) (Double.copy y)))
 ;
 ;  (defn mag-sq [o]
@@ -190,7 +203,7 @@
 ;  ;(defn mag [o]
 ;  ;  (Double.sqrt (mag-sq o)))
 ;
-;  ;(defn dist [a, b]
+;  ;(defn dist [a b]
 ;  ;  (let [b (- b a)]
 ;  ;    (mag b)))
 ;

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -1,59 +1,59 @@
 ; missing: lerp
 
 (defmodule Vector2
-  (deftype V [x Double, y Double])
+  (deftype V2 [x Double, y Double])
 
   (defn init [x y]
-    (V.init x y))
+    (V2.init x y))
 
   (defn copy [v]
-    (V.copy v))
+    (V2.copy v))
 
   (defn get-x [o]
-    (V.x o))
+    (V2.x o))
 
   (defn get-y [o]
-    (V.y o))
+    (V2.y o))
 
   (defn set-x [o v]
-    (V.set-x o v))
+    (V2.set-x o v))
 
   (defn set-y [o v]
-    (V.set-y o v))
+    (V2.set-y o v))
 
   (defn str [o]
-    (string-join @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o)) @")"))
+    (string-join @"Vector2(" (Double.str (V2.x o)) @", " (Double.str (V2.y o)) @")"))
 
   (defn + [a b]
-    (V.init (Double.+ (V.x a) (V.x b))
-            (Double.+ (V.y a) (V.y b))))
+    (V2.init (Double.+ (V2.x a) (V2.x b))
+            (Double.+ (V2.y a) (V2.y b))))
 
   (defn - [a b]
-    (V.init (Double.- (V.x a) (V.x b))
-            (Double.- (V.y a) (V.y b))))
+    (V2.init (Double.- (V2.x a) (V2.x b))
+            (Double.- (V2.y a) (V2.y b))))
 
   (defn * [a n]
-    (V.init (Double.* (V.x a) n)
-            (Double.* (V.y a) n)))
+    (V2.init (Double.* (V2.x a) n)
+            (Double.* (V2.y a) n)))
 
   (defn / [a n]
-    (V.init (Double./ (V.x a) n)
-            (Double./ (V.y a) n)))
+    (V2.init (Double./ (V2.x a) n)
+            (Double./ (V2.y a) n)))
 
   (defn = [a b]
-    (and (Double.= (V.x a) (V.x b))
-         (Double.= (V.y a) (V.y b))))
+    (and (Double.= (V2.x a) (V2.x b))
+         (Double.= (V2.y a) (V2.y b))))
 
   (defn /= [a b]
     (not (= a b)))
 
   (defn approx [a b]
-    (and (Double.approx (V.x a) (V.x b))
-         (Double.approx (V.y a) (V.y b))))
+    (and (Double.approx (V2.x a) (V2.x b))
+         (Double.approx (V2.y a) (V2.y b))))
 
   (defn mag-sq [o]
-    (let [x (V.x o)
-          y (V.y o)]
+    (let [x (V2.x o)
+          y (V2.y o)]
       (Double.+ (Double.* x x) (Double.* y y))))
 
   (defn mag [o]
@@ -62,7 +62,7 @@
   (defn normalize [o]
     (let [m (mag o)]
       (if (Double.= m 0.0)
-        (V.copy o)
+        (V2.copy o)
         (/ o m))))
 
   (defn dist [a b]
@@ -70,16 +70,16 @@
       (mag &s)))
 
   (defn heading [a]
-    (Double.atan2 (V.y a) (V.x a)))
+    (Double.atan2 (V2.y a) (V2.x a)))
 
   (defn rotate [a n]
     (let [h (Double.+ (heading a) n)
           m (mag a)]
-      (V.init (Double.* (Double.cos h) m) (Double.* (Double.sin h) m))))
+      (V2.init (Double.* (Double.cos h) m) (Double.* (Double.sin h) m))))
 
   (defn dot [x y]
-    (Double.+ (Double.* (V.x x) (V.x y))
-              (Double.* (V.y x) (V.y y))))
+    (Double.+ (Double.* (V2.x x) (V2.x y))
+              (Double.* (V2.y x) (V2.y y))))
 
   (defn angle-between [a b]
     (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
@@ -87,42 +87,42 @@
 )
 
 (defmodule Vector3
-  (deftype V [x Double, y Double, z Double])
+  (deftype V3 [x Double, y Double, z Double])
 
   (defn init [x y z]
-    (V.init x y z))
+    (V3.init x y z))
 
   (defn copy [v]
-    (V.copy v))
+    (V3.copy v))
 
   (defn str [o]
-    (string-join @"Vector2(" (Double.str (V.x o)) @", " (Double.str (V.y o))
-                 @", " (Double.str (V.z o)) @")"))
+    (string-join @"Vector2(" (Double.str (V3.x o)) @", " (Double.str (V3.y o))
+                 @", " (Double.str (V3.z o)) @")"))
 
   (defn + [a b]
-    (V.init (Double.+ (V.x a) (V.x b))
-            (Double.+ (V.y a) (V.y b))
-            (Double.+ (V.z a) (V.z b))))
+    (V3.init (Double.+ (V3.x a) (V3.x b))
+            (Double.+ (V3.y a) (V3.y b))
+            (Double.+ (V3.z a) (V3.z b))))
 
   (defn - [a b]
-    (V.init (Double.- (V.x a) (V.x b))
-            (Double.- (V.y a) (V.y b))
-            (Double.- (V.z a) (V.z b))))
+    (V3.init (Double.- (V3.x a) (V3.x b))
+            (Double.- (V3.y a) (V3.y b))
+            (Double.- (V3.z a) (V3.z b))))
 
   (defn * [a n]
-    (V.init (Double.* (V.x a) n)
-            (Double.* (V.y a) n)
-            (Double.* (V.z a) n)))
+    (V3.init (Double.* (V3.x a) n)
+            (Double.* (V3.y a) n)
+            (Double.* (V3.z a) n)))
 
   (defn / [a n]
-    (V.init (Double./ (V.x a) n)
-            (Double./ (V.y a) n)
-            (Double./ (V.z a) n)))
+    (V3.init (Double./ (V3.x a) n)
+            (Double./ (V3.y a) n)
+            (Double./ (V3.z a) n)))
 
   (defn mag-sq [o]
-    (let [x (V.x o)
-          y (V.y o)
-          z (V.z o)]
+    (let [x (V3.x o)
+          y (V3.y o)
+          z (V3.z o)]
       (Double.+ (Double.* x x) (Double.+ (Double.* y y) (Double.* z z)))))
 
   (defn mag [o]
@@ -131,86 +131,86 @@
   (defn normalize [o]
     (let [m (mag o)]
       (if (Double.= m 0.0)
-        (V.copy o)
+        (V3.copy o)
         (/ o m))))
 
   (defn cross [x y]
-    (V.init
-      (Double.- (Double.* (V.y x) (V.z y))
-                (Double.* (V.z x) (V.y y)))
-      (Double.- (Double.* (V.z x) (V.x y))
-                (Double.* (V.x x) (V.z y)))
-      (Double.- (Double.* (V.x x) (V.y y))
-                (Double.* (V.y x) (V.x y)))))
+    (V3.init
+      (Double.- (Double.* (V3.y x) (V3.z y))
+                (Double.* (V3.z x) (V3.y y)))
+      (Double.- (Double.* (V3.z x) (V3.x y))
+                (Double.* (V3.x x) (V3.z y)))
+      (Double.- (Double.* (V3.x x) (V3.y y))
+                (Double.* (V3.y x) (V3.x y)))))
 
   (defn dot [x y]
-    (Double.+ (Double.* (V.x x) (V.x y))
-              (Double.+ (Double.* (V.y x) (V.y y))
-                        (Double.* (V.z x) (V.z y)))))
+    (Double.+ (Double.* (V3.x x) (V3.x y))
+              (Double.+ (Double.* (V3.y x) (V3.y y))
+                        (Double.* (V3.z x) (V3.z y)))))
 
   (defn angle-between [a b]
     (let [dmm (Double./ (dot a b) (Double.* (mag a) (mag b)))]
       (Double.acos (Double.clamp -1.0 1.0 dmm))))
 )
 
-;(defmodule VectorN
-;  (deftype V [n Int, v (Array Double)])
-;
-;  (defn init [n v]
-;    (V.init n v))
-;
-;  (defn str [o]
-;    (string-join @"VectorN(dim=" (Int.str (V.n o)) ;", vals=" (Array.str (V.v o))
-;                  @")"))
-;
-;  (register zip- (Fn [(Fn [Double, Double] Double) &(Array Double) &(Array Double)] V))
-;  (defn zip- [f a b]
-;    (let [total []]
-;      (do
-;        (for [i 0 (Array.count a)]
-;          (set! &total (Array.push-back (Array.copy &total) (f (Array.nth a i) (Array.nth b i)))))
-;        (V.init (Array.count a) total))))
-;
-;  (register zip (Fn [(Fn [Double, Double] Double) &V &V] V))
-;  (defn zip [f a b]
-;    (if (Int.= (V.n a) (V.n b))
-;      (zip- f (V.v a) (V.v b))
-;      (do
-;        (IO.println "Error: vectors are of wrong dimensionality")
-;        (V.copy a))))
-;
-;  (defn + [a b]
-;    (zip add- a b))
-;
-;  (defn - [a b]
-;    (zip Double.- a b))
-;
-;  (defn * [a n]
-;    (zip- Double.* (V.v a) &(Array.repeat (V.n a) n)))
-;
-;  (defn / [a n]
-;    (zip- Double./ (V.v a) &(Array.repeat (V.n a) n)))
-;
-;  (defn square- [n]
-;    (Double.* (Double.copy n) (Double.copy n)))
-;
-;  (defn add- [x y]
-;    (Double.+ (Double.copy x) (Double.copy y)))
-;
-;  (defn mag-sq [o]
-;    (Array.reduce add- 0.0 &(Array.copy-map square- (V.v o))))
-;
-;  ;(defn mag [o]
-;  ;  (Double.sqrt (mag-sq o)))
-;
-;  ;(defn dist [a b]
-;  ;  (let [b (- b a)]
-;  ;    (mag b)))
-;
-;
-;  ;(defn normalize [o]
-;  ;  (let [m (mag o)]
-;  ;    (if (= m 0)
-;  ;      o
-;  ;      (div o n))))
-;)
+(defmodule VectorN
+  (deftype VN [n Int, v (Array Double)])
+
+  (defn init [n v]
+    (VN.init n v))
+
+  (defn str [o]
+    (string-join @"VectorN(dim=" (Int.str (VN.n o)) ;", vals=" (Array.str (VN.v o))
+                  @")"))
+
+  (defn zip- [f a b]
+    (let [total []]
+      (do
+        (for [i 0 (Array.count a)]
+          (set! &total (Array.push-back (Array.copy &total) (f (Double.copy (Array.nth a i)) (Double.copy (Array.nth b i))))))
+        (VN.init (Array.count a) total))))
+
+  (defn zip [f a b]
+    (if (Int.= (VN.n a) (VN.n b))
+      (zip- f (VN.v a) (VN.v b))
+      (do
+        (IO.println "Error: vectors are of wrong dimensionality")
+        (VN.copy a))))
+
+  (defn + [a b]
+    (zip Double.+ a b))
+
+  (defn - [a b]
+    (zip Double.- a b))
+
+  (defn * [a n]
+    (zip- Double.* (VN.v a) &(Array.replicate (VN.n a) &n)))
+
+  (defn / [a n]
+    (zip- Double./ (VN.v a) &(Array.replicate (VN.n a) &n)))
+
+  (defn square- [n]
+    (Double.* (Double.copy n) (Double.copy n)))
+
+  (defn add- [x y]
+    (Double.+ (Double.copy x) (Double.copy y)))
+
+  (defn mag-sq [o]
+    (Array.reduce add- 0.0 &(Array.copy-map square- (VN.v o))))
+
+  (defn mag [o]
+    (Double.sqrt (mag-sq o)))
+
+  (defn dist [a b]
+    (let [s (- b a)]
+      (mag &s)))
+
+  (defn normalize [o]
+    (let [m (mag o)]
+      (if (Double.= m 0.0)
+        (VN.copy o)
+        (/ o m))))
+
+  (defn dot [x y]
+    (Array.reduce add- 0.0 (VN.v &(zip Double.* x y))))
+)

--- a/core/geometry.carp
+++ b/core/geometry.carp
@@ -1,0 +1,6 @@
+(defmodule Geometry
+  (defn degree-to-radians [n]
+    (Double./ (Double.* 2.0 (Double.* n Double.π)) 360.0))
+
+  (defn radians-to-degree [n]
+    (Double./ (Double.* 360.0 n) (Double.* 2.0 Double.π))))

--- a/core/prelude.h
+++ b/core/prelude.h
@@ -209,6 +209,10 @@ double Double_sqrt(double x) {
     return sqrt(x);
 }
 
+double Double_acos(double x) {
+    return acos(x);
+}
+
 double Double_atan2(double x, double y) {
     return atan2(x, y);
 }

--- a/core/prelude.h
+++ b/core/prelude.h
@@ -63,6 +63,8 @@ double Double_copy(double *x) { return *x; }
 #define Double__MINUS_(x, y) ((x) - (y))
 #define Double__MUL_(x, y) ((x) * (y))
 #define Double__DIV_(x, y) ((x) / (y))
+#define Double__LT_(x, y) ((x) < (y))
+#define Double__GT_(x, y) ((x) > (y))
 
 #define Float__PLUS_(x, y) ((x) + (y))
 #define Float__MINUS_(x, y) ((x) - (y))
@@ -201,6 +203,14 @@ double Double_sin(double x) {
 
 double Double_cos(double x) {
     return cos(x);
+}
+
+double Double_sqrt(double x) {
+    return sqrt(x);
+}
+
+double Double_atan2(double x, double y) {
+    return atan2(x, y);
 }
 
 string Double_str(double x) {

--- a/core/prelude.h
+++ b/core/prelude.h
@@ -59,17 +59,18 @@ int Int_copy(int *x) { return *x; }
 float Float_copy(float *x) { return *x; }
 double Double_copy(double *x) { return *x; }
 
-#define Double__PLUS_(x, y) ((x) + (y))
-#define Double__MINUS_(x, y) ((x) - (y))
-#define Double__MUL_(x, y) ((x) * (y))
-#define Double__DIV_(x, y) ((x) / (y))
-#define Double__LT_(x, y) ((x) < (y))
-#define Double__GT_(x, y) ((x) > (y))
+double Double__PLUS_(double x, double y) { return x + y; }
+double Double__MINUS_(double x, double y) { return x - y; }
+double Double__MUL_(double x, double y) { return x * y; }
+double Double__DIV_(double x, double y) { return x / y; }
+bool Double__LT_(double x, double y) { return x < y; }
+bool Double__GT_(double x, double y) { return x > y; }
+bool Double__EQ_(double x, double y) { return x == y; }
 
-#define Float__PLUS_(x, y) ((x) + (y))
-#define Float__MINUS_(x, y) ((x) - (y))
-#define Float__MUL_(x, y) ((x) * (y))
-#define Float__DIV_(x, y) ((x) / (y))
+float Float__PLUS_(float x, float y) { return x + y; }
+float Float__MINUS_(float x, float y) { return x - y; }
+float Float__MUL_(float x, float y) { return x * y; }
+float Float__DIV_(float x, float y) { return x / y; }
 
 #define and(x, y) ((x) && (y))
 #define or(x, y) ((x) || (y))

--- a/core/prelude.h
+++ b/core/prelude.h
@@ -72,8 +72,8 @@ float Float__MINUS_(float x, float y) { return x - y; }
 float Float__MUL_(float x, float y) { return x * y; }
 float Float__DIV_(float x, float y) { return x / y; }
 
-#define and(x, y) ((x) && (y))
-#define or(x, y) ((x) || (y))
+bool and(bool x, bool y) { return x && y; }
+bool or(bool x, bool y) { return x || y; }
 
 void IO_println(string *s) { puts(*s); }
 void IO_print(string *s) { printf("%s", *s); }

--- a/examples/vector.carp
+++ b/examples/vector.carp
@@ -1,5 +1,6 @@
 (use IO)
 (use Vector2)
+(use Geometry)
 
 (defn main []
   (let [x (Vector2.init 1.0 2.0)
@@ -9,4 +10,5 @@
       (println &(Vector2.str &x))
       (println &(Vector2.str &y))
       (println &(Double.str (Vector2.mag &y)))
-      (println &(Vector2.str &(Vector2.rotate &x (Double./ Double.π 2.0)))))))
+      (println &(Vector2.str &(Vector2.rotate &x (Geometry.degree-to-radians 90.0))))
+      (println &(Double.str (Geometry.radians-to-degree (Vector2.angle-between &x &y)))))))

--- a/examples/vector.carp
+++ b/examples/vector.carp
@@ -1,0 +1,10 @@
+(use IO)
+(use Vector2)
+
+(defn main []
+  (let [x (Vector2.init 1 2)
+        y (Vector2.init 3 4)]
+    (do
+      (println &(Vector2.str &(+ &x &y)))
+      (println &(Vector2.str &x))
+      (println &(Vector2.str &y)))))

--- a/examples/vector.carp
+++ b/examples/vector.carp
@@ -2,9 +2,11 @@
 (use Vector2)
 
 (defn main []
-  (let [x (Vector2.init 1 2)
-        y (Vector2.init 3 4)]
+  (let [x (Vector2.init 1.0 2.0)
+        y (Vector2.init 3.0 4.0)]
     (do
       (println &(Vector2.str &(+ &x &y)))
       (println &(Vector2.str &x))
-      (println &(Vector2.str &y)))))
+      (println &(Vector2.str &y))
+      (println &(Double.str (Vector2.mag &y)))
+      (println &(Vector2.str &(Vector2.rotate &x (Double./ Double.π 2.0)))))))

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -19,12 +19,12 @@ templateCopyingMap = defineTypeParameterizedTemplate templateCreator path t
         path = SymPath ["Array"] "copy-map"
         t = FuncTy [fTy, aTy] bTy
         templateCreator = TemplateCreator $
-          \typeEnv env -> 
+          \typeEnv env ->
             Template
             t
             (const (toTemplate "Array $NAME($(Fn [(Ref a)] b) f, Array* a)"))
             (\(FuncTy [(FuncTy [_] outputTy), _] _) ->
-               (toTemplate $ unlines $                
+               (toTemplate $ unlines $
                   [ "$DECL { "
                   , "    Array b;"
                   , "    b.len = a->len;"
@@ -46,7 +46,7 @@ templateCopyingMap = defineTypeParameterizedTemplate templateCreator path t
 
 -- | "Endofunctor Map"
 templateEMap :: (String, Binder)
-templateEMap = 
+templateEMap =
   let fTy = FuncTy [VarTy "a"] (VarTy "a")
       aTy = StructTy "Array" [VarTy "a"]
       bTy = StructTy "Array" [VarTy "a"]
@@ -112,7 +112,7 @@ templateFilter = defineTypeParameterizedTemplate templateCreator path t
 --       \typeEnv env ->
 --         Template
 --         t
---         (const (toTemplate "$b $NAME($(Fn [b (Ref a)] a) f, $b initial_value, Array a)"))        
+--         (const (toTemplate "$b $NAME($(Fn [b (Ref a)] a) f, $b initial_value, Array a)"))
 --         (\(FuncTy [(FuncTy [_, _] _), _, _] _) ->
 --            let deleter = insideArrayDeletion typeEnv env arrTy
 --            in (toTemplate $ unlines $
@@ -120,7 +120,7 @@ templateFilter = defineTypeParameterizedTemplate templateCreator path t
 --                 , "    $b b = initial_value;"
 --                 , "    for(int i = 0; i < a.len; ++i) {"
 --                 , "        b = f(b, &((($a*)a.data)[i]));"
---                 , "    }"               
+--                 , "    }"
 --                 , "    " ++ deleter
 --                 , "    return b;"
 --                 , "}"
@@ -129,7 +129,7 @@ templateFilter = defineTypeParameterizedTemplate templateCreator path t
 --            [defineFunctionTypeAlias ft, defineArrayTypeAlias arrayType] ++ depsForDeleteFunc typeEnv env arrTy)
 
 templatePushBack :: (String, Binder)
-templatePushBack = 
+templatePushBack =
   let aTy = StructTy "Array" [VarTy "a"]
       valTy = VarTy "a"
   in  defineTemplate
@@ -150,7 +150,7 @@ templatePushBack =
       (\(FuncTy [arrayType, _] _) -> [defineArrayTypeAlias arrayType])
 
 templatePopBack :: (String, Binder)
-templatePopBack = 
+templatePopBack =
   let aTy = StructTy "Array" [VarTy "a"]
   in  defineTemplate
       (SymPath ["Array"] "pop-back")
@@ -185,7 +185,7 @@ templateNth =
                         ,"    return &((($t*)a.data)[n]);"
                         ,"}"])
   (\(FuncTy [arrayType, _] _) -> [defineArrayTypeAlias arrayType])
-  
+
 templateReplicate :: (String, Binder)
 templateReplicate = defineTypeParameterizedTemplate templateCreator path t
   where path = SymPath ["Array"] "replicate"
@@ -275,7 +275,7 @@ templateAsetBang = defineTemplate
                         ,"    (($t*)a.data)[n] = newValue;"
                         ,"}"])
   (\(FuncTy [arrayType, _, _] _) -> [defineArrayTypeAlias arrayType])
-  
+
 templateCount :: (String, Binder)
 templateCount = defineTemplate
   (SymPath ["Array"] "count")
@@ -308,7 +308,7 @@ templateRange = defineTypeParameterizedTemplate templateCreator path t
                defineArrayTypeAlias arrayType :
                depsForDeleteFunc typeEnv env arrayType ++
                depsForCopyFunc typeEnv env insideType)
-    
+
 templateDeleteArray :: (String, Binder)
 templateDeleteArray = defineTypeParameterizedTemplate templateCreator path t
   where templateCreator = TemplateCreator $
@@ -324,7 +324,7 @@ templateDeleteArray = defineTypeParameterizedTemplate templateCreator path t
                 defineArrayTypeAlias arrayType : depsForDeleteFunc typeEnv env insideType)
         path = SymPath ["Array"] "delete"
         t = (FuncTy [(StructTy "Array" [VarTy "a"])] UnitTy)
-        
+
 deleteTy :: TypeEnv -> Env -> Ty -> [Token]
 deleteTy typeEnv env (StructTy "Array" [innerType]) =
   [ TokC   "    for(int i = 0; i < a.len; i++) {\n"
@@ -341,7 +341,7 @@ insideArrayDeletion typeEnv env t =
       "    " ++ functionFullName ++ "(((" ++ tyToC t ++ "*)a.data)[i]);\n"
     FunctionNotFound msg -> error msg
     FunctionIgnored -> "    /* Ignore non-managed type inside Array: '" ++ show t ++ "' */\n"
-  
+
 templateCopyArray :: (String, Binder)
 templateCopyArray = defineTypeParameterizedTemplate templateCreator path t
   where templateCreator = TemplateCreator $
@@ -366,7 +366,7 @@ templateCopyArray = defineTypeParameterizedTemplate templateCreator path t
              )
         path = SymPath ["Array"] "copy"
         t = (FuncTy [(RefTy (StructTy "Array" [VarTy "a"]))] (StructTy "Array" [VarTy "a"]))
-        
+
 copyTy :: TypeEnv -> Env -> Ty -> [Token]
 copyTy typeEnv env (StructTy "Array" [innerType]) =
   [ TokC   "    for(int i = 0; i < a->len; i++) {\n"
@@ -383,7 +383,7 @@ insideArrayCopying typeEnv env t =
       "    ((" ++ tyToC t ++ "*)(copy.data))[i] = " ++ functionFullName ++ "(&(((" ++ tyToC t ++ "*)a->data)[i]));\n"
     FunctionNotFound msg -> error msg
     FunctionIgnored -> "    /* Ignore non-managed type inside Array: '" ++ show t ++ "' */\n"
-  
+
 templateStrArray :: (String, Binder)
 templateStrArray = defineTypeParameterizedTemplate templateCreator path t
   where templateCreator = TemplateCreator $

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -382,7 +382,8 @@ insideArrayCopying typeEnv env t =
     FunctionFound functionFullName ->
       "    ((" ++ tyToC t ++ "*)(copy.data))[i] = " ++ functionFullName ++ "(&(((" ++ tyToC t ++ "*)a->data)[i]));\n"
     FunctionNotFound msg -> error msg
-    FunctionIgnored -> "    /* Ignore non-managed type inside Array: '" ++ show t ++ "' */\n"
+    FunctionIgnored ->
+      "    ((" ++ tyToC t ++"*)(copy.data))[i] = ((" ++ tyToC t ++ "*)a->data)[i];\n"
 
 templateStrArray :: (String, Binder)
 templateStrArray = defineTypeParameterizedTemplate templateCreator path t

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -378,12 +378,12 @@ copyTy _ _ _ = []
 -- | The "memberCopy" and "memberDeletion" functions in Deftype are very similar!
 insideArrayCopying :: TypeEnv -> Env -> Ty -> String
 insideArrayCopying typeEnv env t =
-  case findFunctionForMember typeEnv env "copy" (typesCopyFunctionType t) ("Inside array.", t) of
+  case findFunctionForMemberIncludePrimitives typeEnv env "copy" (typesCopyFunctionType t) ("Inside array.", t) of
     FunctionFound functionFullName ->
       "    ((" ++ tyToC t ++ "*)(copy.data))[i] = " ++ functionFullName ++ "(&(((" ++ tyToC t ++ "*)a->data)[i]));\n"
     FunctionNotFound msg -> error msg
     FunctionIgnored ->
-      "    ((" ++ tyToC t ++"*)(copy.data))[i] = ((" ++ tyToC t ++ "*)a->data)[i];\n"
+      "    /* Ignore type inside Array when copying: '" ++ show t ++ "' (no copy function known)*/\n"
 
 templateStrArray :: (String, Binder)
 templateStrArray = defineTypeParameterizedTemplate templateCreator path t

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -1,0 +1,90 @@
+(use Test)
+(use Vector2)
+(use Geometry)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  &(init 1.0 2.0) &(init 1.0 2.0)
+                  "= operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 1.0 2.0) &(init 1.0 1.0)
+                  "/= operator works"
+                  /=
+                  str)
+    (assert-equal test
+                  &(init 3.0 3.0)
+                  &(+ &(init 2.0 1.0) &(init 1.0 2.0))
+                  "+ operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 1.0 -1.0)
+                  &(- &(init 2.0 1.0) &(init 1.0 2.0))
+                  "- operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 4.0 2.0)
+                  &(* &(init 2.0 1.0) 2.0)
+                  "* operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 1.0 0.5)
+                  &(/ &(init 2.0 1.0) 2.0)
+                  "/ operator works"
+                  =
+                  str)
+    (assert-equal test
+                  5.0
+                  (mag &(init 3.0 4.0))
+                  "mag works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  101.0
+                  (mag-sq &(init 10.0 1.0))
+                  "mag-sq works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  &(init 0.6 0.8)
+                  &(normalize &(init 3.0 4.0))
+                  "normalize works"
+                  Vector2.=
+                  Vector2.str)
+    (assert-equal test
+                  5.0
+                  (dist &(init 10.0 10.0) &(init 7.0 6.0))
+                  "dist works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  0.0
+                  (heading &(init 1.0 0.0))
+                  "heading works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  &(init -2.0 1.0)
+                  &(rotate &(init 1.0 2.0) (degree-to-radians 90.0))
+                  "rotate works"
+                  Vector2.approx
+                  Vector2.str)
+    (assert-equal test
+                  90.0
+                  (radians-to-degree (Vector2.angle-between &(init 1.0 0.0) &(init 0.0 1.0)))
+                  "angle-between works"
+                  Double.approx
+                  Double.str)
+    (assert-equal test
+                  44.0
+                  (dot &(init 10.0 2.0) &(init 2.0 12.0))
+                  "dot works"
+                  Double.=
+                  Double.str)
+    (print-test-results test)
+))

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -86,5 +86,11 @@
                   "dot works"
                   Double.=
                   Double.str)
+    (assert-equal test
+                  &(init 2.5 5.0)
+                  &(lerp &(init 0.0 0.0) &(init 5.0 10.0) 0.5)
+                  "lerp works"
+                  =
+                  str)
     (print-test-results test)
 ))

--- a/test/vector3.carp
+++ b/test/vector3.carp
@@ -1,0 +1,75 @@
+(use Test)
+(use Vector3)
+(use Geometry)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  &(init 1.0 2.0 3.0) &(init 1.0 2.0 3.0)
+                  "= operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 1.0 2.0 3.0) &(init 1.0 1.0 3.0)
+                  "/= operator works"
+                  /=
+                  str)
+    (assert-equal test
+                  &(init 3.0 3.0 4.5)
+                  &(+ &(init 2.0 1.0 2.0) &(init 1.0 2.0 2.5))
+                  "+ operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 1.0 -1.0 -1.5)
+                  &(- &(init 2.0 1.0 2.0) &(init 1.0 2.0 3.5))
+                  "- operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 4.0 2.0 2.2)
+                  &(* &(init 2.0 1.0 1.1) 2.0)
+                  "* operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 1.0 0.5 0.25)
+                  &(/ &(init 2.0 1.0 0.5) 2.0)
+                  "/ operator works"
+                  =
+                  str)
+    (assert-equal test
+                  5.0
+                  (mag &(init 3.0 4.0 0.0))
+                  "mag works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  101.0
+                  (mag-sq &(init 10.0 1.0 0.0))
+                  "mag-sq works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  &(init 0.6 0.8 0.0)
+                  &(normalize &(init 3.0 4.0 0.0))
+                  "normalize works"
+                  Vector2.=
+                  Vector2.str)
+    (assert-equal test
+                  90.0
+                  (radians-to-degree (Vector2.angle-between &(init 1.0 0.0 0.0)
+                                                            &(init 0.0 1.0 0.0)))
+                  "angle-between works"
+                  Double.approx
+                  Double.str)
+    (assert-equal test
+                  44.0
+                  (dot &(init 10.0 2.0 3.0) &(init 2.0 12.0 3.0))
+                  "dot works"
+                  Double.=
+                  Double.str)
+    (print-test-results test)
+))
+
+(build)

--- a/test/vector3.carp
+++ b/test/vector3.carp
@@ -54,23 +54,23 @@
                   &(init 0.6 0.8 0.0)
                   &(normalize &(init 3.0 4.0 0.0))
                   "normalize works"
-                  Vector2.=
-                  Vector2.str)
+                  =
+                  str)
     (assert-equal test
                   90.0
-                  (radians-to-degree (Vector2.angle-between &(init 1.0 0.0 0.0)
-                                                            &(init 0.0 1.0 0.0)))
+                  (radians-to-degree (angle-between &(init 1.0 0.0 0.0)
+                                                    &(init 0.0 1.0 0.0)))
                   "angle-between works"
                   Double.approx
                   Double.str)
     (assert-equal test
-                  44.0
+                  53.0
                   (dot &(init 10.0 2.0 3.0) &(init 2.0 12.0 3.0))
                   "dot works"
                   Double.=
                   Double.str)
     (assert-equal test
-                  &(init 2.5 5.0 1.0)
+                  &(init 2.5 5.0 0.75)
                   &(lerp &(init 0.0 0.0 0.5) &(init 5.0 10.0 2.0) 0.5)
                   "lerp works"
                   =

--- a/test/vector3.carp
+++ b/test/vector3.carp
@@ -69,7 +69,11 @@
                   "dot works"
                   Double.=
                   Double.str)
+    (assert-equal test
+                  &(init 2.5 5.0 1.0)
+                  &(lerp &(init 0.0 0.0 0.5) &(init 5.0 10.0 2.0) 0.5)
+                  "lerp works"
+                  =
+                  str)
     (print-test-results test)
 ))
-
-(build)

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -1,0 +1,73 @@
+(use Test)
+(use VectorN)
+(use Geometry)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  &(init 4 [1.0 2.0 3.0 4.0]) &(init 4 [1.0 2.0 3.0 4.0])
+                  "= operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 4 [1.0 2.0 3.0 4.0]) &(init 4 [1.0 1.0 3.0 4.0])
+                  "/= operator works"
+                  /=
+                  str)
+    (assert-equal test
+                  &(init 3 [3.0 3.0 4.5])
+                  &(+ &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 2.5]))
+                  "+ operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 3 [1.0 -1.0 -1.5])
+                  &(- &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 3.5]))
+                  "- operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 3 [4.0 2.0 2.2])
+                  &(* &(init 3 [2.0 1.0 1.1]) 2.0)
+                  "* operator works"
+                  =
+                  str)
+    (assert-equal test
+                  &(init 3 [1.0 0.5 0.25])
+                  &(/ &(init 3 [2.0 1.0 0.5]) 2.0)
+                  "/ operator works"
+                  =
+                  str)
+    (assert-equal test
+                  5.0
+                  (mag &(init 3 [3.0 4.0 0.0]))
+                  "mag works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  101.0
+                  (mag-sq &(init 3 [10.0 1.0 0.0]))
+                  "mag-sq works"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  &(init 3 [0.6 0.8 0.0])
+                  &(normalize &(init 3 [3.0 4.0 0.0]))
+                  "normalize works"
+                  Vector2.=
+                  Vector2.str)
+    (assert-equal test
+                  90.0
+                  (radians-to-degree (Vector2.angle-between &(init 3 [1.0 0.0 0.0])
+                                                            &(init 3 [0.0 1.0 0.0])))
+                  "angle-between works"
+                  Double.approx
+                  Double.str)
+    (assert-equal test
+                  44.0
+                  (dot &(init 3 [10.0 2.0 3.0]) &(init 3 [2.0 12.0 3.0]))
+                  "dot works"
+                  Double.=
+                  Double.str)
+    (print-test-results test)
+))

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -69,5 +69,11 @@
                   "dot works"
                   Double.=
                   Double.str)
+    (assert-equal test
+                  &(init 1 [2.0])
+                  &(lerp &(init 1 [0.0]) &(init 1 [5.0]) 0.4)
+                  "lerp works"
+                  =
+                  str)
     (print-test-results test)
 ))

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -54,17 +54,17 @@
                   &(init 3 [0.6 0.8 0.0])
                   &(normalize &(init 3 [3.0 4.0 0.0]))
                   "normalize works"
-                  Vector2.=
-                  Vector2.str)
+                  =
+                  str)
     (assert-equal test
                   90.0
-                  (radians-to-degree (Vector2.angle-between &(init 3 [1.0 0.0 0.0])
-                                                            &(init 3 [0.0 1.0 0.0])))
+                  (radians-to-degree (angle-between &(init 3 [1.0 0.0 0.0])
+                                                    &(init 3 [0.0 1.0 0.0])))
                   "angle-between works"
                   Double.approx
                   Double.str)
     (assert-equal test
-                  44.0
+                  53.0
                   (dot &(init 3 [10.0 2.0 3.0]) &(init 3 [2.0 12.0 3.0]))
                   "dot works"
                   Double.=


### PR DESCRIPTION
This PR adds a Vector module. Vectors come in the flavors `Vector2`, `Vector3` and `VectorN`. 2- and 3-dimensional vectors are structs with special fields, whereas n-dimensional arrays are basically just arrays on which we can perform vector operations.

## The API of Vectors

The following functions are included:
- Arithmetic operations: i.e. `+`, `-`, `*`, and `/`
- Logic operations: i.e. `=`, `/=`, and `approx` (which checks whether the vectors are identical except for negligible rounding errors)
- `mag` to get the magnitude of a vector
- `mag-sq` to get the squared magnitude of a vector
- `normalize` to normalize a vector
- `dist` to get the distance between two vectors (only 2D)
- `heading` to get the direction of the vector (only 2D)
- `rotate` to rotate a vector (only 2D)
- `dot` to get the dot product of two vectors
- `cross` to get the cross product of two vectors (only 3D)
- `angle-between` to get the angle between two vectors (only 2D and 3D, although ND would be possible)
- `lerp` to linearly interpolate between to vectors

### Open questions
- Did I miss anything?

## Other miscellanous additions

The following is included to make this work:
- A Geometry module (currently only handles conversion between radians and degrees)
- Logical operators on doubles: `=`, `>`, `<`, and `approx` (see above)
- Mathematical functions on doubles: `acos`, `atan2`, `clamp`, and `sqrt`
- prelude: converted macros to functions to enable higher-order handling
- haskell: fix bug in `multiLookupQualified` where a case wasn’t treated.
- test: changed API so that datatypes have to provide custom `str` function to enable genericism
- added test suites for all of them

### Open questions
- Do we need any more geometry functions for now?
- Should all operators be implemented for all numerical datatypes?
- Why do the test suites for Vector3 and VectorN not work? **IMPORTANT; FIXME BEFORE MERGE**

I think that’s it!

Cheers