### PR TITLE
Statistics: add module

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -125,6 +125,9 @@ arrayModule = Env { envBindings = bindings, envParent = Nothing, envModuleName =
                                 , templateDeleteArray
                                 , templateCopyArray
                                 , templateStrArray
+                                , templateSort
+                                , templateIndexOf
+                                , templateElemCount
                                 ]
 
 startingGlobalEnv :: Env
@@ -160,6 +163,7 @@ preludeModules carpDir = map (\s -> carpDir ++ "/core/" ++ s ++ ".carp") [ "Macr
                                                                          , "Vector"
                                                                          , "Geometry"
                                                                          , "Test"
+                                                                         , "Statistics"
                                                                          ]
 
 main :: IO ()

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -6,8 +6,8 @@
         (for [i 0 (count xs)]
           (set! &total (f &total (nth xs i))))
         total)))
-  
-  )
+
+)
 
 ;; BUGS! These function definitions will not create the required typedef for Array, for instance:
 ;; typedef Array Array__int;

--- a/core/Statistics.carp
+++ b/core/Statistics.carp
@@ -1,0 +1,119 @@
+(use Int)
+(use Double)
+
+(defmodule Statistics
+  (defn sorter [a b]
+    (to-int (- @a @b)))
+
+  (defn sum [data]
+    (if (= 0 (Array.count data))
+      0.0
+      (let [total @(Array.nth data 0)]
+        (do
+          (for [i 1 (Array.count data)]
+            (set! &total (+ total @(Array.nth data i))))
+          total))))
+
+  (defn mean [data]
+    (/ (sum data) (from-int (Array.count data))))
+
+  (defn min [a]
+    (let [m (Double.copy (Array.nth a 0))]
+      (do
+        (for [i 1 (Array.count a)]
+          (let [el (Double.copy (Array.nth a i))]
+            (if (Double.< el m)
+              (set! &m el)
+              ())))
+        m)))
+
+  (defn max [a]
+    (let [m (Double.copy (Array.nth a 0))]
+      (do
+        (for [i 1 (Array.count a)]
+          (let [el (Double.copy (Array.nth a i))]
+            (if (Double.> el m)
+              (set! &m el)
+              ())))
+        m)))
+
+  (defn _pp [a mean]
+    (let [sum 0.0]
+      (do
+        (for [i 0 (Array.count a)]
+          (let [tmp (Double.- (Double.copy (Array.nth a i)) mean)]
+            (set! &sum (Double.* tmp tmp))))
+        sum)))
+
+  (defn _xx [a mean]
+    (let [sum 0.0]
+      (do
+        (for [i 0 (Array.count a)]
+          (set! &sum (Double.- (Double.copy (Array.nth a i)) mean)))
+        sum)))
+
+  (defn _ss [data]
+    (let [m (mean data)
+          tmp (_xx data m)]
+      (Double.- (_pp data m)
+                (Double./ (Double.* tmp tmp)
+                          (Double.from-int (Array.count data))))))
+
+  (defn median [data]
+    (let [n (Array.count data)
+          sorted (Array.copy (Array.sort data sorter))]
+      (if (= n 0)
+        0.0
+        (if (= (mod n 2) 1)
+          @(Array.nth data (/ n 2))
+          (let [mid (/ n 2)]
+            (/ (+ (the Double @(Array.nth data (dec mid)))
+                  @(Array.nth data mid))
+                2.0))))))
+
+  (defn low-median [data]
+    (let [n (Array.count data)
+          sorted (Array.copy (Array.sort data sorter))]
+      (if (= n 0)
+        0.0
+        (if (= (mod n 2) 1)
+          @(Array.nth data (/ n 2))
+          @(Array.nth data (dec (/ n 2)))))))
+
+  (defn high-median [data]
+    (let [n (Array.count data)
+          sorted (Array.copy (Array.sort data sorter))]
+      (if (= n 0)
+        0.0
+        @(Array.nth data (/ n 2)))))
+
+  (defn grouped-median [data interval]
+    (let [n (Array.count data)
+          sorted (Array.copy (Array.sort data sorter))]
+      (if (= n 0)
+        0.0
+        (if (= n 1)
+          @(Array.nth data 0)
+          (let [x @(Array.nth data (/ n 2))
+                l (- x (/ (from-int interval) 2.0))
+                cf (Array.index-of data x)
+                f (Array.element-count data x)]
+            (+ l (/ (* (from-int interval) (- (/ (from-int n) 2.0) (from-int cf)))
+                    (from-int f))))))))
+
+  (defn variance [data]
+    (let [n (Array.count data)
+          ss (_ss data)]
+      (/ ss (from-int (dec n)))))
+
+  (defn pvariance [data]
+    (let [n (Array.count data)
+          ss (_ss data)]
+      (/ ss (from-int n))))
+
+  (defn stdev [data]
+    (Double.sqrt (variance data)))
+
+  (defn pstdev [data]
+    (Double.sqrt (pvariance data)))
+)

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -186,6 +186,53 @@ templateNth =
                         ,"}"])
   (\(FuncTy [arrayType, _] _) -> [defineArrayTypeAlias arrayType])
 
+templateSort :: (String, Binder)
+templateSort =
+  let t = VarTy "t"
+  in defineTemplate
+  (SymPath ["Array"] "sort")
+  (FuncTy [RefTy (StructTy "Array" [t]), FuncTy [RefTy t, RefTy t] IntTy] (RefTy (StructTy "Array" [t])))
+  (toTemplate "Array* $NAME (Array *a, $(Fn [(Ref t), (Ref t)] Int) f)")
+  (toTemplate $ unlines ["$DECL {"
+                        ,"    qsort(a->data, a->len, sizeof($t), (int(*)(const void*, const void*))f);"
+                        ,"    return a;"
+                        ,"}"])
+  (\(FuncTy [arrayType, sortType] _) -> [defineFunctionTypeAlias sortType,
+                                         defineArrayTypeAlias arrayType])
+
+templateIndexOf :: (String, Binder)
+templateIndexOf =
+  let t = VarTy "t"
+  in defineTemplate
+  (SymPath ["Array"] "index-of")
+  (FuncTy [RefTy (StructTy "Array" [t]), t] IntTy)
+  (toTemplate "int $NAME (Array *a, $t elem)")
+  (toTemplate $ unlines ["$DECL {"
+                        ,"    int i;"
+                        ,"    for (i = 0; i < a->len; i++) {"
+                        ,"      if ((($t*)a->data)[i] == elem) return i;"
+                        ,"    }"
+                        ,"    return -1;"
+                        ,"}"])
+  (\(FuncTy [arrayType, _] _) -> [defineArrayTypeAlias arrayType])
+
+templateElemCount :: (String, Binder)
+templateElemCount =
+  let t = VarTy "t"
+  in defineTemplate
+  (SymPath ["Array"] "element-count")
+  (FuncTy [RefTy (StructTy "Array" [t]), t] IntTy)
+  (toTemplate "int $NAME (Array *a, $t elem)")
+  (toTemplate $ unlines ["$DECL {"
+                        ,"    int i;"
+                        ,"    int count = 0;"
+                        ,"    for (i = 0; i < a->len; i++) {"
+                        ,"      if ((($t*)a->data)[i] == elem) count++;"
+                        ,"    }"
+                        ,"    return count;"
+                        ,"}"])
+  (\(FuncTy [arrayType, _] _) -> [defineArrayTypeAlias arrayType])
+
 templateReplicate :: (String, Binder)
 templateReplicate = defineTypeParameterizedTemplate templateCreator path t
   where path = SymPath ["Array"] "replicate"

--- a/test/statistics.carp
+++ b/test/statistics.carp
@@ -1,0 +1,66 @@
+(use Test)
+(use Statistics)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  2.0
+                  (median &[1.0 2.0 3.0])
+                  "median works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  2.5
+                  (mean &[1.0 2.0 4.5])
+                  "mean works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  2.0
+                  (low-median &[1.0 2.0 4.0 5.0])
+                  "low-median works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  4.0
+                  (high-median &[1.0 2.0 4.0 5.0])
+                  "high-median works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  3.0
+                  (grouped-median &[1.0 2.0 4.0 5.0] 2)
+                  "grouped-median works as expected I"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  2.5
+                  (grouped-median &[1.0 2.0 4.0 5.0] 3)
+                  "grouped-median works as expected II"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  1.0
+                  (variance &[1.0 2.0 4.0 5.0])
+                  "variance works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  0.75
+                  (pvariance &[1.0 2.0 4.0 5.0])
+                  "pvariance works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  2.0
+                  (stdev &[1.0 1.0 9.0 9.0])
+                  "stdev works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  2.0
+                  (pstdev &[1.0 9.0])
+                  "pstdev works as expected"
+                  Double.=
+                  Double.str)
+    (print-test-results test)))


### PR DESCRIPTION
This PR adds a statistics module and a few required changes to the core to make this work. All statistical functions operate on doubles, because we need functions like `sqrt` to work. If you want to use this library with any other numerical type, you will have to cast it first.

The API is fairly minimal, because I’m not sure I’d be the right person to implement fancier statistical functions.

## The API of Statistics

The following functions are included:
- `sum`, a helper function to sum an Array
- `mean` calculates the mean of an Array
- `min` gets the minimum element in an Array
- `max` gets the maximum element in an Array
- `median`, `low-median`, and `high-median` calculate various flavors of the median
- `grouped-median` calculates another flavor of the median. You need to specify the interval size for it to work.
- `variance` calculates the variance
- `pvariance` calculates the population variance
- `stdev` calculates the standard deviation
- `pstdev` calculates the population standard deviation

## Other miscellaneous additions

To enable this, I had to include the following items:
- `Array.sort` sorts an Array given a sorting function (based on the C function `qsort`)
- `Array.index-of` finds the first index of an element in an Array
- `Array.element-count` counts the occurrence of an element in an Array

### Open questions
- `index-of` and `element-count` are implemented as templates. That’s not necessary, but simplified the implementation, because no custom comparison function had to be injected. It means that the comparison uses `==`, however, which will only work on simple types. This should probably be fixed in the future.

A minimal test suite is included.

Cheers