### PR TITLE
Statistics, revisited

### DIFF
--- a/core/Double.carp
+++ b/core/Double.carp
@@ -17,6 +17,7 @@
   (register str (Fn [Double] String))
   (register floor (Fn [Double] Double))
   (register copy (Fn [(Ref Double)] Double))
+  (register abs (Fn [Double] Double))
 
   (defn clamp [min, max, val]
     (if (> val max)

--- a/core/Statistics.carp
+++ b/core/Statistics.carp
@@ -136,7 +136,7 @@
           n 1.4826] ; taken from Rust and R, because that’s how it’s done apparently
       (do
         (for [i 0 (Array.count data)]
-          (Array.aset! &abs-devs i (- med @(Array.nth data i))))
+          (Array.aset! &abs-devs i (abs (- med @(Array.nth data i)))))
         (* (median &abs-devs) n))))
 
   (defn median-abs-dev-pct [data]

--- a/core/prelude.h
+++ b/core/prelude.h
@@ -266,6 +266,10 @@ double Double_floor(double x) {
     return floor(x);
 }
 
+double Double_abs(double x) {
+    return fabs(x);
+}
+
 string Double_str(double x) {
     char *buffer = CARP_MALLOC(32);
     snprintf(buffer, 32, "%g", x);

--- a/test/statistics.carp
+++ b/test/statistics.carp
@@ -1,5 +1,17 @@
+(use Double)
 (use Test)
 (use Statistics)
+
+(defn all-eq [a b]
+  (if (/= (Array.count a) (Array.count b))
+    false
+    (let [res true]
+      (do
+        (for [i 0 (Array.count a)]
+          (if (not (Double.= @(Array.nth a i) @(Array.nth b i)))
+            (set! &res false)
+            ()))
+        res))))
 
 (defn main []
   (with-test test
@@ -61,6 +73,66 @@
                   2.0
                   (pstdev &[1.0 9.0])
                   "pstdev works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  &[0.0 0.0 0.0 0.0 0.0]
+                  &(winsorize &[0.0 0.0 0.0 0.0 10.0] 90.0)
+                  "winsorizing works as expected"
+                  all-eq
+                  Array.str)
+    (assert-equal test
+                  &[2.5 5.0 7.5]
+                  &(quartiles &[0.0 2.5 5.0 7.5 10.0])
+                  "quartiles work as expected"
+                  all-eq
+                  Array.str)
+    (assert-equal test
+                  5.0
+                  (iqr &[0.0 2.5 5.0 7.5 10.0])
+                  "iqr works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  10.0
+                  (sum &[2.5 5.0 2.0 0.5])
+                  "sum works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  0.5
+                  (min &[2.5 5.0 2.0 0.5])
+                  "min works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  5.0
+                  (max &[2.5 5.0 2.0 0.5])
+                  "max works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  40.0
+                  (stdev-pct &[1.0 1.0 9.0 9.0])
+                  "stdev-pct works as expected"
+                  Double.=
+                  Double.str)
+    (assert-equal test
+                  3.7065
+                  (median-abs-dev &[5.0 10.0])
+                  "median-abs-dev works as expected"
+                  Double.approx
+                  Double.str)
+    (assert-equal test
+                  49.42
+                  (median-abs-dev-pct &[5.0 10.0])
+                  "median-abs-dev-pct works as expected"
+                  Double.approx
+                  Double.str)
+    (assert-equal test
+                  2.0
+                  (Summary.median &(summary &[1.0 2.0 3.0]))
+                  "summary works as expected"
                   Double.=
                   Double.str)
     (print-test-results test)))


### PR DESCRIPTION
This PR introduces the missing tests from #87, where the statistics module was extended but never got the love it needed. In the course of that, I also added the function `Double.abs` for taking the absolute value of a `Double`, and fixed a bug in `median-abs-dev`, which failed to adhere to its promise of taking said absolute value.

Cheers