### PR TITLE
Additions to Char

### DIFF
--- a/core/Char.carp
+++ b/core/Char.carp
@@ -1,2 +1,5 @@
 (defmodule Char
-  (register str (Fn [Char] String)))
+  (register str (Fn [Char] String))
+  (register to-int (Fn [Char] Int))
+  (register from-int (Fn [Int] Char))
+)

--- a/core/String.carp
+++ b/core/String.carp
@@ -9,7 +9,7 @@
   (register cstr       (Fn [&String] (Ptr Char)))
   (register str        (Fn [&String] String))
   (register chars      (Fn [&String] (Array Char)))
-  (register from-chars (Fn [(Array Char)] &String))
+  (register from-chars (Fn [(Array Char)] String))
 
   (defn repeat [n inpt]
     (let [str ""]

--- a/core/prelude.h
+++ b/core/prelude.h
@@ -218,8 +218,8 @@ Array String_chars(string *s) {
 }
 
 string String_from_MINUS_chars(Array a) {
-    string s = malloc(a.len);
-    snprintf(s, a.len, "%s", a.data);
+    string s = malloc(a.len+1);
+    snprintf(s, a.len+1, "%s", a.data);
     return s;
 }
 
@@ -227,6 +227,14 @@ string Char_str(char c) {
     char *buffer = CARP_MALLOC(3);
     snprintf(buffer, 3, "\\%c", c);
     return buffer;
+}
+
+int Char_to_MINUS_int(char c) {
+  return (int)c;
+}
+
+char Char_from_MINUS_int(int i) {
+  return (char)i;
 }
 
 int exmod__bleh(int x) {


### PR DESCRIPTION
This PR adds the functions `Char.from-int` and `Char.to-int`. They are useful for things like `(Array.range \a \z (Char.from-int 1))` (this will generate the letters a-z).

While debugging this, I also found a bug in `String.from-chars`. It allocated enough elements to hold the arrays contents, but not for the null terminator. This means that the last letter was always missing.<sup>1</sup>

Cheers

1. I should really start to write a test suite for the core libraries