### PR TITLE
Math functions, Vol. III: Math for Ints and Longs (Closer)

### DIFF
--- a/core/Int.carp
+++ b/core/Int.carp
@@ -21,5 +21,10 @@
   (register safe-add (λ [Int Int (Ref Int)] Bool))
   (register safe-sub (λ [Int Int (Ref Int)] Bool))
   (register safe-mul (λ [Int Int (Ref Int)] Bool))
+
+  (register abs (λ [Int] Int))
+
+  (defn max [a b] (if (> a b) a b))
+  (defn min [a b] (if (< a b) a b))
   )
 

--- a/core/Long.carp
+++ b/core/Long.carp
@@ -23,4 +23,9 @@
   (register safe-add (λ [Long Long (Ref Long)] Bool))
   (register safe-sub (λ [Long Long (Ref Long)] Bool))
   (register safe-mul (λ [Long Long (Ref Long)] Bool))
+
+  (register abs (λ [Long] Long))
+
+  (defn max [a b] (if (> a b) a b))
+  (defn min [a b] (if (< a b) a b))
 )

--- a/core/prelude.h
+++ b/core/prelude.h
@@ -57,6 +57,7 @@ bool Int__GT_(int x, int y)    { return x > y; }
 
 int Int_inc(int x) { return x + 1; }
 int Int_dec(int x) { return x - 1; }
+int Int_abs(int x) { return abs(x); }
 
 long Long__PLUS_(long x, long y)   { return x + y; }
 long Long__MINUS_(long x, long y)  { return x - y; }
@@ -71,6 +72,7 @@ bool Long__GT_(long x, long y)    { return x > y; }
 
 long Long_inc(long x) { return x + 1; }
 long Long_dec(long x) { return x - 1; }
+long Long_abs(long x) { return labs(x); }
 
 int Int_copy(int *x) { return *x; }
 int Long_copy(long *x) { return *x; }

--- a/test/int_math.carp
+++ b/test/int_math.carp
@@ -1,0 +1,23 @@
+(use Int)
+(use Test)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  1
+                  (min 1 2)
+                  "min works as expected"
+                  =
+                  str)
+    (assert-equal test
+                  2
+                  (max 1 2)
+                  "max works as expected"
+                  =
+                  str)
+    (assert-equal test
+                  1
+                  (abs -1)
+                  "abs works as expected"
+                  =
+                  str)))

--- a/test/long_math.carp
+++ b/test/long_math.carp
@@ -1,0 +1,23 @@
+(use Long)
+(use Test)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  1l
+                  (min 1l 2l)
+                  "min works as expected"
+                  =
+                  str)
+    (assert-equal test
+                  2l
+                  (max 1l 2l)
+                  "max works as expected"
+                  =
+                  str)
+    (assert-equal test
+                  1l
+                  (abs -1l)
+                  "abs works as expected"
+                  =
+                  str)))


### PR DESCRIPTION
This PR is the third and last installment in our beloved series “Math functions”. It adds a few functions for Ints and Longs, namely `min`, `max`, and `abs`. I feel like math on integers is and should be restricted, but if you’re missing any functions, please let me know!

As always, a test suite is included.

Cheers