### PR TITLE
Tests return non-zero on failure

### DIFF
--- a/core/Test.carp
+++ b/core/Test.carp
@@ -126,7 +126,9 @@
 
 (defmacro with-test [name :rest forms]
   (list 'let [name &(Test.State.init 0 0)]
-    (cons 'do (with-test-internal name forms))))
+    (cons-last
+      (list 'Test.State.failed name)
+      (cons 'do (with-test-internal name forms)))))
 
 (defmacro deftest [name state-name :rest forms]
   (list 'defn name []


### PR DESCRIPTION
This PR introduces a change to the `with-test` macro that makes it return the number of failed tests, making it easy for e.g. a bash script to check whether anything has failed in the test suite.

Cheers