### PR TITLE
Improve precision of π and e

### DIFF
--- a/core/Double.carp
+++ b/core/Double.carp
@@ -1,6 +1,6 @@
 (defmodule Double
-  (def π 3.1415926536)
-  (def e 2.7182818285)
+  (def π 3.141592653589793)
+  (def e 2.718281828459045)
   (register = (Fn [Double Double] Bool))
   (register < (Fn [Double Double] Bool))
   (register > (Fn [Double Double] Bool))


### PR DESCRIPTION
This PR improves the precision of π and e. While working on the physics library I realized that the low-precision versions we had degraded the precision of my calculations.

Cheers