### PR TITLE
Added macro-error function

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -103,6 +103,11 @@ eval env xobj =
                (XObj (Lst lst1) _ _, XObj (Lst lst2) _ _) ->
                  return (XObj (Lst (lst1 ++ lst2)) i t) -- TODO: should they get their own i:s and t:s
                _ -> Left (EvalError "Applying 'append' to non-list or empty list")
+        [XObj (Sym (SymPath [] "macro-error")) _ _, arg] ->
+          do evaledArg <- eval env arg
+             case evaledArg of
+              XObj (Str msg) _ _ -> Left (EvalError msg)
+              _                  -> Left (EvalError "Calling 'macro-error' with non-string argument")
         [XObj If _ _, condition, ifTrue, ifFalse] ->
           do evaledCondition <- eval env condition
              case obj evaledCondition of


### PR DESCRIPTION
This PR adds a function `macro-error` to `Eval`. This function provides a mechanism to abort compilation from a macro, and is intended to be used when the macro occurs an unfixable error during expansion, i.e. was called with the wrong arguments.

```
(defmacro one-arg [:rest args]
   (if (= (count args) 1)
     (car args)
     (macro-error "one-arg needs to be called with exactly one argument.")))
```

Cheers