### PR TITLE
Add CFLAG to build on typical Linux OSes

### DIFF
--- a/core/sdl.carp
+++ b/core/sdl.carp
@@ -4,6 +4,7 @@
 
 ;; Compiler flags
 (add-cflag "-I/usr/local/include/SDL2")
+(add-cflag "-I/usr/include/SDL2")
 (add-cflag "-D_THREAD_SAFE")
 (add-lib "-L/usr/local/lib")
 (add-lib "-lSDL2")


### PR DESCRIPTION
Hi,

I use Ubuntu16.04 to build examples/game.carp, but I got the following error message:

```
Welcome to Carp 0.2.0
This is free software with ABSOLUTELY NO WARRANTY.
Evaluate (help) for more information.
./out/main.c:3:10: fatal error: 'SDL.h' file not found
#include <SDL.h>
         ^
1 error generated.
carp: callCommand: clang ./out/main.c -o ./out/a.out -D_THREAD_SAFE -I/usr/local/include/SDL2 -fPIC -lSDL2_image -lSDL2 -L/usr/local/lib -lm -I/home/tamamu/Carp/core/  -g  (exit 1): failed
```

On my Ubuntu (and other typical Linux OSes), SDL has been installed under `/usr/include/`, so I added the path to `core/sdl.carp`.

Thanks.