### PR TITLE
Simplify Test module

### DIFF
--- a/core/Test.carp
+++ b/core/Test.carp
@@ -43,7 +43,7 @@
 (defmodule Test
   (deftype State [passed Int, failed Int])
 
-  (defn handler [state expected actual descr what op str]
+  (defn handler [state expected actual descr what op]
     (if (op expected actual)
       (do
         (IO.color "green")
@@ -59,35 +59,20 @@
         (IO.color "reset")
         (State.update-failed (State.copy state) Int.inc))))
 
-  (defn assert-equal [state x y descr op str]
-    (handler state x y descr "value" op str))
+  (defn assert-op [state x y descr op]
+    (handler state x y descr "value" op))
 
-  (defn assert-str-equal [state x y descr]
-    (assert-equal state x y descr String.= String.str))
+  (defn assert-equal [state x y descr]
+    (handler state x y descr "value" =))
 
-  (defn assert-int-equal [state x y descr]
-    (assert-equal state x y descr Int.= Int.str))
-
-  (defn assert-bool-equal [state x y descr]
-    (assert-equal state x y descr Bool.= Bool.str))
-
-  (defn assert-not-equal [state x y descr op str]
-    (handler state x y descr "not value" op str))
-
-  (defn assert-bool-not-equal [state x y descr]
-    (assert-equal state x y descr Bool./= Bool.str))
-
-  (defn assert-str-not-equal [state x y descr]
-    (assert-equal state x y descr String./= String.str))
-
-  (defn assert-int-not-equal [state x y descr]
-    (assert-equal state x y descr Int./= Int.str))
+  (defn assert-not-equal [state x y descr]
+    (handler state x y descr "not value" /=))
 
   (defn assert-true [state x descr]
-    (assert-bool-equal state true x descr))
+    (assert-equal state true x descr))
 
   (defn assert-false [state x descr]
-    (assert-bool-equal state false x descr))
+    (assert-equal state false x descr))
 
   (defn reset [state]
     (State.set-failed (State.set-passed state 0) 0))

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -19,7 +19,7 @@
   (defn set-y [o v]
     (V2.set-y o v))
 
-  (defn str [o]
+  (defn to-string [o]
     (string-join @"Vector2(" (Double.str (V2.x o)) @", " (Double.str (V2.y o)) @")"))
 
   (defn + [a b]
@@ -97,7 +97,7 @@
   (defn copy [v]
     (V3.copy v))
 
-  (defn str [o]
+  (defn to-string [o]
     (string-join @"Vector2(" (Double.str (V3.x o)) @", " (Double.str (V3.y o))
                  @", " (Double.str (V3.z o)) @")"))
 
@@ -173,7 +173,7 @@
   (defn init [n v]
     (VN.init n v))
 
-  (defn str [o]
+  (defn to-string [o]
     (string-join @"VectorN(dim=" (Int.str (VN.n o)) @", vals=" (Array.str (VN.v o))
                   @")"))
 

--- a/examples/test.carp
+++ b/examples/test.carp
@@ -1,4 +1,7 @@
+(load "Test.carp")
 (use Test)
+(use Int)
+(use String)
 
 ;(deftest my-test test
 ;  (assert-int-equal test 1 2 "1 == 2")
@@ -7,7 +10,7 @@
 
 (defn main []
   (with-test test
-    (assert-int-equal test 1 2 "1 == 2")
+    (assert-equal test 1 2 "1 == 2")
     (assert-true test (Int.> (Array.count &[1 2 3]) 1) "len([1 2 3]) == 1")
-    (assert-str-not-equal test "hi" "bye" "hi != bye")
+    (assert-not-equal test "hi" "bye" "hi != bye")
     (print-test-results test)))

--- a/test/double_math.carp
+++ b/test/double_math.carp
@@ -8,133 +8,90 @@
     (assert-equal test
                   -1.0
                   (neg 1.0)
-                  "neg works as expected"
-                  Double.=
-                  Double.str)
+                  "neg works as expected")
     (assert-equal test
                   0.0
                   (acos 1.0)
-                  "acos works as expected"
-                  Double.=
-                  Double.str)
+                  "acos works as expected")
     (assert-equal test
                   0.0
                   (asin 0.0)
-                  "asin works as expected"
-                  Double.=
-                  Double.str)
+                  "asin works as expected")
     (assert-equal test
                   0.0
                   (atan 0.0)
-                  "atan works as expected"
-                  Double.=
-                  Double.str)
+                  "atan works as expected")
     (assert-equal test
                   0.0
                   (atan2 0.0 0.0)
-                  "atan2 works as expected"
-                  Double.=
-                  Double.str)
+                  "atan2 works as expected")
     (assert-equal test
                   1.0
                   (cos 0.0)
-                  "cos works as expected"
-                  Double.=
-                  Double.str)
+                  "cos works as expected")
     (assert-equal test
                   1.0
                   (cosh 0.0)
-                  "cosh works as expected"
-                  Double.=
-                  Double.str)
+                  "cosh works as expected")
     (assert-equal test
                   1.0
                   (cosh 0.0)
-                  "cosh works as expected"
-                  Double.=
-                  Double.str)
+                  "cosh works as expected")
     (assert-equal test
                   0.0
                   (sin 0.0)
-                  "sin works as expected"
-                  Double.=
-                  Double.str)
+                  "sin works as expected")
     (assert-equal test
                   0.0
                   (sinh 0.0)
-                  "sinh works as expected"
-                  Double.=
-                  Double.str)
+                  "sinh works as expected")
     (assert-equal test
                   0.0
                   (tanh 0.0)
-                  "tanh works as expected"
-                  Double.=
-                  Double.str)
+                  "tanh works as expected")
     (assert-equal test
                   Double.e
                   (exp 1.0)
-                  "exp works as expected"
-                  Double.approx
-                  Double.str)
+                  "exp works as expected")
     (assert-equal test
                   8.0
                   (ldexp 2.0 2)
-                  "ldexp works as expected"
-                  Double.=
-                  Double.str)
+                  "ldexp works as expected")
     (assert-equal test
                   1.0
                   (log Double.e)
-                  "log works as expected"
-                  Double.approx
-                  Double.str)
+                  "log works as expected")
     (assert-equal test
                   1.0
                   (log10 10.0)
-                  "log10 works as expected"
-                  Double.=
-                  Double.str)
+                  "log10 works as expected")
     (assert-equal test
                   256.0
                   (pow 2.0 8.0)
-                  "pow works as expected"
-                  Double.=
-                  Double.str)
+                  "pow works as expected")
     (assert-equal test
                   3.0
                   (sqrt 9.0)
-                  "sqrt works as expected"
-                  Double.=
-                  Double.str)
+                  "sqrt works as expected")
     (assert-equal test
                   2.0
                   (ceil 1.3)
-                  "ceil works as expected"
-                  Double.=
-                  Double.str)
+                  "ceil works as expected")
     (assert-equal test
                   2.0
                   (abs -2.0)
-                  "abs works as expected"
-                  Double.=
-                  Double.str)
+                  "abs works as expected")
     (assert-equal test
                   1.0
                   (floor 1.9)
-                  "floor works as expected"
-                  Double.=
-                  Double.str)
+                  "floor works as expected")
     (assert-equal test
                   1.0
                   (floor 1.9)
-                  "floor works as expected"
-                  Double.=
-                  Double.str)
-    (assert-equal test
-                  0.3
-                  (mod 9.3 3.0)
-                  "mod works as expected"
-                  Double.approx
-                  Double.str)
+                  "floor works as expected")
+    (assert-op test
+               0.3
+               (mod 9.3 3.0)
+               "mod works as expected"
+               Double.approx)
     (print-test-results test)))

--- a/test/float_math.carp
+++ b/test/float_math.carp
@@ -8,133 +8,92 @@
     (assert-equal test
                   -1.0f
                   (neg 1.0f)
-                  "neg works as expected"
-                  Float.=
-                  Float.str)
+                  "neg works as expected")
     (assert-equal test
                   0.0f
                   (acos 1.0f)
-                  "acos works as expected"
-                  Float.=
-                  Float.str)
+                  "acos works as expected")
     (assert-equal test
                   0.0f
                   (asin 0.0f)
-                  "asin works as expected"
-                  Float.=
-                  Float.str)
+                  "asin works as expected")
     (assert-equal test
                   0.0f
                   (atan 0.0f)
-                  "atan works as expected"
-                  Float.=
-                  Float.str)
+                  "atan works as expected")
     (assert-equal test
                   0.0f
                   (atan2 0.0f 0.0f)
-                  "atan2 works as expected"
-                  Float.=
-                  Float.str)
+                  "atan2 works as expected")
     (assert-equal test
                   1.0f
                   (cos 0.0f)
-                  "cos works as expected"
-                  Float.=
-                  Float.str)
+                  "cos works as expected")
     (assert-equal test
                   1.0f
                   (cosh 0.0f)
-                  "cosh works as expected"
-                  Float.=
-                  Float.str)
+                  "cosh works as expected")
     (assert-equal test
                   1.0f
                   (cosh 0.0f)
-                  "cosh works as expected"
-                  Float.=
-                  Float.str)
+                  "cosh works as expected")
     (assert-equal test
                   0.0f
                   (sin 0.0f)
-                  "sin works as expected"
-                  Float.=
-                  Float.str)
+                  "sin works as expected")
     (assert-equal test
                   0.0f
                   (sinh 0.0f)
-                  "sinh works as expected"
-                  Float.=
-                  Float.str)
+                  "sinh works as expected")
     (assert-equal test
                   0.0f
                   (tanh 0.0f)
-                  "tanh works as expected"
-                  Float.=
-                  Float.str)
-    (assert-equal test
-                  1.0f
-                  (exp 0.0f)
-                  "exp works as expected"
-                  Float.approx
-                  Float.str)
+                  "tanh works as expected")
+    (assert-op test
+               1.0f
+               (exp 0.0f)
+               "exp works as expected"
+               Float.approx)
     (assert-equal test
                   8.0f
                   (ldexp 2.0f 2)
-                  "ldexp works as expected"
-                  Float.=
-                  Float.str)
-    (assert-equal test
-                  1.0f
-                  (log (Double.to-float Double.e))
-                  "log works as expected"
-                  Float.approx
-                  Float.str)
+                  "ldexp works as expected")
+    (assert-op test
+               1.0f
+               (log (Double.to-float Double.e))
+               "log works as expected"
+               Float.approx)
     (assert-equal test
                   1.0f
                   (log10 10.0f)
-                  "log10 works as expected"
-                  Float.=
-                  Float.str)
+                  "log10 works as expected")
     (assert-equal test
                   256.0f
                   (pow 2.0f 8.0f)
-                  "pow works as expected"
-                  Float.=
-                  Float.str)
+                  "pow works as expected")
     (assert-equal test
                   3.0f
                   (sqrt 9.0f)
-                  "sqrt works as expected"
-                  Float.=
-                  Float.str)
+                  "sqrt works as expected")
     (assert-equal test
                   2.0f
                   (ceil 1.3f)
-                  "ceil works as expected"
-                  Float.=
-                  Float.str)
+                  "ceil works as expected")
     (assert-equal test
                   2.0f
                   (abs -2.0f)
-                  "abs works as expected"
-                  Float.=
-                  Float.str)
+                  "abs works as expected")
     (assert-equal test
                   1.0f
                   (floor 1.9f)
-                  "floor works as expected"
-                  Float.=
-                  Float.str)
+                  "floor works as expected")
     (assert-equal test
                   1.0f
                   (floor 1.9f)
-                  "floor works as expected"
-                  Float.=
-                  Float.str)
-    (assert-equal test
-                  0.3f
-                  (mod 9.3f 3.0f)
-                  "mod works as expected"
-                  Float.approx
-                  Float.str)
+                  "floor works as expected")
+    (assert-op test
+               0.3f
+               (mod 9.3f 3.0f)
+               "mod works as expected"
+               Float.approx)
     (print-test-results test)))

--- a/test/int_math.carp
+++ b/test/int_math.carp
@@ -8,18 +8,13 @@
     (assert-equal test
                   1
                   (min 1 2)
-                  "min works as expected"
-                  =
-                  str)
+                  "min works as expected")
     (assert-equal test
                   2
                   (max 1 2)
-                  "max works as expected"
-                  =
-                  str)
+                  "max works as expected")
     (assert-equal test
                   1
                   (abs -1)
-                  "abs works as expected"
-                  =
-                  str)))
+                  "abs works as expected")
+    (print-test-results test)))

--- a/test/long_math.carp
+++ b/test/long_math.carp
@@ -8,18 +8,13 @@
     (assert-equal test
                   1l
                   (min 1l 2l)
-                  "min works as expected"
-                  =
-                  str)
+                  "min works as expected")
     (assert-equal test
                   2l
                   (max 1l 2l)
-                  "max works as expected"
-                  =
-                  str)
+                  "max works as expected")
     (assert-equal test
                   1l
                   (abs -1l)
-                  "abs works as expected"
-                  =
-                  str)))
+                  "abs works as expected")
+    (print-test-results test)))

--- a/test/safe_artihmetic.carp
+++ b/test/safe_artihmetic.carp
@@ -27,109 +27,73 @@
     (assert-equal test
                   false
                   (safe-add 1 2 &i)
-                  "safe-add is false without overflow"
-                  =
-                  str)
+                  "safe-add is false without overflow")
     (assert-equal test
                   3
                   (return-res-int safe-add 1 2)
-                  "safe-add really adds"
-                  =
-                  str)
+                  "safe-add really adds")
     (assert-equal test
                   true
                   (safe-add 1000000000 2000000000 &i)
-                  "safe-add is true with overflow"
-                  =
-                  str)
+                  "safe-add is true with overflow")
     (assert-equal test
                   false
                   (safe-sub 1 2 &i)
-                  "safe-sub is false without overflow"
-                  =
-                  str)
+                  "safe-sub is false without overflow")
     (assert-equal test
                   -1
                   (return-res-int safe-sub 1 2)
-                  "safe-sub really subs"
-                  =
-                  str)
+                  "safe-sub really subs")
     (assert-equal test
                   true
                   (safe-sub -1000000000 2000000000 &i)
-                  "safe-sub is true with overflow"
-                  =
-                  str)
+                  "safe-sub is true with overflow")
     (assert-equal test
                   false
                   (safe-mul 1 2 &i)
-                  "safe-mul is false without overflow"
-                  =
-                  str)
+                  "safe-mul is false without overflow")
     (assert-equal test
                   4
                   (return-res-int safe-mul 2 2)
-                  "safe-mul really muls"
-                  =
-                  str)
+                  "safe-mul really muls")
     (assert-equal test
                   true
                   (safe-mul 1000000000 2000000000 &i)
-                  "safe-mul is true with overflow"
-                  =
-                  str)
+                  "safe-mul is true with overflow")
     (assert-equal test
                   false
                   (safe-add 1l 2l &l)
-                  "safe-add is false without overflow"
-                  =
-                  str)
+                  "safe-add is false without overflow")
     (assert-equal test
                   3l
                   (return-res-long safe-add 1l 2l)
-                  "safe-add really adds"
-                  =
-                  str)
+                  "safe-add really adds")
     (assert-equal test
                   true
                   (safe-add 9000000000000000000l 2000000000000000000l &l)
-                  "safe-add is true with overflow"
-                  =
-                  str)
+                  "safe-add is true with overflow")
     (assert-equal test
                   false
                   (safe-sub 1l 2l &l)
-                  "safe-sub is false without overflow"
-                  =
-                  str)
+                  "safe-sub is false without overflow")
     (assert-equal test
                   -1l
                   (return-res-long safe-sub 1l 2l)
-                  "safe-sub really subs"
-                  =
-                  str)
+                  "safe-sub really subs")
     (assert-equal test
                   true
                   (safe-sub 9000000000000000000l -2000000000000000000l &l)
-                  "safe-sub is true with overflow"
-                  =
-                  str)
+                  "safe-sub is true with overflow")
     (assert-equal test
                   false
                   (safe-mul 1l 2l &l)
-                  "safe-mul is false without overflow"
-                  =
-                  str)
+                  "safe-mul is false without overflow")
     (assert-equal test
                   4l
                   (return-res-long safe-mul 2l 2l)
-                  "safe-mul really muls"
-                  =
-                  str)
+                  "safe-mul really muls")
     (assert-equal test
                   true
                   (safe-mul 9000000000000000000l 2000000000000000000l &l)
-                  "safe-mul is true with overflow"
-                  =
-                  str)
+                  "safe-mul is true with overflow")
     (print-test-results test)))

--- a/test/statistics.carp
+++ b/test/statistics.carp
@@ -21,121 +21,85 @@
     (assert-equal test
                   2.0
                   (median &[1.0 2.0 3.0])
-                  "median works as expected"
-                  Double.=
-                  Double.str)
+                  "median works as expected")
     (assert-equal test
                   2.5
                   (mean &[1.0 2.0 4.5])
-                  "mean works as expected"
-                  Double.=
-                  Double.str)
+                  "mean works as expected")
     (assert-equal test
                   2.0
                   (low-median &[1.0 2.0 4.0 5.0])
-                  "low-median works as expected"
-                  Double.=
-                  Double.str)
+                  "low-median works as expected")
     (assert-equal test
                   4.0
                   (high-median &[1.0 2.0 4.0 5.0])
-                  "high-median works as expected"
-                  Double.=
-                  Double.str)
+                  "high-median works as expected")
     (assert-equal test
                   3.0
                   (grouped-median &[1.0 2.0 4.0 5.0] 2)
-                  "grouped-median works as expected I"
-                  Double.=
-                  Double.str)
+                  "grouped-median works as expected I")
     (assert-equal test
                   2.5
                   (grouped-median &[1.0 2.0 4.0 5.0] 3)
-                  "grouped-median works as expected II"
-                  Double.=
-                  Double.str)
+                  "grouped-median works as expected II")
     (assert-equal test
                   1.0
                   (variance &[1.0 2.0 4.0 5.0])
-                  "variance works as expected"
-                  Double.=
-                  Double.str)
+                  "variance works as expected")
     (assert-equal test
                   0.75
                   (pvariance &[1.0 2.0 4.0 5.0])
-                  "pvariance works as expected"
-                  Double.=
-                  Double.str)
+                  "pvariance works as expected")
     (assert-equal test
                   2.0
                   (stdev &[1.0 1.0 9.0 9.0])
-                  "stdev works as expected"
-                  Double.=
-                  Double.str)
+                  "stdev works as expected")
     (assert-equal test
                   2.0
                   (pstdev &[1.0 9.0])
-                  "pstdev works as expected"
-                  Double.=
-                  Double.str)
-    (assert-equal test
-                  &[0.0 0.0 0.0 0.0 0.0]
-                  &(winsorize &[0.0 0.0 0.0 0.0 10.0] 90.0)
-                  "winsorizing works as expected"
-                  all-eq
-                  Array.str)
-    (assert-equal test
-                  &[2.5 5.0 7.5]
-                  &(quartiles &[0.0 2.5 5.0 7.5 10.0])
-                  "quartiles work as expected"
-                  all-eq
-                  Array.str)
+                  "pstdev works as expected")
+    (assert-op test
+               &[0.0 0.0 0.0 0.0 0.0]
+               &(winsorize &[0.0 0.0 0.0 0.0 10.0] 90.0)
+               "winsorizing works as expected"
+               all-eq)
+    (assert-op test
+               &[2.5 5.0 7.5]
+               &(quartiles &[0.0 2.5 5.0 7.5 10.0])
+               "quartiles work as expected"
+               all-eq)
     (assert-equal test
                   5.0
                   (iqr &[0.0 2.5 5.0 7.5 10.0])
-                  "iqr works as expected"
-                  Double.=
-                  Double.str)
+                  "iqr works as expected")
     (assert-equal test
                   10.0
                   (sum &[2.5 5.0 2.0 0.5])
-                  "sum works as expected"
-                  Double.=
-                  Double.str)
+                  "sum works as expected")
     (assert-equal test
                   0.5
                   (min &[2.5 5.0 2.0 0.5])
-                  "min works as expected"
-                  Double.=
-                  Double.str)
+                  "min works as expected")
     (assert-equal test
                   5.0
                   (max &[2.5 5.0 2.0 0.5])
-                  "max works as expected"
-                  Double.=
-                  Double.str)
+                  "max works as expected")
     (assert-equal test
                   40.0
                   (stdev-pct &[1.0 1.0 9.0 9.0])
-                  "stdev-pct works as expected"
-                  Double.=
-                  Double.str)
-    (assert-equal test
-                  3.7065
-                  (median-abs-dev &[5.0 10.0])
-                  "median-abs-dev works as expected"
-                  Double.approx
-                  Double.str)
-    (assert-equal test
-                  49.42
-                  (median-abs-dev-pct &[5.0 10.0])
-                  "median-abs-dev-pct works as expected"
-                  Double.approx
-                  Double.str)
+                  "stdev-pct works as expected")
+    (assert-op test
+               3.7065
+               (median-abs-dev &[5.0 10.0])
+               "median-abs-dev works as expected"
+               Double.approx)
+    (assert-op test
+               49.42
+               (median-abs-dev-pct &[5.0 10.0])
+               "median-abs-dev-pct works as expected"
+               Double.approx)
     (assert-equal test
                   2.0
                   (Summary.median &(summary &[1.0 2.0 3.0]))
-                  "summary works as expected"
-                  Double.=
-                  Double.str)
+                  "summary works as expected")
     (print-test-results test)))

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -5,96 +5,67 @@
 (use Test)
 (use Vector2)
 (use Geometry)
+(use Double)
 
 (defn main []
   (with-test test
     (assert-equal test
                   &(init 1.0 2.0) &(init 1.0 2.0)
-                  "= operator works"
-                  =
-                  Vector2.str)
+                  "= operator works")
     (assert-equal test
                   &(init 1.0 2.0) &(init 1.0 1.0)
-                  "/= operator works"
-                  Vector2./=
-                  Vector2.str)
+                  "/= operator works")
     (assert-equal test
                   &(init 3.0 3.0)
                   &(+ &(init 2.0 1.0) &(init 1.0 2.0))
-                  "+ operator works"
-                  =
-                  Vector2.str)
+                  "+ operator works")
     (assert-equal test
                   &(init 1.0 -1.0)
                   &(- &(init 2.0 1.0) &(init 1.0 2.0))
-                  "- operator works"
-                  =
-                  Vector2.str)
+                  "- operator works")
     (assert-equal test
                   &(init 4.0 2.0)
                   &(* &(init 2.0 1.0) 2.0)
-                  "* operator works"
-                  =
-                  Vector2.str)
+                  "* operator works")
     (assert-equal test
                   &(init 1.0 0.5)
                   &(/ &(init 2.0 1.0) 2.0)
-                  "/ operator works"
-                  =
-                  Vector2.str)
+                  "/ operator works")
     (assert-equal test
                   5.0
                   (mag &(init 3.0 4.0))
-                  "mag works"
-                  Double.=
-                  Double.str)
+                  "mag works")
     (assert-equal test
                   101.0
                   (mag-sq &(init 10.0 1.0))
-                  "mag-sq works"
-                  Double.=
-                  Double.str)
+                  "mag-sq works")
     (assert-equal test
                   &(init 0.6 0.8)
                   &(normalize &(init 3.0 4.0))
-                  "normalize works"
-                  Vector2.=
-                  Vector2.str)
+                  "normalize works")
     (assert-equal test
                   5.0
                   (dist &(init 10.0 10.0) &(init 7.0 6.0))
-                  "dist works"
-                  Double.=
-                  Double.str)
+                  "dist works")
     (assert-equal test
                   0.0
                   (heading &(init 1.0 0.0))
-                  "heading works"
-                  Double.=
-                  Double.str)
+                  "heading works")
     (assert-equal test
                   &(init -2.0 1.0)
                   &(rotate &(init 1.0 2.0) (degree-to-radians 90.0))
-                  "rotate works"
-                  Vector2.approx
-                  Vector2.str)
+                  "rotate works")
     (assert-equal test
                   90.0
                   (radians-to-degree (Vector2.angle-between &(init 1.0 0.0) &(init 0.0 1.0)))
-                  "angle-between works"
-                  Double.approx
-                  Double.str)
+                  "angle-between works")
     (assert-equal test
                   44.0
                   (dot &(init 10.0 2.0) &(init 2.0 12.0))
-                  "dot works"
-                  Double.=
-                  Double.str)
+                  "dot works")
     (assert-equal test
                   &(init 2.5 5.0)
                   &(lerp &(init 0.0 0.0) &(init 5.0 10.0) 0.5)
-                  "lerp works"
-                  =
-                  Vector2.str)
+                  "lerp works")
     (print-test-results test)
 ))

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -12,9 +12,10 @@
     (assert-equal test
                   &(init 1.0 2.0) &(init 1.0 2.0)
                   "= operator works")
-    (assert-equal test
-                  &(init 1.0 2.0) &(init 1.0 1.0)
-                  "/= operator works")
+    (assert-op test
+               &(init 1.0 2.0) &(init 1.0 1.0)
+               "/= operator works"
+               Vector2./=)
     (assert-equal test
                   &(init 3.0 3.0)
                   &(+ &(init 2.0 1.0) &(init 1.0 2.0))
@@ -51,10 +52,11 @@
                   0.0
                   (heading &(init 1.0 0.0))
                   "heading works")
-    (assert-equal test
-                  &(init -2.0 1.0)
-                  &(rotate &(init 1.0 2.0) (degree-to-radians 90.0))
-                  "rotate works")
+    (assert-op test
+               &(init -2.0 1.0)
+               &(rotate &(init 1.0 2.0) (degree-to-radians 90.0))
+               "rotate works"
+               approx)
     (assert-equal test
                   90.0
                   (radians-to-degree (Vector2.angle-between &(init 1.0 0.0) &(init 0.0 1.0)))

--- a/test/vector3.carp
+++ b/test/vector3.carp
@@ -5,79 +5,58 @@
 (use Test)
 (use Vector3)
 (use Geometry)
+(use Double)
 
 (defn main []
   (with-test test
     (assert-equal test
                   &(init 1.0 2.0 3.0) &(init 1.0 2.0 3.0)
-                  "= operator works"
-                  =
-                  Vector3.str)
-    (assert-equal test
-                  &(init 1.0 2.0 3.0) &(init 1.0 1.0 3.0)
-                  "/= operator works"
-                  Vector3./=
-                  Vector3.str)
+                  "= operator works")
+    (assert-op test
+               &(init 1.0 2.0 3.0) &(init 1.0 1.0 3.0)
+               "/= operator works"
+               Vector3./=)
     (assert-equal test
                   &(init 3.0 3.0 4.5)
                   &(+ &(init 2.0 1.0 2.0) &(init 1.0 2.0 2.5))
-                  "+ operator works"
-                  =
-                  Vector3.str)
+                  "+ operator works")
     (assert-equal test
                   &(init 1.0 -1.0 -1.5)
                   &(- &(init 2.0 1.0 2.0) &(init 1.0 2.0 3.5))
-                  "- operator works"
-                  =
-                  Vector3.str)
+                  "- operator works")
     (assert-equal test
                   &(init 4.0 2.0 2.2)
                   &(* &(init 2.0 1.0 1.1) 2.0)
-                  "* operator works"
-                  =
-                  Vector3.str)
+                  "* operator works")
     (assert-equal test
                   &(init 1.0 0.5 0.25)
                   &(/ &(init 2.0 1.0 0.5) 2.0)
-                  "/ operator works"
-                  =
-                  Vector3.str)
+                  "/ operator works")
     (assert-equal test
                   5.0
                   (mag &(init 3.0 4.0 0.0))
-                  "mag works"
-                  Double.=
-                  Double.str)
+                  "mag works")
     (assert-equal test
                   101.0
                   (mag-sq &(init 10.0 1.0 0.0))
-                  "mag-sq works"
-                  Double.=
-                  Double.str)
+                  "mag-sq works")
     (assert-equal test
                   &(init 0.6 0.8 0.0)
                   &(normalize &(init 3.0 4.0 0.0))
-                  "normalize works"
-                  =
-                  Vector3.str)
-    (assert-equal test
-                  90.0
-                  (radians-to-degree (angle-between &(init 1.0 0.0 0.0)
-                                                    &(init 0.0 1.0 0.0)))
-                  "angle-between works"
-                  Double.approx
-                  Double.str)
+                  "normalize works")
+    (assert-op test
+               90.0
+               (radians-to-degree (angle-between &(init 1.0 0.0 0.0)
+                                                 &(init 0.0 1.0 0.0)))
+               "angle-between works"
+               Double.approx)
     (assert-equal test
                   53.0
                   (dot &(init 10.0 2.0 3.0) &(init 2.0 12.0 3.0))
-                  "dot works"
-                  Double.=
-                  Double.str)
+                  "dot works")
     (assert-equal test
                   &(init 2.5 5.0 0.75)
                   &(lerp &(init 0.0 0.0 0.5) &(init 5.0 10.0 2.0) 0.5)
-                  "lerp works"
-                  =
-                  Vector3.str)
+                  "lerp works")
     (print-test-results test)
 ))

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -5,79 +5,58 @@
 (use Test)
 (use VectorN)
 (use Geometry)
+(use Double)
 
 (defn main []
   (with-test test
     (assert-equal test
                   &(init 4 [1.0 2.0 3.0 4.0]) &(init 4 [1.0 2.0 3.0 4.0])
-                  "= operator works"
-                  =
-                  VectorN.str)
-    (assert-equal test
-                  &(init 4 [1.0 2.0 3.0 4.0]) &(init 4 [1.0 1.0 3.0 4.0])
-                  "/= operator works"
-                  VectorN./=
-                  VectorN.str)
+                  "= operator works")
+    (assert-op test
+               &(init 4 [1.0 2.0 3.0 4.0]) &(init 4 [1.0 1.0 3.0 4.0])
+               "/= operator works"
+               VectorN./=)
     (assert-equal test
                   &(init 3 [3.0 3.0 4.5])
                   &(+ &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 2.5]))
-                  "+ operator works"
-                  =
-                  VectorN.str)
+                  "+ operator works")
     (assert-equal test
                   &(init 3 [1.0 -1.0 -1.5])
                   &(- &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 3.5]))
-                  "- operator works"
-                  =
-                  VectorN.str)
+                  "- operator works")
     (assert-equal test
                   &(init 3 [4.0 2.0 2.2])
                   &(* &(init 3 [2.0 1.0 1.1]) 2.0)
-                  "* operator works"
-                  =
-                  VectorN.str)
+                  "* operator works")
     (assert-equal test
                   &(init 3 [1.0 0.5 0.25])
                   &(/ &(init 3 [2.0 1.0 0.5]) 2.0)
-                  "/ operator works"
-                  =
-                  VectorN.str)
+                  "/ operator works")
     (assert-equal test
                   5.0
                   (mag &(init 3 [3.0 4.0 0.0]))
-                  "mag works"
-                  Double.=
-                  Double.str)
+                  "mag works")
     (assert-equal test
                   101.0
                   (mag-sq &(init 3 [10.0 1.0 0.0]))
-                  "mag-sq works"
-                  Double.=
-                  Double.str)
+                  "mag-sq works")
     (assert-equal test
                   &(init 3 [0.6 0.8 0.0])
                   &(normalize &(init 3 [3.0 4.0 0.0]))
-                  "normalize works"
-                  =
-                  VectorN.str)
-    (assert-equal test
-                  90.0
-                  (radians-to-degree (angle-between &(init 3 [1.0 0.0 0.0])
-                                                    &(init 3 [0.0 1.0 0.0])))
-                  "angle-between works"
-                  Double.approx
-                  Double.str)
+                  "normalize works")
+    (assert-op test
+               90.0
+               (radians-to-degree (angle-between &(init 3 [1.0 0.0 0.0])
+                                                 &(init 3 [0.0 1.0 0.0])))
+               "angle-between works"
+               Double.approx)
     (assert-equal test
                   53.0
                   (dot &(init 3 [10.0 2.0 3.0]) &(init 3 [2.0 12.0 3.0]))
-                  "dot works"
-                  Double.=
-                  Double.str)
+                  "dot works")
     (assert-equal test
                   &(init 1 [2.0])
                   &(lerp &(init 1 [0.0]) &(init 1 [5.0]) 0.4)
-                  "lerp works"
-                  =
-                  VectorN.str)
+                  "lerp works")
     (print-test-results test)
 ))


### PR DESCRIPTION
This PR simplifies the Test module. Specifying which `=` and `str` functions to use is not necessary anymore. If you do want to use your own comparison operation, this PR also introduces a new function called `assert-op`, which is similar to `assert-equal` but takes another argument that is a function, like so:

```
(assert-op my-test-state
                   1.0
                   1.0000000000001
                  "1.0 and 1.0000000000001 are approximately equal"
                  Double.approx)
```

Cheers