### PR TITLE
Added int conversion to long module

### DIFF
--- a/core/Long.carp
+++ b/core/Long.carp
@@ -15,6 +15,8 @@
   (register mask (λ [Long Long] Bool))
   (register inc (λ [Long] Long))
   (register dec (λ [Long] Long))
+  (register to-int (λ [Long] Int))
+  (register from-int (λ [Int] Long))
   (register copy (λ [&Long] Long)) ;; TODO: Should not be needed when refs to value types are auto-converted to non-refs.
 
   (defn /= [x y]

--- a/core/core.h
+++ b/core/core.h
@@ -192,6 +192,15 @@ bool Long_mask(long a, long b) {
     return a & b;
 }
 
+int Long_to_MINUS_int(long a) {
+  return (int) a;
+}
+
+long Long_from_MINUS_int(int a) {
+  return (long) a;
+}
+
+
 void String_delete(string s) {
     CARP_FREE(s);
 }


### PR DESCRIPTION
This PR adds `to-int` and `from-int` to the `Long` module. These operations are not safe, i.e. you might lose precision—it is just casting after all.

Cheers