### PR TITLE
Miscellaneous fixes

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -7,6 +7,11 @@
           (set! &total (f &total (nth xs i))))
         total)))
 
+  (defn first [a]
+    @(Array.nth a 0))
+
+  (defn last [a]
+    @(Array.nth a (Int.dec (Array.count a))))
 )
 
 ;; BUGS! These function definitions will not create the required typedef for Array, for instance:

--- a/core/Char.carp
+++ b/core/Char.carp
@@ -1,4 +1,5 @@
 (defmodule Char
+  (register = (Fn [Char Char] Bool))
   (register str (Fn [Char] String))
   (register to-int (Fn [Char] Int))
   (register from-int (Fn [Int] Char))

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -26,5 +26,7 @@
 
   (defn max [a b] (if (> a b) a b))
   (defn min [a b] (if (< a b) a b))
-  )
 
+  (defn even? [a] (= (mod a 2) 0))
+  (defn odd? [a] (not (even? a)))
+)

--- a/core/Long.carp
+++ b/core/Long.carp
@@ -28,4 +28,7 @@
 
   (defn max [a b] (if (> a b) a b))
   (defn min [a b] (if (< a b) a b))
+
+  (defn even? [a] (= (mod a 2l) 0l))
+  (defn odd? [a] (not (even? a)))
 )

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -68,3 +68,6 @@
 
 (defmacro ==> [:rest forms]
   (thread-last-internal forms))
+
+(defmacro swap! [x y]
+  (list 'let (array 'tmp y) (list 'do (list 'set! &y x) (list 'set! &x 'tmp))))

--- a/core/core.h
+++ b/core/core.h
@@ -252,6 +252,10 @@ string String_from_MINUS_chars(Array a) {
     return s;
 }
 
+bool Char__EQ_(char a, char b) {
+  return a == b;
+}
+
 string Char_str(char c) {
     char *buffer = CARP_MALLOC(3);
     snprintf(buffer, 3, "\\%c", c);

--- a/test/array.carp
+++ b/test/array.carp
@@ -1,0 +1,16 @@
+(load "Test.carp")
+
+(use Array)
+(use Test)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  1
+                  (first &[1 2 3])
+                  "first works as expected")
+    (assert-equal test
+                  \c
+                  (last &[\a \b \c])
+                  "last works as expected")
+    (print-test-results test)))

--- a/test/int_math.carp
+++ b/test/int_math.carp
@@ -17,4 +17,12 @@
                   1
                   (abs -1)
                   "abs works as expected")
+    (assert-equal test
+                  false
+                  (even? 3)
+                  "even? works as expected")
+    (assert-equal test
+                  true
+                  (odd? 3)
+                  "odd? works as expected")
     (print-test-results test)))

--- a/test/long_math.carp
+++ b/test/long_math.carp
@@ -17,4 +17,12 @@
                   1l
                   (abs -1l)
                   "abs works as expected")
+    (assert-equal test
+                  false
+                  (even? 3l)
+                  "even? works as expected")
+    (assert-equal test
+                  true
+                  (odd? 3l)
+                  "odd? works as expected")
     (print-test-results test)))


### PR DESCRIPTION
This PR introduces... Well, I’m running out of catchy descriptions. Basically I was doing some Project Euler problems with Carp and noticed a few missing functions.

This PR introduces:
* `Array.first`: get the head of an `Array`
* `Array.last`: get the last element of an `Array`
* `Char.=`: I can’t believe this wasn’t there already
* `Int.even?`/`Int.odd?`: tests whether number is even or odd (also introduced to `Long`)
* `swap!`: a macro that swaps two values in place, compiles to this:
```
; if called as (swap! a b)
(let [tmp b]
  (do
    (set! &b a)
    (set! &a b)
  )
)
```

That’s all! A few tests are also included.

Cheers

PS: This will most likely conflict with #116. I’ll resolve that conflict after you’ve figured out what you want to merge first.