### PR TITLE
Miscellaneous fixes

### DIFF
--- a/core/Bool.carp
+++ b/core/Bool.carp
@@ -2,4 +2,5 @@
   (register = (Fn [Bool Bool] Bool))
   (register /= (Fn [Bool Bool] Bool))
   (register str (Fn [Bool] String))
+  (register copy (Fn [&Bool] Bool))
   )

--- a/core/SDLHelper.h
+++ b/core/SDLHelper.h
@@ -1,3 +1,4 @@
+#include <core.h>
 #include <SDL.h>
 
 typedef struct {
@@ -45,6 +46,16 @@ SDL_Keycode event_MINUS_keycode(SDL_Event *e) {
 
 int Keycode__EQ_(SDL_Keycode a, SDL_Keycode b) {
     return a == b;
+}
+
+SDL_Keycode Keycode_copy(SDL_Keycode* a) {
+    return *a;
+}
+
+string Keycode_str(SDL_Keycode a) {
+    char *buffer = CARP_MALLOC(32);
+    snprintf(buffer, 32, "%d", a);
+    return buffer;
 }
 
 SDL_Rect make_MINUS_rect(int x, int y, int w, int h) {

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -4,9 +4,6 @@
   (defn init [x y]
     (V2.init x y))
 
-  (defn copy [v]
-    (V2.copy v))
-
   (defn get-x [o]
     (V2.x o))
 
@@ -93,9 +90,6 @@
 
   (defn init [x y z]
     (V3.init x y z))
-
-  (defn copy [v]
-    (V3.copy v))
 
   (defn to-string [o]
     (string-join @"Vector2(" (Double.str (V3.x o)) @", " (Double.str (V3.y o))

--- a/core/core.h
+++ b/core/core.h
@@ -491,6 +491,10 @@ string Float_str(float x) {
 }
 
 // Bool
+bool Bool_copy(bool* b) {
+  return *b;
+}
+
 bool Bool__EQ_(bool a, bool b) {
   return a == b;
 }

--- a/core/sdl.carp
+++ b/core/sdl.carp
@@ -80,6 +80,8 @@
 
 (defmodule Keycode
   (register = (Fn [SDL_Keycode SDL_Keycode] Bool))
+  (register copy (Fn [(Ref SDL_Keycode)] SDL_Keycode))
+  (register str (Fn [SDL_Keycode] String))
 
   (defn /= [x y]
     (not (= x y)))


### PR DESCRIPTION
This PR fixes a few problems that I’ve encountered while getting Snake to work, specifically:

- add a `copy` function for `Bool` types
- add a `copy` and `str` function for `SDL_Keycode` types
- fix the compiler so that it looks for a `str` function that matches even if the type is external
- remove `copy` functions from the vector modules, because they conflict with the types

Cheers