### PR TITLE
Add when and unless macros

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -99,3 +99,6 @@
 
 (defmacro when [condition form]
   (list 'if condition form (list)))
+
+(defmacro unless [condition form]
+  (list 'if condition (list) form))

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -96,3 +96,6 @@
 
 (defmacro use-all [:rest names]
   (cons 'do (use-all-fn names)))
+
+(defmacro when [condition form]
+  (list 'if condition form (list)))

--- a/test/control_flow.carp
+++ b/test/control_flow.carp
@@ -12,6 +12,20 @@
           (set! &x (inc x))))
       x)))
 
+(defn when-test-true []
+  (let [x 0]
+    (do
+      (when true
+        (set! &x 5))
+      x)))
+
+(defn when-test-false []
+  (let [x 0]
+    (do
+      (when false
+        (set! &x 5))
+      x)))
+
 (defn all-eq [a b]
   (if (/= (Array.count a) (Array.count b))
     false
@@ -29,5 +43,15 @@
                   5
                   (break-test)
                   "break works as expected"
+    )
+    (assert-equal test
+                  5
+                  (when-test-true)
+                  "when works as expected when true"
+    )
+    (assert-equal test
+                  0
+                  (when-test-false)
+                  "when works as expected when false"
     )
     (print-test-results test)))

--- a/test/control_flow.carp
+++ b/test/control_flow.carp
@@ -26,6 +26,20 @@
         (set! &x 5))
       x)))
 
+(defn unless-test-true []
+  (let [x 0]
+    (do
+      (unless true
+        (set! &x 5))
+      x)))
+
+(defn unless-test-false []
+  (let [x 0]
+    (do
+      (unless false
+        (set! &x 5))
+      x)))
+
 (defn all-eq [a b]
   (if (/= (Array.count a) (Array.count b))
     false
@@ -53,5 +67,15 @@
                   0
                   (when-test-false)
                   "when works as expected when false"
+    )
+    (assert-equal test
+                  0
+                  (unless-test-true)
+                  "unless works as expected when true"
+    )
+    (assert-equal test
+                  5
+                  (unless-test-false)
+                  "unless works as expected when false"
     )
     (print-test-results test)))


### PR DESCRIPTION
This PR adds the macros `when` and `unless`. Those are single-branch alternatives to `if` that are of type `()` and thus only make sense when they’re side-effectual.

```clojure
(let [x 0]
  (when true
      (set! &x 1))) ; x will be 1

(let [x 0]
   (unless false
      (set! &x 1))) ; same
```

Test cases are included.

Cheers