### PR TITLE
Arithmetic interfaces

### DIFF
--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -3,13 +3,15 @@
 
 (definterface zero (λ [] a))
 (definterface add-ref (λ [&a &a] a))
-;; sub-ref, mul-ref, div-ref
+(definterface sub-ref (λ [&a &a] a))
+(definterface mul-ref (λ [&a &a] a))
+(definterface div-ref (λ [&a &a] a))
 
 ;; These interfaces would be desirable also? Produces errors in Vector module for now...
-;; (definterface + (λ [a a] a))
-;; (definterface - (λ [a a] a))
-;; (definterface * (λ [a a] a))
-;; (definterface / (λ [a a] a))
+(definterface + (λ [a a] a))
+(definterface - (λ [a a] a))
+(definterface * (λ [a a] a))
+(definterface / (λ [a a] a))
 
 ;; <
 ;; <=

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -19,19 +19,19 @@
   (defn to-string [o]
     (string-join @"Vector2(" (Double.str (V2.x o)) @", " (Double.str (V2.y o)) @")"))
 
-  (defn + [a b]
+  (defn add [a b]
     (V2.init (Double.+ (V2.x a) (V2.x b))
             (Double.+ (V2.y a) (V2.y b))))
 
-  (defn - [a b]
+  (defn sub [a b]
     (V2.init (Double.- (V2.x a) (V2.x b))
             (Double.- (V2.y a) (V2.y b))))
 
-  (defn * [a n]
+  (defn mul [a n]
     (V2.init (Double.* (V2.x a) n)
             (Double.* (V2.y a) n)))
 
-  (defn / [a n]
+  (defn div [a n]
     (V2.init (Double./ (V2.x a) n)
             (Double./ (V2.y a) n)))
 
@@ -58,10 +58,10 @@
     (let [m (mag o)]
       (if (Double.= m 0.0)
         (V2.copy o)
-        (/ o m))))
+        (div o m))))
 
   (defn dist [a b]
-    (let [s (- b a)]
+    (let [s (sub b a)]
       (mag &s)))
 
   (defn heading [a]
@@ -102,22 +102,22 @@
 
   (defn /= [a b]
     (not (= a b)))
-  (defn + [a b]
+  (defn add [a b]
     (V3.init (Double.+ (V3.x a) (V3.x b))
             (Double.+ (V3.y a) (V3.y b))
             (Double.+ (V3.z a) (V3.z b))))
 
-  (defn - [a b]
+  (defn sub [a b]
     (V3.init (Double.- (V3.x a) (V3.x b))
             (Double.- (V3.y a) (V3.y b))
             (Double.- (V3.z a) (V3.z b))))
 
-  (defn * [a n]
+  (defn mul [a n]
     (V3.init (Double.* (V3.x a) n)
             (Double.* (V3.y a) n)
             (Double.* (V3.z a) n)))
 
-  (defn / [a n]
+  (defn div [a n]
     (V3.init (Double./ (V3.x a) n)
             (Double./ (V3.y a) n)
             (Double./ (V3.z a) n)))
@@ -135,7 +135,7 @@
     (let [m (mag o)]
       (if (Double.= m 0.0)
         (V3.copy o)
-        (/ o m))))
+        (div o m))))
 
   (defn cross [x y]
     (V3.init
@@ -199,16 +199,16 @@
   (defn /= [a b]
     (not (= a b)))
 
-  (defn + [a b]
+  (defn add [a b]
     (zip Double.+ a b))
 
-  (defn - [a b]
+  (defn sub [a b]
     (zip Double.- a b))
 
-  (defn * [a n]
+  (defn mul [a n]
     (zip- Double.* (VN.v a) &(Array.replicate (VN.n a) &n)))
 
-  (defn / [a n]
+  (defn div [a n]
     (zip- Double./ (VN.v a) &(Array.replicate (VN.n a) &n)))
 
   (defn square- [n]
@@ -224,14 +224,14 @@
     (Double.sqrt (mag-sq o)))
 
   (defn dist [a b]
-    (let [s (- b a)]
+    (let [s (sub b a)]
       (mag &s)))
 
   (defn normalize [o]
     (let [m (mag o)]
       (if (Double.= m 0.0)
         (VN.copy o)
-        (/ o m))))
+        (div o m))))
 
   (defn dot [x y]
     (Array.reduce add- 0.0 (VN.v &(zip Double.* x y))))

--- a/examples/vector.carp
+++ b/examples/vector.carp
@@ -7,9 +7,9 @@
   (let [x (Vector2.init 1.0 2.0)
         y (Vector2.init 3.0 4.0)]
     (do
-      (println &(Vector2.str &(+ &x &y)))
-      (println &(Vector2.str &x))
-      (println &(Vector2.str &y))
+      (println &(str &(Vector2.add &x &y)))
+      (println &(str &x))
+      (println &(str &y))
       (println &(Double.str (Vector2.mag &y)))
-      (println &(Vector2.str &(Vector2.rotate &x (Geometry.degree-to-radians 90.0))))
+      (println &(str &(Vector2.rotate &x (Geometry.degree-to-radians 90.0))))
       (println &(Double.str (Geometry.radians-to-degree (Vector2.angle-between &x &y)))))))

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -15,20 +15,20 @@
                Vector2./=)
     (assert-equal test
                   &(init 3.0 3.0)
-                  &(+ &(init 2.0 1.0) &(init 1.0 2.0))
-                  "+ operator works")
+                  &(add &(init 2.0 1.0) &(init 1.0 2.0))
+                  "add operator works")
     (assert-equal test
                   &(init 1.0 -1.0)
-                  &(- &(init 2.0 1.0) &(init 1.0 2.0))
-                  "- operator works")
+                  &(sub &(init 2.0 1.0) &(init 1.0 2.0))
+                  "sub operator works")
     (assert-equal test
                   &(init 4.0 2.0)
-                  &(* &(init 2.0 1.0) 2.0)
-                  "* operator works")
+                  &(mul &(init 2.0 1.0) 2.0)
+                  "mul operator works")
     (assert-equal test
                   &(init 1.0 0.5)
-                  &(/ &(init 2.0 1.0) 2.0)
-                  "/ operator works")
+                  &(div &(init 2.0 1.0) 2.0)
+                  "div operator works")
     (assert-equal test
                   5.0
                   (mag &(init 3.0 4.0))

--- a/test/vector3.carp
+++ b/test/vector3.carp
@@ -15,20 +15,20 @@
                Vector3./=)
     (assert-equal test
                   &(init 3.0 3.0 4.5)
-                  &(+ &(init 2.0 1.0 2.0) &(init 1.0 2.0 2.5))
-                  "+ operator works")
+                  &(add &(init 2.0 1.0 2.0) &(init 1.0 2.0 2.5))
+                  "add operator works")
     (assert-equal test
                   &(init 1.0 -1.0 -1.5)
-                  &(- &(init 2.0 1.0 2.0) &(init 1.0 2.0 3.5))
-                  "- operator works")
+                  &(sub &(init 2.0 1.0 2.0) &(init 1.0 2.0 3.5))
+                  "sub operator works")
     (assert-equal test
                   &(init 4.0 2.0 2.2)
-                  &(* &(init 2.0 1.0 1.1) 2.0)
-                  "* operator works")
+                  &(mul &(init 2.0 1.0 1.1) 2.0)
+                  "mul operator works")
     (assert-equal test
                   &(init 1.0 0.5 0.25)
-                  &(/ &(init 2.0 1.0 0.5) 2.0)
-                  "/ operator works")
+                  &(div &(init 2.0 1.0 0.5) 2.0)
+                  "div operator works")
     (assert-equal test
                   5.0
                   (mag &(init 3.0 4.0 0.0))

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -15,20 +15,20 @@
                VectorN./=)
     (assert-equal test
                   &(init 3 [3.0 3.0 4.5])
-                  &(+ &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 2.5]))
-                  "+ operator works")
+                  &(add &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 2.5]))
+                  "add operator works")
     (assert-equal test
                   &(init 3 [1.0 -1.0 -1.5])
-                  &(- &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 3.5]))
-                  "- operator works")
+                  &(sub &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 3.5]))
+                  "sub operator works")
     (assert-equal test
                   &(init 3 [4.0 2.0 2.2])
-                  &(* &(init 3 [2.0 1.0 1.1]) 2.0)
-                  "* operator works")
+                  &(mul &(init 3 [2.0 1.0 1.1]) 2.0)
+                  "mul operator works")
     (assert-equal test
                   &(init 3 [1.0 0.5 0.25])
-                  &(/ &(init 3 [2.0 1.0 0.5]) 2.0)
-                  "/ operator works")
+                  &(div &(init 3 [2.0 1.0 0.5]) 2.0)
+                  "div operator works")
     (assert-equal test
                   5.0
                   (mag &(init 3 [3.0 4.0 0.0]))


### PR DESCRIPTION
This PR adds arithmetic functions and reference arithmetic functions. This required that we rename the arithmetic functions in the Vector modules, because `*` and `/` don’t adhere to the interface.

I also took the liberty of fixing the tests and examples.

Cheers