### PR TITLE
Add useful macros to the standard library

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -103,7 +103,7 @@
 (defmacro unless [condition form]
   (list 'if condition (list) form))
 
-(defmacro do-let [bindings :rest forms]
+(defmacro let-do [bindings :rest forms]
   (list 'let bindings
     (cons 'do forms)))
 

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -2,7 +2,7 @@
   (if (= (count xs) 0)
     (list)
     (if (= (count xs) 2)
-      (macro-error "case has even number of branches; add an else branch")
+      (macro-error "cond has even number of branches; add an else branch")
       (if (= (count xs) 1)
         (car xs)
         (list

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -2,7 +2,7 @@
   (if (= (count xs) 0)
     (list)
     (if (= (count xs) 2)
-      (list)
+      (list 'if (car xs) (car (cdr xs)) ())
       (if (= (count xs) 1)
         (car xs)
         (list
@@ -102,3 +102,33 @@
 
 (defmacro unless [condition form]
   (list 'if condition (list) form))
+
+(defmacro do-let [bindings :rest forms]
+  (list 'let bindings
+    (cons 'do forms)))
+
+(defmacro defn+ [name arguments :rest body]
+  (list 'defn name arguments (cons 'do body)))
+
+(defmacro comment [:rest forms]
+  ())
+
+(defmacro forever [:rest forms]
+  (list 'while true (cons 'do forms)))
+
+(defdynamic case-internal [name xs]
+  (if (= (count xs) 0)
+    (list)
+    (if (= (count xs) 2)
+      (list 'if (list '= name (car xs)) (car (cdr xs)) (list))
+      (if (= (count xs) 1)
+        (car xs)
+        (list 'if
+         (list '= name (car xs))
+          (car (cdr xs))
+          (case-internal name (cdr (cdr xs))))))))
+
+(defmacro case [name :rest forms]
+  (case-internal name forms))
+
+>>>>>>> f73b12a... core: added useful macros to the standard library

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -2,7 +2,7 @@
   (if (= (count xs) 0)
     (list)
     (if (= (count xs) 2)
-      (list 'if (car xs) (car (cdr xs)) ())
+      (macro-error "case has even number of branches; add an else branch")
       (if (= (count xs) 1)
         (car xs)
         (list
@@ -107,20 +107,20 @@
   (list 'let bindings
     (cons 'do forms)))
 
-(defmacro defn+ [name arguments :rest body]
+(defmacro defn-do [name arguments :rest body]
   (list 'defn name arguments (cons 'do body)))
 
 (defmacro comment [:rest forms]
   ())
 
-(defmacro forever [:rest forms]
+(defmacro forever-do [:rest forms]
   (list 'while true (cons 'do forms)))
 
 (defdynamic case-internal [name xs]
   (if (= (count xs) 0)
     (list)
     (if (= (count xs) 2)
-      (list 'if (list '= name (car xs)) (car (cdr xs)) (list))
+      (macro-error "case has even number of branches; add an else branch")
       (if (= (count xs) 1)
         (car xs)
         (list 'if
@@ -130,5 +130,3 @@
 
 (defmacro case [name :rest forms]
   (case-internal name forms))
-
->>>>>>> f73b12a... core: added useful macros to the standard library

--- a/core/Statistics.carp
+++ b/core/Statistics.carp
@@ -181,7 +181,8 @@
           (let [samp @(Array.nth tmp i)]
             (cond
               (> samp hi) (Array.aset! tmp i hi)
-              (< samp lo) (Array.aset! tmp i lo))))
+              (< samp lo) (Array.aset! tmp i lo)
+              ())))
         (Array.copy tmp))))
 
   (defn summary [samples]

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -6,6 +6,11 @@
     (set! &x (+ x 1))
     (= x 2)))
 
+(defn test-comment []
+  (do-let [x 1]
+    (comment (set! &x (+ x 1)))
+    (= x 1)))
+
 (defn test-case-dflt []
   (case 1
     2 false
@@ -29,5 +34,9 @@
     (assert-true test
                  (test-case-select)
                  "case correctly selects branch"
+    )
+    (assert-true test
+                 (test-comment)
+                 "comment ignores input"
     )
     (print-test-results test)))

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -2,12 +2,12 @@
 (use Test)
 
 (defn test-do-let []
-  (do-let [x 1]
+  (let-do [x 1]
     (set! &x (+ x 1))
     (= x 2)))
 
 (defn test-comment []
-  (do-let [x 1]
+  (let-do [x 1]
     (comment (set! &x (+ x 1)))
     (= x 1)))
 

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -1,0 +1,33 @@
+(load "Test.carp")
+(use Test)
+
+(defn test-do-let []
+  (do-let [x 1]
+    (set! &x (+ x 1))
+    (= x 2)))
+
+(defn test-case-dflt []
+  (case 1
+    2 false
+    true))
+
+(defn test-case-select []
+  (case 1
+    1 true
+    false))
+
+(defn main []
+  (with-test test
+    (assert-true test
+                 (test-do-let)
+                 "do-let works as expected"
+    )
+    (assert-true test
+                 (test-case-dflt)
+                 "case correctly selects default"
+    )
+    (assert-true test
+                 (test-case-select)
+                 "case correctly selects branch"
+    )
+    (print-test-results test)))

--- a/test/statistics.carp
+++ b/test/statistics.carp
@@ -14,6 +14,17 @@
             ()))
         res))))
 
+(defn all-approx [a b]
+  (if (Int./= (Array.count a) (Array.count b))
+    false
+    (let [res true]
+      (do
+        (for [i 0 (Array.count a)]
+          (if (not (Double.approx @(Array.nth a i) @(Array.nth b i)))
+            (set! &res false)
+            ()))
+        res))))
+
 (defn main []
   (with-test test
     (assert-equal test
@@ -57,10 +68,10 @@
                   (pstdev &[1.0 9.0])
                   "pstdev works as expected")
     (assert-op test
-               &[0.0 0.0 0.0 0.0 0.0]
-               &(winsorize &[0.0 0.0 0.0 0.0 10.0] 90.0)
+               &[0.0 0.0 0.0 0.0 8.0]
+               &(winsorize &[0.0 0.0 0.0 0.0 10.0] 5.0)
                "winsorizing works as expected"
-               all-eq)
+               all-approx)
     (assert-op test
                &[2.5 5.0 7.5]
                &(quartiles &[0.0 2.5 5.0 7.5 10.0])


### PR DESCRIPTION
This PR introduces a few useful macros to the standard library. It also changes the behavior of `cond`.

## Summary of macros added

- `do-let`: combines `let` and `do`.
- `defn+`: combines `defn` and `do`.
- `comment`: comments a block of code by ignoring the forms passed into it.
- `forever`: runs a sequence of forms forever.
- `case`: simple equality matching, similar to `case` in Scheme.

## Changes to other parts of Carp

I took the liberty of changing the definition of `cond` to expand into a last `if` statement if the number of forms  is even. That way it might still fail when type-checking, but not silently remove the last conditional clause. This is a net positive, but maybe using `macro-error` instead would be even better.

Some test cases are attached, although many of these macros are hard to test.

Cheers