### PR TITLE
Fix error conditions on project-set!

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -680,22 +680,25 @@ commandProjectSet [XObj (Str key) _ _, value] =
   do ctx <- get
      let proj = contextProj ctx
          env = contextGlobalEnv ctx
-     Right evaledValue <- eval env value -- TODO: fix!!!
-     let (XObj (Str valueStr) _ _) = evaledValue
-     newCtx <- case key of
-                 "cflag" -> return ctx { contextProj = proj { projectCFlags = addIfNotPresent valueStr (projectCFlags proj) } }
-                 "libflag" -> return ctx { contextProj = proj { projectCFlags = addIfNotPresent valueStr (projectCFlags proj) } }
-                 "prompt" -> return ctx { contextProj = proj { projectPrompt = valueStr } }
-                 "search-path" -> return ctx { contextProj = proj { projectCarpSearchPaths = addIfNotPresent valueStr (projectCarpSearchPaths proj) } }
-                 "printAST" -> return ctx { contextProj = proj { projectPrintTypedAST = (valueStr == "true") } }
-                 "echoC" -> return ctx { contextProj = proj { projectEchoC = (valueStr == "true") } }
-                 "echoCompilationCommand" -> return ctx { contextProj = proj { projectEchoCompilationCommand = (valueStr == "true") } }
-                 "compiler" -> return ctx { contextProj = proj { projectCompiler = valueStr } }
-                 _ ->
-                   liftIO $ do putStrLnWithColor Red ("Unrecognized key: '" ++ key ++ "'")
-                               return ctx
-     put newCtx
-     return dynamicNil
+     evaled <- eval env value
+     case evaled of
+       Left e -> err (show e) dynamicNil
+       Right (XObj (Str valueStr) _ _) -> do
+          newCtx <- case key of
+                      "cflag" -> return ctx { contextProj = proj { projectCFlags = addIfNotPresent valueStr (projectCFlags proj) } }
+                      "libflag" -> return ctx { contextProj = proj { projectCFlags = addIfNotPresent valueStr (projectCFlags proj) } }
+                      "prompt" -> return ctx { contextProj = proj { projectPrompt = valueStr } }
+                      "search-path" -> return ctx { contextProj = proj { projectCarpSearchPaths = addIfNotPresent valueStr (projectCarpSearchPaths proj) } }
+                      "printAST" -> return ctx { contextProj = proj { projectPrintTypedAST = (valueStr == "true") } }
+                      "echoC" -> return ctx { contextProj = proj { projectEchoC = (valueStr == "true") } }
+                      "echoCompilationCommand" -> return ctx { contextProj = proj { projectEchoCompilationCommand = (valueStr == "true") } }
+                      "compiler" -> return ctx { contextProj = proj { projectCompiler = valueStr } }
+                      _ -> err ("Unrecognized key: '" ++ key ++ "'") ctx
+          put newCtx
+          return dynamicNil
+       Right val -> err "Argument to project-set! must be a string" dynamicNil
+    where err msg ret = liftIO $ do putStrLnWithColor Red msg
+                                    return ret
 commandProjectSet args =
   liftIO $ do putStrLnWithColor Red ("Invalid args to 'project-set!' command: " ++ joinWithComma (map pretty args))
               return dynamicNil


### PR DESCRIPTION
This PR fixes the section in `commandProjectSet` that was marked as `TODO`. It checks the return value of the call to `eval`, and prints appropriate error messages when something goes wrong.

Cheers