### PR TITLE
anima fixes

### DIFF
--- a/core/sdl.carp
+++ b/core/sdl.carp
@@ -34,6 +34,7 @@
 (register make-point (Fn [Int Int] SDL_Point))
 
 ;; Rendering
+(register-type SDL_Renderer)
 (register SDL_RenderPresent (Fn [(Ptr SDL_Renderer)] ()))
 (register SDL_RenderClear (Fn [(Ptr SDL_Renderer)] ()))
 (register SDL_RenderCopy (Fn [(Ptr SDL_Renderer) (Ptr SDL_Texture) (Ptr SDL_Rect) (Ptr SDL_Rect)] ())) ;; src-rect & dest-rect

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -77,6 +77,8 @@ eval env xobj =
                              then Right trueXObj else Right falseXObj
                            (XObj (Str a) _ _, XObj (Str b) _ _) ->
                              if a == b then Right trueXObj else Right falseXObj
+                           (XObj (Sym a) _ _, XObj (Sym b) _ _) ->
+                             if a == b then Right trueXObj else Right falseXObj
                            _ ->
                              Left (EvalError ("Can't compare " ++ pretty okA ++ " with " ++ pretty okB))
 


### PR DESCRIPTION
This PR introduces a few fixes to problems that I ran into while working on anima.

1. `SDL_Renderer` was used as a type, but never registered. This seems to be possible when registering functions, but it’s not great.
2. `=` in macros wasn’t able to compare symbols. This is useful when rewriting expressions conditionally, though.

I also found that there is a certain lack of operators. `>`, `<`, `and`, `or`, and `not` should IMO be implemented. I could do that. What do you think?

Cheers