### PR TITLE
Add logic and arithmetic macros

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -75,12 +75,98 @@ eval env xobj =
                            (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
                              if (round aNum :: Int) == (round bNum :: Int)
                              then Right trueXObj else Right falseXObj
+                           (XObj (Num LongTy aNum) _ _, XObj (Num LongTy bNum) _ _) ->
+                             if (round aNum :: Int) == (round bNum :: Int)
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num FloatTy aNum) _ _, XObj (Num floatTy bNum) _ _) ->
+                             if aNum == bNum
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num DoubleTy aNum) _ _, XObj (Num DoubleTy bNum) _ _) ->
+                             if aNum == bNum
+                             then Right trueXObj else Right falseXObj
                            (XObj (Str a) _ _, XObj (Str b) _ _) ->
                              if a == b then Right trueXObj else Right falseXObj
                            (XObj (Sym a) _ _, XObj (Sym b) _ _) ->
                              if a == b then Right trueXObj else Right falseXObj
                            _ ->
                              Left (EvalError ("Can't compare " ++ pretty okA ++ " with " ++ pretty okB))
+
+        [XObj (Sym (SymPath [] "<")) _ _, a, b] ->
+          do evaledA <- eval env a
+             evaledB <- eval env b
+             return $ do okA <- evaledA
+                         okB <- evaledB
+                         case (okA, okB) of
+                           (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
+                             if (round aNum :: Int) < (round bNum :: Int)
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num LongTy aNum) _ _, XObj (Num LongTy bNum) _ _) ->
+                             if (round aNum :: Int) < (round bNum :: Int)
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num FloatTy aNum) _ _, XObj (Num floatTy bNum) _ _) ->
+                             if aNum < bNum
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num DoubleTy aNum) _ _, XObj (Num DoubleTy bNum) _ _) ->
+                             if aNum < bNum
+                             then Right trueXObj else Right falseXObj
+                           _ ->
+                             Left (EvalError ("Can't compare (<) " ++ pretty okA ++ " with " ++ pretty okB))
+
+        [XObj (Sym (SymPath [] ">")) _ _, a, b] ->
+          do evaledA <- eval env a
+             evaledB <- eval env b
+             return $ do okA <- evaledA
+                         okB <- evaledB
+                         case (okA, okB) of
+                           (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
+                             if (round aNum :: Int) > (round bNum :: Int)
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num LongTy aNum) _ _, XObj (Num LongTy bNum) _ _) ->
+                             if (round aNum :: Int) > (round bNum :: Int)
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num FloatTy aNum) _ _, XObj (Num floatTy bNum) _ _) ->
+                             if aNum > bNum
+                             then Right trueXObj else Right falseXObj
+                           (XObj (Num DoubleTy aNum) _ _, XObj (Num DoubleTy bNum) _ _) ->
+                             if aNum > bNum
+                             then Right trueXObj else Right falseXObj
+                           _ ->
+                             Left (EvalError ("Can't compare (>) " ++ pretty okA ++ " with " ++ pretty okB))
+
+
+        [XObj (Sym (SymPath [] "and")) _ _, a, b] ->
+          do evaledA <- eval env a
+             evaledB <- eval env b
+             return $ do okA <- evaledA
+                         okB <- evaledB
+                         case (okA, okB) of
+                           (XObj (Bol ab) _ _, XObj (Bol bb) _ _) ->
+                             if ab && bb
+                             then Right trueXObj else Right falseXObj
+                           _ ->
+                             Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okA ++ " and " ++ pretty okB))
+
+        [XObj (Sym (SymPath [] "or")) _ _, a, b] ->
+          do evaledA <- eval env a
+             evaledB <- eval env b
+             return $ do okA <- evaledA
+                         okB <- evaledB
+                         case (okA, okB) of
+                           (XObj (Bol ab) _ _, XObj (Bol bb) _ _) ->
+                             if ab || bb
+                             then Right trueXObj else Right falseXObj
+                           _ ->
+                             Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okA ++ " and " ++ pretty okB))
+
+        [XObj (Sym (SymPath [] "not")) _ _, a] ->
+          do evaledA <- eval env a
+             return $ do okA <- evaledA
+                         case okA of
+                           XObj (Bol ab) _ _ ->
+                             if ab
+                             then Right falseXObj else Right trueXObj
+                           _ ->
+                             Left (EvalError ("Can't perform logical operation (not) on " ++ pretty okA))
 
         [XObj If _ _, condition, ifTrue, ifFalse] ->
           do evaledCondition <- eval env condition

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -21,6 +21,13 @@
     1 true
     false))
 
+(defmacro test-and [a b] (and a b))
+(defmacro test-or [a b] (or a b))
+(defmacro test-not [a] (not a))
+(defmacro test-< [a b] (< a b))
+(defmacro test-> [a b] (> a b))
+(defmacro test-= [a b] (= a b))
+
 (defn main []
   (with-test test
     (assert-true test
@@ -38,5 +45,142 @@
     (assert-true test
                  (test-comment)
                  "comment ignores input"
+    )
+    (assert-true test
+                 (test-not false)
+                 "not macro works as expected"
+    )
+    (assert-false test
+                  (test-and false true)
+                  "and macro works as expected I"
+    )
+    (assert-true test
+                 (test-and true true)
+                 "and macro works as expected II"
+    )
+    (assert-false test
+                 (test-or false false)
+                 "or macro works as expected I"
+    )
+    (assert-true test
+                 (test-or false true)
+                 "or macro works as expected II"
+    )
+    (assert-true test
+                 (test-or true true)
+                 "or macro works as expected III"
+    )
+    (assert-true test
+                 (test-< 1 2)
+                 "< macro works as expected on ints I"
+    )
+    (assert-false test
+                  (test-< 2 2)
+                  "< macro works as expected on ints II"
+    )
+    (assert-true test
+                 (test-< 1l 2l)
+                 "< macro works as expected on longs I"
+    )
+    (assert-false test
+                  (test-< 2l 2l)
+                  "< macro works as expected on longs II"
+    )
+    (assert-true test
+                 (test-< 1.0 2.0)
+                 "< macro works as expected on doubles I"
+    )
+    (assert-false test
+                  (test-< 2.0 2.0)
+                  "< macro works as expected on doubles II"
+    )
+    (assert-true test
+                 (test-< 1.0f 2.0f)
+                 "< macro works as expected on floats I"
+    )
+    (assert-false test
+                  (test-< 2.0f 2.0f)
+                  "< macro works as expected on floats II"
+    )
+    (assert-true test
+                 (test-> 2 1)
+                 "> macro works as expected on ints I"
+    )
+    (assert-false test
+                  (test-> 2 2)
+                  "> macro works as expected on ints II"
+    )
+    (assert-true test
+                 (test-> 2l 1l)
+                 "> macro works as expected on longs I"
+    )
+    (assert-false test
+                  (test-> 2l 2l)
+                  "> macro works as expected on longs II"
+    )
+    (assert-true test
+                 (test-> 2.0 1.0)
+                 "> macro works as expected on doubles I"
+    )
+    (assert-false test
+                  (test-> 2.0 2.0)
+                  "> macro works as expected on doubles II"
+    )
+    (assert-true test
+                 (test-> 2.0f 1.0f)
+                 "> macro works as expected on floats I"
+    )
+    (assert-false test
+                  (test-> 2.0f 2.0f)
+                  "> macro works as expected on floats II"
+    )
+
+    (assert-true test
+                 (test-= 2 2)
+                 "= macro works as expected on ints I"
+    )
+    (assert-false test
+                  (test-= 2 1)
+                  "= macro works as expected on ints II"
+    )
+    (assert-true test
+                 (test-= 2l 2l)
+                 "= macro works as expected on longs I"
+    )
+    (assert-false test
+                  (test-= 2l 1l)
+                  "= macro works as expected on longs II"
+    )
+    (assert-true test
+                 (test-= 2.0 2.0)
+                 "= macro works as expected on doubles I"
+    )
+    (assert-false test
+                  (test-= 2.0 1.0)
+                  "= macro works as expected on doubles II"
+    )
+    (assert-true test
+                 (test-= 2.0f 2.0f)
+                 "= macro works as expected on floats I"
+    )
+    (assert-false test
+                  (test-= 2.0f 1.0f)
+                  "= macro works as expected on floats II"
+    )
+    (assert-true test
+                 (test-= "erik" "erik")
+                 "= macro works as expected on strings I"
+    )
+    (assert-false test
+                  (test-= "erik" "svedäng")
+                  "= macro works as expected on strings II"
+    )
+    (assert-true test
+                 (test-= veit veit)
+                 "= macro works as expected on symbols I"
+    )
+    (assert-false test
+                  (test-= veit heller)
+                  "= macro works as expected on symbols II"
     )
     (print-test-results test)))


### PR DESCRIPTION
This PR introduces `>`, `<`, `and`, `or`, and `not` to the macro system. It also generalizes `=` to work on all numeric types. This was discussed in #142.

A test suite is attached.

Cheers