### PR TITLE
Add Float.from-int

### DIFF
--- a/core/Float.carp
+++ b/core/Float.carp
@@ -6,6 +6,7 @@
   (register * (Fn [Float Float] Float))
   (register / (Fn [Float Float] Float))
   (register to-int (Fn [Float] Int))
+  (register from-int (Fn [Int] Float))
   (register random-between (λ [Float Float] Float))
   (register str (Fn [Float] String))
   (register copy (Fn [(Ref Float)] Float))

--- a/core/core.h
+++ b/core/core.h
@@ -405,8 +405,12 @@ string Double_str(double x) {
     return buffer;
 }
 
-int Float_to_MINUS_int(double x) {
+int Float_to_MINUS_int(float x) {
     return (int)x;
+}
+
+float Float_from_MINUS_int(int x) {
+    return (float)x;
 }
 
 float Float_random_MINUS_between(float lower, float upper) {


### PR DESCRIPTION
This PR adds `Float.from-int`, which was notably absent from conversions between numeric types. It also fixes the signature of `Float.to-int`, which claimed it took a `Double` as argument.

Cheers