### PR TITLE
Fix for --core-flag

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -239,11 +239,13 @@ main = do args <- SystemEnvironment.getArgs
           sysEnv <- SystemEnvironment.getEnvironment
           let (argFilesToLoad, execMode, otherOptions) = parseArgs args
               logMemory = LogMemory `elem` otherOptions
+              noCore = NoCore `elem` otherOptions
               projectWithFiles = defaultProject { projectFiles = argFilesToLoad
                                                 , projectCFlags = (if logMemory then ["-D LOG_MEMORY"] else []) ++
                                                                   (projectCFlags defaultProject)
+                                                ,projectIncludes = (if noCore then [] else projectIncludes defaultProject)
                                                 }
-              noCore = NoCore `elem` otherOptions
+              
               noArray = False
               coreModulesToLoad = if noCore then [] else (coreModules (projectCarpDir projectWithCarpDir))
               projectWithCarpDir = case lookup "CARP_DIR" sysEnv of


### PR DESCRIPTION
Hi Erik, please do check this work a bit extra if you dont mind. I checked with the repl that core.h is not included anymore, but sadly I'm not a Haskell wizard (yet) :-) 

Merry Christmas.