### PR TITLE
Add varargs macro

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -130,3 +130,29 @@
 
 (defmacro case [name :rest forms]
   (case-internal name forms))
+
+(defdynamic build-vararg [fn forms]
+  (if (= (count forms) 0)
+    (macro-error "vararg macro needs at least one argument")
+    (if (= (count forms) 1)
+      (car forms)
+      (list fn (car forms) (build-vararg fn (cdr forms))))))
+
+(defmacro and* [:rest forms]
+  (build-vararg 'and forms))
+
+(defmacro or* [:rest forms]
+  (build-vararg 'or forms))
+
+(defdynamic build-str* [forms]
+  (if (= (count forms) 0)
+    (list "")
+    (if (= (count forms) 1)
+      (list 'str (car forms))
+      (list 'String.append (list 'str (car forms)) (build-str* (cdr forms))))))
+
+(defmacro str* [:rest forms]
+  (build-str* forms))
+
+(defmacro println* [:rest forms]
+  (list 'IO.println (list 'ref (build-str* forms))))

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -191,4 +191,25 @@
                   (test-= veit heller)
                   "= macro works as expected on symbols II"
     )
+    (assert-false test
+                  (and* true true false)
+                  "and* macro works as expected I"
+    )
+    (assert-true test
+                 (and* true true true)
+                 "and* macro works as expected II"
+    )
+    (assert-false test
+                  (or* false false false)
+                  "or* macro works as expected I"
+    )
+    (assert-true test
+                 (or* true false true)
+                 "or* macro works as expected II"
+    )
+    (assert-equal test
+                  "1@\" thing \"2@\" things\""
+                  &(str* 1 " thing " 2 " things")
+                  "str* macro works as expected"
+    )
     (print-test-results test)))


### PR DESCRIPTION
This PR (re-)introduces the varargs macros `and*`, `or*`, `str*`, and `println*`. `str*`/`println*` produces pretty ugly strings for now, because it calls `str` on Strings (you can observe that behavior in the last included test case, "str* macro works as expected".

Test cases are included.

Cheers