### PR TITLE
Add formatted string output

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -137,48 +137,48 @@ arrayModule = Env { envBindings = bindings, envParent = Nothing, envModuleName =
 
 dynamicStringModule :: Env
 dynamicStringModule = Env { envBindings = bindings, envParent = Nothing, envModuleName = Just "String", envUseModules = [], envMode = ExternalEnv }
-  where bindings = Map.fromList [ addCommand "char-at" (CommandFunction commandCharAt)
-                                , addCommand "index-of" (CommandFunction commandIndexOf)
-                                , addCommand "substring" (CommandFunction commandSubstring)
-                                , addCommand "count" (CommandFunction commandStringCount)
+  where bindings = Map.fromList [ addCommand "char-at" 2 commandCharAt
+                                , addCommand "index-of" 2 commandIndexOf
+                                , addCommand "substring" 3 commandSubstring
+                                , addCommand "count" 1 commandStringCount
                                 ]
 
 dynamicModule :: Env
 dynamicModule = Env { envBindings = bindings, envParent = Nothing, envModuleName = Just "Dynamic", envUseModules = [], envMode = ExternalEnv }
   where bindings = Map.fromList $
-                    [ addCommand "list?" (CommandFunction commandIsList)
-                    , addCommand "count" (CommandFunction commandCount)
-                    , addCommand "car" (CommandFunction commandCar)
-                    , addCommand "cdr" (CommandFunction commandCdr)
-                    , addCommand "last" (CommandFunction commandLast)
-                    , addCommand "all-but-last" (CommandFunction commandAllButLast)
-                    , addCommand "cons" (CommandFunction commandCons)
-                    , addCommand "cons-last" (CommandFunction commandConsLast)
-                    , addCommand "append" (CommandFunction commandAppend)
-                    , addCommand "macro-error" (CommandFunction commandMacroError)
-                    , addCommand "=" (CommandFunction commandEq)
-                    , addCommand "<" (CommandFunction commandLt)
-                    , addCommand ">" (CommandFunction commandGt)
-                    , addCommand "+" (CommandFunction commandPlus)
-                    , addCommand "-" (CommandFunction commandMinus)
-                    , addCommand "/" (CommandFunction commandDiv)
-                    , addCommand "*" (CommandFunction commandMul)
-                    , addCommand "c" (CommandFunction commandC)
-                    , addCommand "quit" (CommandFunction commandQuit)
-                    , addCommand "cat" (CommandFunction commandCat)
-                    , addCommand "run" (CommandFunction commandRunExe)
-                    , addCommand "build" (CommandFunction commandBuild)
-                    , addCommand "reload" (CommandFunction commandReload)
-                    , addCommand "env" (CommandFunction commandListBindings)
-                    , addCommand "help" (CommandFunction commandHelp)
-                    , addCommand "project" (CommandFunction commandProject)
-                    , addCommand "load" (CommandFunction commandLoad)
-                    , addCommand "macro-log" (CommandFunction commandPrint)
-                    , addCommand "expand" (CommandFunction commandExpand)
-                    , addCommand "project-set!" (CommandFunction commandProjectSet)
-                    , addCommand "os" (CommandFunction commandOS)
-                    , addCommand "system-include" (CommandFunction commandAddSystemInclude)
-                    , addCommand "local-include" (CommandFunction commandAddLocalInclude)
+                    [ addCommand "list?" 1 commandIsList
+                    , addCommand "count" 1 commandCount
+                    , addCommand "car" 1 commandCar
+                    , addCommand "cdr" 1 commandCdr
+                    , addCommand "last" 1 commandLast
+                    , addCommand "all-but-last" 1 commandAllButLast
+                    , addCommand "cons" 2 commandCons
+                    , addCommand "cons-last" 2 commandConsLast
+                    , addCommand "append" 2 commandAppend
+                    , addCommand "macro-error" 1 commandMacroError
+                    , addCommand "=" 2 commandEq
+                    , addCommand "<" 2 commandLt
+                    , addCommand ">" 2 commandGt
+                    , addCommand "+" 2 commandPlus
+                    , addCommand "-" 2 commandMinus
+                    , addCommand "/" 2 commandDiv
+                    , addCommand "*" 2 commandMul
+                    , addCommand "c" 1 commandC
+                    , addCommand "quit" 0 commandQuit
+                    , addCommand "cat" 0 commandCat
+                    , addCommand "run" 0 commandRunExe
+                    , addCommand "build" 0 commandBuild
+                    , addCommand "reload" 0 commandReload
+                    , addCommand "env" 0 commandListBindings
+                    , addCommand "help" 1 commandHelp
+                    , addCommand "project" 0 commandProject
+                    , addCommand "load" 1 commandLoad
+                    , addCommand "macro-log" 1 commandPrint
+                    , addCommand "expand" 1 commandExpand
+                    , addCommand "project-set!" 2 commandProjectSet
+                    , addCommand "os" 0 commandOS
+                    , addCommand "system-include" 1 commandAddSystemInclude
+                    , addCommand "local-include" 1 commandAddLocalInclude
                     ]
                     ++ [("String", Binder (XObj (Mod dynamicStringModule) Nothing Nothing))]
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -135,38 +135,48 @@ arrayModule = Env { envBindings = bindings, envParent = Nothing, envModuleName =
                                 , templateElemCount
                                 ]
 
+dynamicStringModule :: Env
+dynamicStringModule = Env { envBindings = bindings, envParent = Nothing, envModuleName = Just "String", envUseModules = [], envMode = ExternalEnv }
+  where bindings = Map.fromList [ addCommand "char-at" (CommandFunction commandCharAt)
+                                , addCommand "index-of" (CommandFunction commandIndexOf)
+                                , addCommand "substring" (CommandFunction commandSubstring)
+                                , addCommand "count" (CommandFunction commandStringCount)
+                                ]
+
 dynamicModule :: Env
 dynamicModule = Env { envBindings = bindings, envParent = Nothing, envModuleName = Just "Dynamic", envUseModules = [], envMode = ExternalEnv }
-  where bindings = Map.fromList [ addCommand "list?" (CommandFunction commandIsList)
-                                , addCommand "count" (CommandFunction commandCount)
-                                , addCommand "car" (CommandFunction commandCar)
-                                , addCommand "cdr" (CommandFunction commandCdr)
-                                , addCommand "last" (CommandFunction commandLast)
-                                , addCommand "all-but-last" (CommandFunction commandAllButLast)
-                                , addCommand "cons" (CommandFunction commandCons)
-                                , addCommand "cons-last" (CommandFunction commandConsLast)
-                                , addCommand "append" (CommandFunction commandAppend)
-                                , addCommand "macro-error" (CommandFunction commandMacroError)
-                                , addCommand "=" (CommandFunction commandEq)
-                                , addCommand "<" (CommandFunction commandLt)
-                                , addCommand ">" (CommandFunction commandGt)
-                                , addCommand "c" (CommandFunction commandC)
-                                , addCommand "quit" (CommandFunction commandQuit)
-                                , addCommand "cat" (CommandFunction commandCat)
-                                , addCommand "run" (CommandFunction commandRunExe)
-                                , addCommand "build" (CommandFunction commandBuild)
-                                , addCommand "reload" (CommandFunction commandReload)
-                                , addCommand "env" (CommandFunction commandListBindings)
-                                , addCommand "help" (CommandFunction commandHelp)
-                                , addCommand "project" (CommandFunction commandProject)
-                                , addCommand "load" (CommandFunction commandLoad)
-                                , addCommand "macro-log" (CommandFunction commandPrint)
-                                , addCommand "expand" (CommandFunction commandExpand)
-                                , addCommand "project-set!" (CommandFunction commandProjectSet)
-                                , addCommand "os" (CommandFunction commandOS)
-                                , addCommand "system-include" (CommandFunction commandAddSystemInclude)
-                                , addCommand "local-include" (CommandFunction commandAddLocalInclude)
-                                ]
+  where bindings = Map.fromList $
+                    [ addCommand "list?" (CommandFunction commandIsList)
+                    , addCommand "count" (CommandFunction commandCount)
+                    , addCommand "car" (CommandFunction commandCar)
+                    , addCommand "cdr" (CommandFunction commandCdr)
+                    , addCommand "last" (CommandFunction commandLast)
+                    , addCommand "all-but-last" (CommandFunction commandAllButLast)
+                    , addCommand "cons" (CommandFunction commandCons)
+                    , addCommand "cons-last" (CommandFunction commandConsLast)
+                    , addCommand "append" (CommandFunction commandAppend)
+                    , addCommand "macro-error" (CommandFunction commandMacroError)
+                    , addCommand "=" (CommandFunction commandEq)
+                    , addCommand "<" (CommandFunction commandLt)
+                    , addCommand ">" (CommandFunction commandGt)
+                    , addCommand "c" (CommandFunction commandC)
+                    , addCommand "quit" (CommandFunction commandQuit)
+                    , addCommand "cat" (CommandFunction commandCat)
+                    , addCommand "run" (CommandFunction commandRunExe)
+                    , addCommand "build" (CommandFunction commandBuild)
+                    , addCommand "reload" (CommandFunction commandReload)
+                    , addCommand "env" (CommandFunction commandListBindings)
+                    , addCommand "help" (CommandFunction commandHelp)
+                    , addCommand "project" (CommandFunction commandProject)
+                    , addCommand "load" (CommandFunction commandLoad)
+                    , addCommand "macro-log" (CommandFunction commandPrint)
+                    , addCommand "expand" (CommandFunction commandExpand)
+                    , addCommand "project-set!" (CommandFunction commandProjectSet)
+                    , addCommand "os" (CommandFunction commandOS)
+                    , addCommand "system-include" (CommandFunction commandAddSystemInclude)
+                    , addCommand "local-include" (CommandFunction commandAddLocalInclude)
+                    ]
+                    ++ [("String", Binder (XObj (Mod dynamicStringModule) Nothing Nothing))]
 
 startingGlobalEnv :: Bool -> Env
 startingGlobalEnv noArray =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -159,6 +159,10 @@ dynamicModule = Env { envBindings = bindings, envParent = Nothing, envModuleName
                     , addCommand "=" (CommandFunction commandEq)
                     , addCommand "<" (CommandFunction commandLt)
                     , addCommand ">" (CommandFunction commandGt)
+                    , addCommand "+" (CommandFunction commandPlus)
+                    , addCommand "+" (CommandFunction commandMinus)
+                    , addCommand "/" (CommandFunction commandDiv)
+                    , addCommand "*" (CommandFunction commandMul)
                     , addCommand "c" (CommandFunction commandC)
                     , addCommand "quit" (CommandFunction commandQuit)
                     , addCommand "cat" (CommandFunction commandCat)
@@ -216,6 +220,7 @@ coreModules :: String -> [String]
 coreModules carpDir = map (\s -> carpDir ++ "/core/" ++ s ++ ".carp") [ "Interfaces"
                                                                       , "Macros"
                                                                       , "Dynamic"
+                                                                      , "Format"
                                                                       , "Int"
                                                                       , "Long"
                                                                       , "Double"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -160,7 +160,7 @@ dynamicModule = Env { envBindings = bindings, envParent = Nothing, envModuleName
                     , addCommand "<" (CommandFunction commandLt)
                     , addCommand ">" (CommandFunction commandGt)
                     , addCommand "+" (CommandFunction commandPlus)
-                    , addCommand "+" (CommandFunction commandMinus)
+                    , addCommand "-" (CommandFunction commandMinus)
                     , addCommand "/" (CommandFunction commandDiv)
                     , addCommand "*" (CommandFunction commandMul)
                     , addCommand "c" (CommandFunction commandC)

--- a/core/Bool.carp
+++ b/core/Bool.carp
@@ -3,4 +3,5 @@
   (register /= (Fn [Bool Bool] Bool))
   (register str (Fn [Bool] String))
   (register copy (Fn [&Bool] Bool))
+  (register format (Fn [&String Bool] String))
   )

--- a/core/Char.carp
+++ b/core/Char.carp
@@ -4,6 +4,7 @@
   (register to-int (Fn [Char] Int))
   (register from-int (Fn [Int] Char))
   (register copy (Fn [&Char] Char))
+  (register format (Fn [&String Char] String))
 
   (defn random []
     (from-int (Int.random)))

--- a/core/Double.carp
+++ b/core/Double.carp
@@ -39,7 +39,7 @@
   (register mod (Fn [Double Double] Double))
   (register copy (Fn [(Ref Double)] Double))
   (register abs (Fn [Double] Double))
-  (register format (Fn [String Double] String))
+  (register format (Fn [&String Double] String))
 
   (defn clamp [min, max, val]
     (if (> val max)

--- a/core/Double.carp
+++ b/core/Double.carp
@@ -39,6 +39,7 @@
   (register mod (Fn [Double Double] Double))
   (register copy (Fn [(Ref Double)] Double))
   (register abs (Fn [Double] Double))
+  (register format (Fn [String Double] String))
 
   (defn clamp [min, max, val]
     (if (> val max)

--- a/core/Dynamic.carp
+++ b/core/Dynamic.carp
@@ -5,6 +5,12 @@
     (defdynamic append [s1 s2]
       (macro-log "Can't append strings in dynamic runtime yet.")))
 
+  (defdynamic inc [x]
+    (+ x 1))
+
+  (defdynamic dec [x]
+    (- x 1))
+
   )
 
 

--- a/core/Float.carp
+++ b/core/Float.carp
@@ -11,7 +11,7 @@
   (register random-between (λ [Float Float] Float))
   (register str (Fn [Float] String))
   (register copy (Fn [(Ref Float)] Float))
-  (register format (Fn [String Float] String))
+  (register format (Fn [&String Float] String))
 
   (register = (Fn [Float Float] Bool))
   (defn /= [x y]

--- a/core/Float.carp
+++ b/core/Float.carp
@@ -11,6 +11,7 @@
   (register random-between (λ [Float Float] Float))
   (register str (Fn [Float] String))
   (register copy (Fn [(Ref Float)] Float))
+  (register format (Fn [String Float] String))
 
   (register = (Fn [Float Float] Bool))
   (defn /= [x y]

--- a/core/Format.carp
+++ b/core/Format.carp
@@ -17,9 +17,9 @@
             (if (= -1 next)
               (if (< 1 (count args))
                 (macro-error "error in format string: too many arguments to format string")
-                (list 'format (list 'copy s) (car args)))
+                (list 'format s (car args)))
               (let [slice (String.substring s 0 (+ (inc idx) next))]
-                (list 'String.append (list 'format (list 'copy slice) (car args))
+                (list 'String.append (list 'format slice (car args))
                                      (fmt-internal (String.substring s (+ (inc idx) next) len)
                                                    (cdr args)))))))))))
 

--- a/core/Format.carp
+++ b/core/Format.carp
@@ -1,10 +1,10 @@
 (defdynamic fmt-internal [s args]
   (let [idx (String.index-of s \%)
         len (String.count s)]
-    (if (= idx -1) s ; no more splits found, just return string
+    (if (= idx -1) (list 'copy s) ; no more splits found, just return string
       (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
         (list 'String.append
-              (String.substring s 0 (+ idx 2))
+              (list 'copy (String.substring s 0 (+ idx 2)))
               (fmt-internal (String.substring s (+ idx 2) len)))
         (if (= 0 (count args)) ; we need to insert something, but have nothing
           (macro-error "error in format string: not enough arguments for format string")
@@ -12,12 +12,11 @@
           ; get the next % after our escaper
           (let [next (String.index-of (String.substring s (inc idx) len) \%)]
             (if (= 0 next)
-              (list 'fmt slice (car args))
-              (let [offs (+ idx 2)
-                    slice (String.substring s 0 (+ idx 2))]
-                (list 'String.append (list 'fmt slice (car args))
-                                     (fmt-internal (String.substring s offs len)
+              (list 'format (list 'copy slice) (car args))
+              (let [slice (String.substring s 0 (+ (inc idx) next))]
+                (list 'String.append (list 'format (list 'copy slice) (car args))
+                                     (fmt-internal (String.substring s (+ (inc idx) next) len)
                                                    (cdr args)))))))))))
 
-(defmacro format [s :rest args]
+(defmacro fmt [s :rest args]
   (fmt-internal s args))

--- a/core/Format.carp
+++ b/core/Format.carp
@@ -1,18 +1,23 @@
 (defdynamic fmt-internal [s args]
   (let [idx (String.index-of s \%)
         len (String.count s)]
-    (if (= idx -1) (list 'copy s) ; no more splits found, just return string
+    (if (= idx -1)
+      (if (< 0 (count args))
+        (macro-error "error in format string: too many arguments to format string")
+        (list 'copy s)) ; no more splits found, just return string
       (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
         (list 'String.append
               (list 'copy (String.substring s 0 (+ idx 2)))
               (fmt-internal (String.substring s (+ idx 2) len)))
         (if (= 0 (count args)) ; we need to insert something, but have nothing
-          (macro-error "error in format string: not enough arguments for format string")
+          (macro-error "error in format string: not enough arguments to format string")
           ; okay, this is the meat:
           ; get the next % after our escaper
           (let [next (String.index-of (String.substring s (inc idx) len) \%)]
             (if (= 0 next)
-              (list 'format (list 'copy slice) (car args))
+              (if (< 1 (count args))
+                (macro-error "error in format string: too many arguments to format string")
+                (list 'format (list 'copy slice) (car args)))
               (let [slice (String.substring s 0 (+ (inc idx) next))]
                 (list 'String.append (list 'format (list 'copy slice) (car args))
                                      (fmt-internal (String.substring s (+ (inc idx) next) len)

--- a/core/Format.carp
+++ b/core/Format.carp
@@ -14,10 +14,10 @@
           ; okay, this is the meat:
           ; get the next % after our escaper
           (let [next (String.index-of (String.substring s (inc idx) len) \%)]
-            (if (= 0 next)
+            (if (= -1 next)
               (if (< 1 (count args))
                 (macro-error "error in format string: too many arguments to format string")
-                (list 'format (list 'copy slice) (car args)))
+                (list 'format (list 'copy s) (car args)))
               (let [slice (String.substring s 0 (+ (inc idx) next))]
                 (list 'String.append (list 'format (list 'copy slice) (car args))
                                      (fmt-internal (String.substring s (+ (inc idx) next) len)

--- a/core/Format.carp
+++ b/core/Format.carp
@@ -1,24 +1,23 @@
 (defdynamic fmt-internal [s args]
   (let [idx (String.index-of s \%)
         len (String.count s)]
-    (cond
-      (= idx -1) s ; no more splits found, just return string
-      (= \% (String.char-at s (inc idx))) ; this is an escaped %
+    (if (= idx -1) s ; no more splits found, just return string
+      (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
         (list 'String.append
               (String.substring s 0 (+ idx 2))
-              (fmt-internal (String.substring (+ idx 2) len)))
-      (= 0 (count args)) ; we need to insert something, but have nothing
-        (macro-error "error in format string: not enough arguments for format string")
-      ; okay, this is the meat:
-      ; get the next % after our escaper
-      (let [next (String.index-of (String.substring s (inc idx) len) \%)]
-        (if (= 0 next)
-          (list 'fmt slice (car args))
-          (let [offs (+ (inc idx) 1)
-                slice (String.substring s 0 offs)]
-            (list 'String.append (list 'fmt slice (car args))
-                                 (fmt-internal (String.substring s offs len)
-                                               (cdr args)))))))))
+              (fmt-internal (String.substring s (+ idx 2) len)))
+        (if (= 0 (count args)) ; we need to insert something, but have nothing
+          (macro-error "error in format string: not enough arguments for format string")
+          ; okay, this is the meat:
+          ; get the next % after our escaper
+          (let [next (String.index-of (String.substring s (inc idx) len) \%)]
+            (if (= 0 next)
+              (list 'fmt slice (car args))
+              (let [offs (+ idx 2)
+                    slice (String.substring s 0 (+ idx 2))]
+                (list 'String.append (list 'fmt slice (car args))
+                                     (fmt-internal (String.substring s offs len)
+                                                   (cdr args)))))))))))
 
-(defmacro fmt [s :rest args]
+(defmacro format [s :rest args]
   (fmt-internal s args))

--- a/core/Format.carp
+++ b/core/Format.carp
@@ -1,0 +1,24 @@
+(defdynamic fmt-internal [s args]
+  (let [idx (String.index-of s \%)
+        len (String.count s)]
+    (cond
+      (= idx -1) s ; no more splits found, just return string
+      (= \% (String.char-at s (inc idx))) ; this is an escaped %
+        (list 'String.append
+              (String.substring s 0 (+ idx 2))
+              (fmt-internal (String.substring (+ idx 2) len)))
+      (= 0 (count args)) ; we need to insert something, but have nothing
+        (macro-error "error in format string: not enough arguments for format string")
+      ; okay, this is the meat:
+      ; get the next % after our escaper
+      (let [next (String.index-of (String.substring s (inc idx) len) \%)]
+        (if (= 0 next)
+          (list 'fmt slice (car args))
+          (let [offs (+ (inc idx) 1)
+                slice (String.substring s 0 offs)]
+            (list 'String.append (list 'fmt slice (car args))
+                                 (fmt-internal (String.substring s offs len)
+                                               (cdr args)))))))))
+
+(defmacro fmt [s :rest args]
+  (fmt-internal s args))

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -22,6 +22,7 @@
   (register inc (λ [Int] Int))
   (register dec (λ [Int] Int))
   (register copy (λ [&Int] Int)) ;; TODO: Should not be needed when refs to value types are auto-converted to non-refs.
+  (register format (Fn [String Int] String))
 
   (register safe-add (λ [Int Int (Ref Int)] Bool))
   (register safe-sub (λ [Int Int (Ref Int)] Bool))

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -22,7 +22,7 @@
   (register inc (λ [Int] Int))
   (register dec (λ [Int] Int))
   (register copy (λ [&Int] Int)) ;; TODO: Should not be needed when refs to value types are auto-converted to non-refs.
-  (register format (Fn [String Int] String))
+  (register format (Fn [&String Int] String))
 
   (register safe-add (λ [Int Int (Ref Int)] Bool))
   (register safe-sub (λ [Int Int (Ref Int)] Bool))

--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -1,5 +1,6 @@
 (definterface = (λ [a a] Bool))
 (definterface /= (λ [a a] Bool))
+(definterface format (λ [String a] String))
 
 (definterface zero (λ [] a))
 (definterface add-ref (λ [&a &a] a))

--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -1,6 +1,6 @@
 (definterface = (λ [a a] Bool))
 (definterface /= (λ [a a] Bool))
-(definterface format (λ [String a] String))
+(definterface format (λ [&String a] String))
 
 (definterface zero (λ [] a))
 (definterface add-ref (λ [&a &a] a))

--- a/core/Long.carp
+++ b/core/Long.carp
@@ -23,6 +23,7 @@
   (register to-int (λ [Long] Int))
   (register from-int (λ [Int] Long))
   (register copy (λ [&Long] Long)) ;; TODO: Should not be needed when refs to value types are auto-converted to non-refs.
+  (register format (Fn [String Long] String))
 
   (defn /= [x y]
     (not (Long.= x y)))

--- a/core/Long.carp
+++ b/core/Long.carp
@@ -23,7 +23,7 @@
   (register to-int (λ [Long] Int))
   (register from-int (λ [Int] Long))
   (register copy (λ [&Long] Long)) ;; TODO: Should not be needed when refs to value types are auto-converted to non-refs.
-  (register format (Fn [String Long] String))
+  (register format (Fn [&String Long] String))
 
   (defn /= [x y]
     (not (Long.= x y)))

--- a/core/String.carp
+++ b/core/String.carp
@@ -12,7 +12,7 @@
   (register chars      (Fn [&String] (Array Char)))
   (register from-chars (Fn [(Array Char)] String))
   (register tail (λ [(Ref String)] String))
-  (register format (Fn [String String] String))
+  (register format (Fn [&String &String] String))
 
   (defn /= [a b]
     (not (= (the (Ref String) a) b)))

--- a/core/String.carp
+++ b/core/String.carp
@@ -12,6 +12,7 @@
   (register chars      (Fn [&String] (Array Char)))
   (register from-chars (Fn [(Array Char)] String))
   (register tail (λ [(Ref String)] String))
+  (register format (Fn [String String] String))
 
   (defn /= [a b]
     (not (= (the (Ref String) a) b)))

--- a/core/core.h
+++ b/core/core.h
@@ -297,8 +297,8 @@ char String_char_MINUS_at(string* s, int i) {
 
 string String_format(string str, string s) {
     int n = strlen(s);
-    string buffer = CARP_MALLOC(n);
-    snprintf(buffer, n, str, *s);
+    string buffer = CARP_MALLOC(n+1);
+    snprintf(buffer, n+2, str, s);
     return buffer;
 }
 

--- a/core/core.h
+++ b/core/core.h
@@ -186,10 +186,10 @@ string Int_str(int x) {
     return buffer;
 }
 
-string Int_format(string str, int x) {
-    int n = strlen(str) + 32;
+string Int_format(string* str, int x) {
+    int n = strlen(*str) + 32;
     char *buffer = CARP_MALLOC(n+1);
-    snprintf(buffer, n+1, str, x);
+    snprintf(buffer, n+1, *str, x);
     return buffer;
 }
 
@@ -224,10 +224,10 @@ string Long_str(long x) {
     return buffer;
 }
 
-string Long_format(string str, long x) {
-    int n = strlen(str) + 32;
+string Long_format(string* str, long x) {
+    int n = strlen(*str) + 32;
     char *buffer = CARP_MALLOC(n+1);
-    snprintf(buffer, n+1, str, x);
+    snprintf(buffer, n+1, *str, x);
     return buffer;
 }
 
@@ -297,10 +297,10 @@ char String_char_MINUS_at(string* s, int i) {
   return (*s)[i];
 }
 
-string String_format(string str, string s) {
-    int n = strlen(s) + strlen(str);
+string String_format(string *str, string *s) {
+    int n = strlen(*s) + strlen(*str);
     string buffer = CARP_MALLOC(n+1);
-    snprintf(buffer, n+1, str, s);
+    snprintf(buffer, n+1, *str, *s);
     return buffer;
 }
 
@@ -352,6 +352,14 @@ char Char_from_MINUS_int(int i) {
 char Char_copy(char *c) {
   return *c;
 }
+
+string Char_format(string* str, char b) {
+    int n = strlen(*str) + 32;
+    char *buffer = CARP_MALLOC(n+1);
+    snprintf(buffer, n+1, *str, b);
+    return buffer;
+}
+
 
 // Double.toInt : Double -> Int
 int Double_to_MINUS_int(double x) {
@@ -470,10 +478,10 @@ double Double_random_MINUS_between(double lower, double upper) {
     return lower + diff * r;
 }
 
-string Double_format(string s, double x) {
-    int n = strlen(s) + 32;
+string Double_format(string* s, double x) {
+    int n = strlen(*s) + 32;
     char *buffer = CARP_MALLOC(n+1);
-    snprintf(buffer, n+1, s, x);
+    snprintf(buffer, n+1, *s, x);
     return buffer;
 }
 
@@ -585,10 +593,10 @@ string Float_str(float x) {
     return buffer;
 }
 
-string Float_format(string str, float x) {
-    int n = strlen(str) + 32;
+string Float_format(string* str, float x) {
+    int n = strlen(*str) + 32;
     char *buffer = CARP_MALLOC(n+1);
-    snprintf(buffer, n+1, str, x);
+    snprintf(buffer, n+1, *str, x);
     return buffer;
 }
 
@@ -613,6 +621,13 @@ string Bool_str(bool b) {
     } else {
         return String_copy(&false_str);
     }
+}
+
+string Bool_format(string* str, bool b) {
+    int n = strlen(*str) + 32;
+    char *buffer = CARP_MALLOC(n+1);
+    snprintf(buffer, n+1, *str, b);
+    return buffer;
 }
 
 void System_exit(int code) {

--- a/core/core.h
+++ b/core/core.h
@@ -187,8 +187,9 @@ string Int_str(int x) {
 }
 
 string Int_format(string str, int x) {
-    char *buffer = CARP_MALLOC(64);
-    snprintf(buffer, 64, str, x);
+    int n = strlen(str) + 32;
+    char *buffer = CARP_MALLOC(n+1);
+    snprintf(buffer, n+1, str, x);
     return buffer;
 }
 
@@ -224,8 +225,9 @@ string Long_str(long x) {
 }
 
 string Long_format(string str, long x) {
-    char *buffer = CARP_MALLOC(64);
-    snprintf(buffer, 64, str, x);
+    int n = strlen(str) + 32;
+    char *buffer = CARP_MALLOC(n+1);
+    snprintf(buffer, n+1, str, x);
     return buffer;
 }
 
@@ -296,9 +298,9 @@ char String_char_MINUS_at(string* s, int i) {
 }
 
 string String_format(string str, string s) {
-    int n = strlen(s);
+    int n = strlen(s) + strlen(str);
     string buffer = CARP_MALLOC(n+1);
-    snprintf(buffer, n+2, str, s);
+    snprintf(buffer, n+1, str, s);
     return buffer;
 }
 
@@ -469,8 +471,9 @@ double Double_random_MINUS_between(double lower, double upper) {
 }
 
 string Double_format(string s, double x) {
-    char *buffer = CARP_MALLOC(32);
-    snprintf(buffer, 32, s, x);
+    int n = strlen(s) + 32;
+    char *buffer = CARP_MALLOC(n+1);
+    snprintf(buffer, n+1, s, x);
     return buffer;
 }
 
@@ -583,8 +586,9 @@ string Float_str(float x) {
 }
 
 string Float_format(string str, float x) {
-    char *buffer = CARP_MALLOC(32);
-    snprintf(buffer, 32, str, x);
+    int n = strlen(str) + 32;
+    char *buffer = CARP_MALLOC(n+1);
+    snprintf(buffer, n+1, str, x);
     return buffer;
 }
 

--- a/core/core.h
+++ b/core/core.h
@@ -186,6 +186,16 @@ string Int_str(int x) {
     return buffer;
 }
 
+string Int_format(string str, int x) {
+    char *buffer = CARP_MALLOC(64);
+    snprintf(buffer, 64, str, x);
+    return buffer;
+}
+
+bool Int_mask(int a, int b) {
+    return a & b;
+}
+
 long Long_from_MINUS_string(string *s) {
     return atol(*s);
 }
@@ -211,6 +221,16 @@ string Long_str(long x) {
     char *buffer = CARP_MALLOC(64);
     snprintf(buffer, 64, "%ldl", x);
     return buffer;
+}
+
+string Long_format(string str, long x) {
+    char *buffer = CARP_MALLOC(64);
+    snprintf(buffer, 64, str, x);
+    return buffer;
+}
+
+bool Long_mask(long a, long b) {
+    return a & b;
 }
 
 int Long_to_MINUS_int(long a) {
@@ -273,6 +293,13 @@ string String_str(string *s) {
 
 char String_char_MINUS_at(string* s, int i) {
   return (*s)[i];
+}
+
+string String_format(string str, string s) {
+    int n = strlen(s);
+    string buffer = CARP_MALLOC(n);
+    snprintf(buffer, n, str, *s);
+    return buffer;
 }
 
 Array String_chars(string *s) {
@@ -441,6 +468,12 @@ double Double_random_MINUS_between(double lower, double upper) {
     return lower + diff * r;
 }
 
+string Double_format(string s, double x) {
+    char *buffer = CARP_MALLOC(32);
+    snprintf(buffer, 32, s, x);
+    return buffer;
+}
+
 int Float_to_MINUS_int(float x) {
     return (int)x;
 }
@@ -546,6 +579,12 @@ float Float_mod(float x, float y) {
 string Float_str(float x) {
     char *buffer = CARP_MALLOC(32);
     snprintf(buffer, 32, "%gf", x);
+    return buffer;
+}
+
+string Float_format(string str, float x) {
+    char *buffer = CARP_MALLOC(32);
+    snprintf(buffer, 32, str, x);
     return buffer;
 }
 

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -75,8 +75,7 @@ commandProjectSet [XObj (Str key) _ _, value] =
     where err msg ret = liftIO $ do putStrLnWithColor Red msg
                                     return ret
 commandProjectSet args =
-  liftIO $ do putStrLnWithColor Red ("Invalid args to 'project-set!' command: " ++ joinWithComma (map pretty args))
-              return dynamicNil
+  return (Left (EvalError ("Invalid args to 'project-set!' command: " ++ joinWithComma (map pretty args))))
 
 -- | Command for exiting the REPL/compiler
 commandQuit :: CommandCallback
@@ -119,8 +118,7 @@ commandBuild args =
                   return ("//Types:\n" ++ typeDecl ++ "\n\n//Declarations:\n" ++ decl ++ "\n\n//Definitions:\n" ++ c)
      case src of
        Left err ->
-         liftIO $ do putStrLnWithColor Red ("[CODEGEN ERROR] " ++ show err)
-                     return dynamicNil
+         return (Left (EvalError ("[CODEGEN ERROR] " ++ show err)))
        Right okSrc ->
          liftIO $ do let compiler = projectCompiler proj
                          echoCompilationCommand = projectEchoCompilationCommand proj
@@ -332,9 +330,8 @@ commandIsList [x] =
   case x of
     XObj (Lst _) _ _ -> return (Right trueXObj)
     _ -> return (Right falseXObj)
-commandIsList _ =
-  do liftIO $ putStrLnWithColor Red "Invalid args to 'list?'"
-     return dynamicNil
+commandIsList args =
+  return (Left (EvalError ("Invalid args to 'list?': " ++ joinWithComma (map pretty args))))
 
 commandCount :: CommandCallback
 commandCount [x] =
@@ -343,8 +340,7 @@ commandCount [x] =
     XObj (Arr arr) _ _ -> return (Right (XObj (Num IntTy (fromIntegral (length arr))) Nothing Nothing))
     _ -> return (Left (EvalError ("Applying 'count' to non-list: " ++ pretty x ++ " at " ++ prettyInfoFromXObj x)))
 commandCount args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'count': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'count': " ++ joinWithComma (map pretty args))))
 
 commandCar :: CommandCallback
 commandCar [x] =
@@ -353,8 +349,7 @@ commandCar [x] =
     XObj (Arr (car : _)) _ _ -> return (Right car)
     _ -> return (Left (EvalError ("Applying 'car' to non-list: " ++ pretty x)))
 commandCar args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'car': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'car': " ++ joinWithComma (map pretty args))))
 
 commandCdr :: CommandCallback
 commandCdr [x] =
@@ -363,8 +358,7 @@ commandCdr [x] =
     XObj (Arr (_ : cdr)) _ _ -> return (Right (XObj (Arr cdr) Nothing Nothing))
     _ -> return (Left (EvalError "Applying 'cdr' to non-list or empty list"))
 commandCdr args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'cdr': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'cdr': " ++ joinWithComma (map pretty args))))
 
 commandLast :: CommandCallback
 commandLast [x] =
@@ -373,8 +367,7 @@ commandLast [x] =
     XObj (Arr arr) _ _ -> return (Right (last arr))
     _ -> return (Left (EvalError "Applying 'last' to non-list or empty list."))
 commandLast args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'last': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'last': " ++ joinWithComma (map pretty args))))
 
 commandAllButLast :: CommandCallback
 commandAllButLast [x] =
@@ -383,8 +376,7 @@ commandAllButLast [x] =
     XObj (Arr arr) _ _ -> return (Right (XObj (Arr (init arr)) Nothing Nothing))
     _ -> return (Left (EvalError "Applying 'all-but-last' to non-list or empty list."))
 commandAllButLast args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'all-but-last': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'all-but-last': " ++ joinWithComma (map pretty args))))
 
 commandCons :: CommandCallback
 commandCons [x, xs] =
@@ -392,8 +384,7 @@ commandCons [x, xs] =
     XObj (Lst lst) _ _ -> return (Right (XObj (Lst (x : lst)) (info x) (ty x))) -- TODO: probably not correct to just copy 'i' and 't'?
     _ -> return (Left (EvalError "Applying 'cons' to non-list or empty list."))
 commandCons args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'cons': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'cons': " ++ joinWithComma (map pretty args))))
 
 commandConsLast :: CommandCallback
 commandConsLast [x, xs] =
@@ -401,8 +392,7 @@ commandConsLast [x, xs] =
     XObj (Lst lst) i t -> return (Right (XObj (Lst (lst ++ [x])) i t)) -- TODO: should they get their own i:s and t:s
     _ -> return (Left (EvalError "Applying 'cons-last' to non-list or empty list."))
 commandConsLast args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'cons-last': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'cons-last': " ++ joinWithComma (map pretty args))))
 
 commandAppend :: CommandCallback
 commandAppend [xs, ys] =
@@ -412,8 +402,7 @@ commandAppend [xs, ys] =
     _ ->
       return (Left (EvalError "Applying 'append' to non-list or empty list."))
 commandAppend args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'append': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'append': " ++ joinWithComma (map pretty args))))
 
 commandMacroError :: CommandCallback
 commandMacroError [msg] =
@@ -421,8 +410,7 @@ commandMacroError [msg] =
     XObj (Str msg) _ _ -> return (Left (EvalError msg))
     _                  -> return (Left (EvalError "Calling 'macro-error' with non-string argument"))
 commandMacroError args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'macro-error': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'macro-error': " ++ joinWithComma (map pretty args))))
 
 commandEq :: CommandCallback
 commandEq [a, b] =
@@ -446,8 +434,7 @@ commandEq [a, b] =
     _ ->
       Left (EvalError ("Can't compare " ++ pretty a ++ " with " ++ pretty b))
 commandEq args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to '=': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to '=': " ++ joinWithComma (map pretty args))))
 
 commandLt :: CommandCallback
 commandLt [a, b] =
@@ -467,8 +454,7 @@ commandLt [a, b] =
    _ ->
      Left (EvalError ("Can't compare (<) " ++ pretty a ++ " with " ++ pretty b))
 commandLt args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to '<': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to '<': " ++ joinWithComma (map pretty args))))
 
 commandGt :: CommandCallback
 commandGt [a, b] =
@@ -488,8 +474,7 @@ commandGt [a, b] =
     _ ->
       Left (EvalError ("Can't compare (>) " ++ pretty a ++ " with " ++ pretty b))
 commandGt args =
-  do liftIO $ putStrLnWithColor Red ("Invalid args to '>': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to '>': " ++ joinWithComma (map pretty args))))
 
 commandCharAt :: CommandCallback
 commandCharAt [a, b] =
@@ -499,9 +484,7 @@ commandCharAt [a, b] =
     _ ->
       Left (EvalError ("Can't call char-at with " ++ pretty a ++ " and " ++ pretty b))
 commandCharAt args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'char-at': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'char-at': " ++ joinWithComma (map pretty args))))
 
 commandIndexOf :: CommandCallback
 commandIndexOf [a, b] =
@@ -512,9 +495,7 @@ commandIndexOf [a, b] =
       Left (EvalError ("Can't call index-of with " ++ pretty a ++ " and " ++ pretty b))
   where getIdx c s = fromIntegral $ fromMaybe (-1) $ elemIndex c s
 commandIndexOf args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'index-of': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'index-of': " ++ joinWithComma (map pretty args))))
 
 commandSubstring :: CommandCallback
 commandSubstring [a, b, c] =
@@ -524,9 +505,7 @@ commandSubstring [a, b, c] =
     _ ->
       Left (EvalError ("Can't call substring with " ++ pretty a ++ ", " ++ pretty b ++ " and " ++ pretty c))
 commandSubstring args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'substring': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'substring': " ++ joinWithComma (map pretty args))))
 
 commandStringCount :: CommandCallback
 commandStringCount [a] =
@@ -536,9 +515,7 @@ commandStringCount [a] =
     _ ->
       Left (EvalError ("Can't call count with " ++ pretty a))
 commandStringCount args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to 'count': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to 'count': " ++ joinWithComma (map pretty args))))
 
 commandPlus :: CommandCallback
 commandPlus [a, b] =
@@ -546,11 +523,9 @@ commandPlus [a, b] =
     (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
       Right (XObj (Num IntTy (aNum + bNum)) (Just dummyInfo) (Just IntTy))
     _ ->
-      Left (EvalError ("Can't call + with " ++ pretty a))
+      Left (EvalError ("Can't call + with " ++ pretty a ++ " and " ++ pretty b))
 commandPlus args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to '+': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to '+': " ++ joinWithComma (map pretty args))))
 
 commandMinus :: CommandCallback
 commandMinus [a, b] =
@@ -558,11 +533,9 @@ commandMinus [a, b] =
     (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
       Right (XObj (Num IntTy (aNum - bNum)) (Just dummyInfo) (Just IntTy))
     _ ->
-      Left (EvalError ("Can't call - with " ++ pretty a))
+      Left (EvalError ("Can't call - with " ++ pretty a ++ " and " ++ pretty b))
 commandMinus args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to '-': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to '-': " ++ joinWithComma (map pretty args))))
 
 commandDiv :: CommandCallback
 commandDiv [a, b] =
@@ -570,11 +543,9 @@ commandDiv [a, b] =
     (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
       Right (XObj (Num IntTy (aNum / bNum)) (Just dummyInfo) (Just IntTy))
     _ ->
-      Left (EvalError ("Can't call / with " ++ pretty a))
+      Left (EvalError ("Can't call / with " ++ pretty a ++ " and " ++ pretty b))
 commandDiv args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to '/': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to '/': " ++ joinWithComma (map pretty args))))
 
 commandMul :: CommandCallback
 commandMul [a, b] =
@@ -582,8 +553,6 @@ commandMul [a, b] =
     (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
       Right (XObj (Num IntTy (aNum * bNum)) (Just dummyInfo) (Just IntTy))
     _ ->
-      Left (EvalError ("Can't call * with " ++ pretty a))
+      Left (EvalError ("Can't call * with " ++ pretty a ++ " and " ++ pretty b))
 commandMul args =
-  -- TODO: this (and all functions above) should rather return Left here
-  do liftIO $ putStrLnWithColor Red ("Invalid args to '*': " ++ joinWithComma (map pretty args))
-     return dynamicNil
+  return (Left (EvalError ("Invalid args to '*': " ++ joinWithComma (map pretty args))))

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -540,3 +540,50 @@ commandStringCount args =
   do liftIO $ putStrLnWithColor Red ("Invalid args to 'count': " ++ joinWithComma (map pretty args))
      return dynamicNil
 
+commandPlus :: CommandCallback
+commandPlus [a, b] =
+  return $ case (a, b) of
+    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
+      Right (XObj (Num IntTy (aNum + bNum)) (Just dummyInfo) (Just IntTy))
+    _ ->
+      Left (EvalError ("Can't call + with " ++ pretty a))
+commandPlus args =
+  -- TODO: this (and all functions above) should rather return Left here
+  do liftIO $ putStrLnWithColor Red ("Invalid args to '+': " ++ joinWithComma (map pretty args))
+     return dynamicNil
+
+commandMinus :: CommandCallback
+commandMinus [a, b] =
+  return $ case (a, b) of
+    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
+      Right (XObj (Num IntTy (aNum - bNum)) (Just dummyInfo) (Just IntTy))
+    _ ->
+      Left (EvalError ("Can't call - with " ++ pretty a))
+commandMinus args =
+  -- TODO: this (and all functions above) should rather return Left here
+  do liftIO $ putStrLnWithColor Red ("Invalid args to '-': " ++ joinWithComma (map pretty args))
+     return dynamicNil
+
+commandDiv :: CommandCallback
+commandDiv [a, b] =
+  return $ case (a, b) of
+    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
+      Right (XObj (Num IntTy (aNum / bNum)) (Just dummyInfo) (Just IntTy))
+    _ ->
+      Left (EvalError ("Can't call / with " ++ pretty a))
+commandDiv args =
+  -- TODO: this (and all functions above) should rather return Left here
+  do liftIO $ putStrLnWithColor Red ("Invalid args to '/': " ++ joinWithComma (map pretty args))
+     return dynamicNil
+
+commandMul :: CommandCallback
+commandMul [a, b] =
+  return $ case (a, b) of
+    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
+      Right (XObj (Num IntTy (aNum * bNum)) (Just dummyInfo) (Just IntTy))
+    _ ->
+      Left (EvalError ("Can't call * with " ++ pretty a))
+commandMul args =
+  -- TODO: this (and all functions above) should rather return Left here
+  do liftIO $ putStrLnWithColor Red ("Invalid args to '*': " ++ joinWithComma (map pretty args))
+     return dynamicNil

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -411,6 +411,8 @@ commandEq [a, b] =
       then Right trueXObj else Right falseXObj
     (XObj (Str sa) _ _, XObj (Str sb) _ _) ->
       if sa == sb then Right trueXObj else Right falseXObj
+    (XObj (Chr ca) _ _, XObj (Chr cb) _ _) ->
+      if ca == cb then Right trueXObj else Right falseXObj
     (XObj (Sym sa) _ _, XObj (Sym sb) _ _) ->
       if sa == sb then Right trueXObj else Right falseXObj
     _ ->

--- a/test/format.carp
+++ b/test/format.carp
@@ -1,0 +1,46 @@
+(load "Test.carp")
+(use Test)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                  "c"
+                  &(format "%c" \c)
+                  "format works on chars"
+    )
+    (assert-equal test
+                  "1"
+                  &(format "%d" true)
+                  "format works on bools"
+    )
+    (assert-equal test
+                  "10"
+                  &(format "%d" 10)
+                  "format works on ints"
+    )
+    (assert-equal test
+                  "10"
+                  &(format "%ld" 10)
+                  "format works on longs"
+    )
+    (assert-equal test
+                  "10.0"
+                  &(format "%.1f" 10.0f)
+                  "format works on floats"
+    )
+    (assert-equal test
+                  "10.050"
+                  &(format "%2.3f" 10.05)
+                  "format works on doubles"
+    )
+    (assert-equal test
+                  "outside string: inside string :outside string"
+                  &(format "outside string: %s :outside string" "inside string")
+                  "format works on strings"
+    )
+    (assert-equal test
+                  "10 %% 12.0 yay"
+                  &(fmt "%d %% %.1f %s" 10 12.0 "yay")
+                  "fmt macro works"
+    )
+    (print-test-results test)))


### PR DESCRIPTION
This PR fixes #108 and adds formatted strings. It is fairly big and introduces a breaking change, so review with caution!

It adds the dynamic functions `+`, `-`, `*`, and `/` and the dynamic module `String` containing the functions `char-at`, `index-of`, `substring`, and `count`. I refrained from making `count` generic, but that could be discussed as well.

I also made registering new commands more convenient, with an arity that then gets checked at dispatch time, which is a little more convenient than writing an error branch for every function. Multi-arity commands are TBD.

I also added the interface `format`, which takes a string and a thing and returns the string representation of that thing (so its `sprintf` with one argument). This is used in the `fmt` macro, which splits `sprintf`-like strings at compile time and transforms it into a concatenation. *NOTE:* This is possibly expensive!

There are also a few minor things, like making `=` for macros work on Chars and such.

Cheers