### PR TITLE
Fix printing percent in format

### DIFF
--- a/core/Format.carp
+++ b/core/Format.carp
@@ -7,7 +7,7 @@
         (list 'copy s)) ; no more splits found, just return string
       (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
         (list 'String.append
-              (list 'copy (String.substring s 0 (+ idx 2)))
+              @"%"
               (fmt-internal (String.substring s (+ idx 2) len)))
         (if (= 0 (count args)) ; we need to insert something, but have nothing
           (macro-error "error in format string: not enough arguments to format string")

--- a/test/format.carp
+++ b/test/format.carp
@@ -39,7 +39,7 @@
                   "format works on strings"
     )
     (assert-equal test
-                  "10 %% 12.0 yay"
+                  "10 % 12.0 yay"
                   &(fmt "%d %% %.1f %s" 10 12.0 "yay")
                   "fmt macro works"
     )


### PR DESCRIPTION
This PR fixes printing `%` in `format`.

Tests were updated.

Cheers