### PR TITLE
Small project cflag/libflag fix

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -66,7 +66,7 @@ commandProjectSet [XObj (Str key) _ _, value] =
        XObj (Str valueStr) _ _ -> do
           newCtx <- case key of
                       "cflag" -> return ctx { contextProj = proj { projectCFlags = addIfNotPresent valueStr (projectCFlags proj) } }
-                      "libflag" -> return ctx { contextProj = proj { projectCFlags = addIfNotPresent valueStr (projectCFlags proj) } }
+                      "libflag" -> return ctx { contextProj = proj { projectLibFlags = addIfNotPresent valueStr (projectLibFlags proj) } }
                       "prompt" -> return ctx { contextProj = proj { projectPrompt = valueStr } }
                       "search-path" -> return ctx { contextProj = proj { projectCarpSearchPaths = addIfNotPresent valueStr (projectCarpSearchPaths proj) } }
                       "printAST" -> return ctx { contextProj = proj { projectPrintTypedAST = (valueStr == "true") } }

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -41,7 +41,7 @@ addIfNotPresent :: Eq a => a -> [a] -> [a]
 addIfNotPresent x xs =
   if x `elem` xs
   then xs
-  else x : xs
+  else xs ++ [x]
 
 remove :: (a -> Bool) -> [a] -> [a]
 remove f = filter (not . f)


### PR DESCRIPTION
- `AddIfNotPresent` should append to list (or at least in this case), so `cflag` & `libflag` are in the right order.
- Fix: `libflag` should fill `projectLibFlags`, instead of `projectCFlags`.