### PR TITLE
Miscellaneous fixes

### DIFF
--- a/core/String.carp
+++ b/core/String.carp
@@ -93,7 +93,7 @@
     (= sub &(prefix-string s (count sub))))
 
   (defn ends-with? [s sub]
-    (= sub &(suffix-string s (count sub))))
+    (= sub &(suffix-string s (- (count s) (count sub)))))
 )
 
 (defmodule StringCopy

--- a/core/core.h
+++ b/core/core.h
@@ -321,7 +321,8 @@ Array String_chars(string *s) {
 
 string String_from_MINUS_chars(Array a) {
     string s = CARP_MALLOC(a.len+1);
-    snprintf(s, a.len+1, "%s", a.data);
+    memmove(s, a.data, a.len);
+    s[a.len] = '\0';
     return s;
 }
 

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -496,31 +496,39 @@ commandStringCount [a] =
 commandPlus :: CommandCallback
 commandPlus [a, b] =
   return $ case (a, b) of
-    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
-      Right (XObj (Num IntTy (aNum + bNum)) (Just dummyInfo) (Just IntTy))
+    (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
+      if aty == bty
+      then Right (XObj (Num aty (aNum + bNum)) (Just dummyInfo) (Just aty))
+      else Left (EvalError ("Can't call + with " ++ pretty a ++ " and " ++ pretty b))
     _ ->
       Left (EvalError ("Can't call + with " ++ pretty a ++ " and " ++ pretty b))
 
 commandMinus :: CommandCallback
 commandMinus [a, b] =
   return $ case (a, b) of
-    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
-      Right (XObj (Num IntTy (aNum - bNum)) (Just dummyInfo) (Just IntTy))
+    (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
+      if aty == bty
+      then Right (XObj (Num aty (aNum - bNum)) (Just dummyInfo) (Just aty))
+      else Left (EvalError ("Can't call - with " ++ pretty a ++ " and " ++ pretty b))
     _ ->
       Left (EvalError ("Can't call - with " ++ pretty a ++ " and " ++ pretty b))
 
 commandDiv :: CommandCallback
 commandDiv [a, b] =
   return $ case (a, b) of
-    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
-      Right (XObj (Num IntTy (aNum / bNum)) (Just dummyInfo) (Just IntTy))
+    (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
+      if aty == bty
+      then Right (XObj (Num aty (aNum / bNum)) (Just dummyInfo) (Just aty))
+      else Left (EvalError ("Can't call / with " ++ pretty a ++ " and " ++ pretty b))
     _ ->
       Left (EvalError ("Can't call / with " ++ pretty a ++ " and " ++ pretty b))
 
 commandMul :: CommandCallback
 commandMul [a, b] =
   return $ case (a, b) of
-    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
-      Right (XObj (Num IntTy (aNum * bNum)) (Just dummyInfo) (Just IntTy))
+    (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
+      if aty == bty
+      then Right (XObj (Num aty (aNum * bNum)) (Just dummyInfo) (Just aty))
+      else Left (EvalError ("Can't call * with " ++ pretty a ++ " and " ++ pretty b))
     _ ->
       Left (EvalError ("Can't call * with " ++ pretty a ++ " and " ++ pretty b))

--- a/test/string.carp
+++ b/test/string.carp
@@ -56,6 +56,11 @@
                   "chars works as expected"
     )
     (assert-equal test
+                  "erik"
+                  &(from-chars [\e \r \i \k])
+                  "from-chars works as expected"
+    )
+    (assert-equal test
                   "edan"
                   &(substring "svedang" 2 6)
                   "substring works as expected"
@@ -74,6 +79,11 @@
                   true
                   (ends-with? "heller" "ler")
                   "ends-with? works as expected"
+    )
+    (assert-equal test
+                  true
+                  (ends-with? "ller" "ler")
+                  "ends-with? works (regression test for #157)"
     )
     (assert-equal test
                   true


### PR DESCRIPTION
This PR fixes multiple minor issues Namely, the following problems are addressed:

- `String.ends-with?` did not actually work. It did happen on a small range of inputs (namely if the pattern string was exactly half of the length of the string to match), and thus the test worked. I fixed that and added a regression test for the future.
- `String.from-chars` should use `memmove` instead of `snprintf`. Added a test case for `from-chars` as well.
- The arithmetic macros `+`, `*`, `-`, and `/` should accept all numerical types, not just integers.

Cheers