### PR TITLE
Add test case for sort

### DIFF
--- a/test/array.carp
+++ b/test/array.carp
@@ -12,6 +12,11 @@
 
 (defn inc-ref [x] (+ @x 1))
 
+(defn cmp [a b]
+  (if (= @a @b)
+    0
+    (if (> @a @b) 1 -1)))
+
 (defn main []
   (let [a (range 0 9 1)
         b (Array.replicate 5 "Hi")]
@@ -80,6 +85,11 @@
                     &[10 9 8 7 6 5 4 3 2 1 0]
                     &(range 10 0 -1)
                     "range works as expected"
+      )
+      (assert-equal test
+                    &[1 2 3 4 5 6 7 8 9]
+                    (sort &(range 9 1 -1) cmp)
+                    "sort works as expected"
       )
       (assert-equal test
                     &[@"Hi!" @"Hi!" @"Hi!" @"Hi!" @"Hi!"]


### PR DESCRIPTION
This PR adds a test case for `sort`.

I also want to start a conversation around whether we should have a generic function `cmp` or make it an interface. A problem with the current implementation of `sort` is that `cmp` takes refs, and that might require us to copy things. There are a few different strategies with which we could avoid this; for instance, we could change `sort` not to work with refs. That would only defer the problem of copying, though. If we made `cmp` an interface, we would have to copy a lot of code, except in the places where we wouldn’t, with strings for example.

I’m not entirely sure how to go about this.

Cheers