### PR TITLE
Better sort

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -118,4 +118,7 @@
 
   ;(defmacro push-back! [a e]
   ;  (list 'set! a (list 'Array.push-back (list 'copy a) e)))
+
+  (defn sort [a]
+    (sort-with a cmp))
 )

--- a/core/Double.carp
+++ b/core/Double.carp
@@ -61,4 +61,7 @@
 
   (defn add-ref [x y]
     (+ @x @y))
+
+  (defn cmp [x y]
+    (if (= (the Double @x) @y) 0 (if (< @x @y) -1 1)))
 )

--- a/core/Double.carp
+++ b/core/Double.carp
@@ -61,7 +61,15 @@
 
   (defn add-ref [x y]
     (+ @x @y))
+)
 
-  (defn cmp [x y]
-    (if (= (the Double @x) @y) 0 (if (< @x @y) -1 1)))
+(defmodule DoubleRef
+  (defn = [a b]
+    (Double.= @a @b))
+
+  (defn < [a b]
+    (Double.< @a @b))
+
+  (defn > [a b]
+    (Double.> @a @b))
 )

--- a/core/Float.carp
+++ b/core/Float.carp
@@ -62,4 +62,6 @@
   (defn add-ref [x y]
     (+ @x @y))
 
+  (defn cmp [x y]
+    (if (= (the Float @x) @y) 0 (if (< @x @y) -1 1)))
 )

--- a/core/Float.carp
+++ b/core/Float.carp
@@ -61,7 +61,15 @@
 
   (defn add-ref [x y]
     (+ @x @y))
+)
 
-  (defn cmp [x y]
-    (if (= (the Float @x) @y) 0 (if (< @x @y) -1 1)))
+(defmodule FloatRef
+  (defn = [a b]
+    (Float.= @a @b))
+
+  (defn < [a b]
+    (Float.< @a @b))
+
+  (defn > [a b]
+    (Float.> @a @b))
 )

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -42,4 +42,6 @@
   (defn add-ref [x y]
     (+ @x @y))
 
+  (defn cmp [x y]
+    (if (= (the Int @x) @y) 0 (if (< @x @y) -1 1)))
 )

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -41,7 +41,15 @@
 
   (defn add-ref [x y]
     (+ @x @y))
+)
 
-  (defn cmp [x y]
-    (if (= (the Int @x) @y) 0 (if (< @x @y) -1 1)))
+(defmodule IntRef
+  (defn = [a b]
+    (Int.= @a @b))
+
+  (defn < [a b]
+    (Int.< @a @b))
+
+  (defn > [a b]
+    (Int.> @a @b))
 )

--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -26,7 +26,6 @@
 
 (definterface random (Fn [] a))
 (definterface random-between (Fn [a a] a))
-(definterface cmp (Fn [&a &a] Int))
 
 (definterface pi a)
 
@@ -41,3 +40,8 @@
 (defn >= [a b]
   (or (> a b)
       (= a b)))
+
+(defn cmp [a b]
+  (if (= a b)
+    0
+    (if (< a b) -1 1)))

--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -26,6 +26,7 @@
 
 (definterface random (Fn [] a))
 (definterface random-between (Fn [a a] a))
+(definterface cmp (Fn [&a &a] Int))
 
 (definterface pi a)
 

--- a/core/Long.carp
+++ b/core/Long.carp
@@ -39,4 +39,7 @@
 
   (defn even? [a] (= (mod a 2l) 0l))
   (defn odd? [a] (not (even? a)))
+
+  (defn cmp [x y]
+    (if (= (the Long @x) @y) 0 (if (< @x @y) -1 1)))
 )

--- a/core/Long.carp
+++ b/core/Long.carp
@@ -39,7 +39,15 @@
 
   (defn even? [a] (= (mod a 2l) 0l))
   (defn odd? [a] (not (even? a)))
+)
 
-  (defn cmp [x y]
-    (if (= (the Long @x) @y) 0 (if (< @x @y) -1 1)))
+(defmodule LongRef
+  (defn = [a b]
+    (Long.= @a @b))
+
+  (defn < [a b]
+    (Long.< @a @b))
+
+  (defn > [a b]
+    (Long.> @a @b))
 )

--- a/core/Statistics.carp
+++ b/core/Statistics.carp
@@ -17,9 +17,6 @@
     iqr Double
   ])
 
-  (defn sorter [a b]
-    (to-int (- @a @b)))
-
   (defn sum [data]
     (if (= 0 (Array.count data))
       0.0
@@ -76,7 +73,7 @@
 
   (defn median [data]
     (let [n (Array.count data)
-          sorted (Array.copy (Array.sort data sorter))]
+          sorted (Array.sort @data)]
       (cond (= n 0) 0.0
             (= (mod n 2) 1) @(Array.nth data (/ n 2))
             (let [mid (/ n 2)] ; else
@@ -86,21 +83,21 @@
 
   (defn low-median [data]
     (let [n (Array.count data)
-          sorted (Array.copy (Array.sort data sorter))]
+          sorted (Array.sort @data)]
       (cond (= n 0) 0.0
             (= (mod n 2) 1) @(Array.nth data (/ n 2))
             @(Array.nth data (dec (/ n 2)))))) ; else
 
   (defn high-median [data]
     (let [n (Array.count data)
-          sorted (Array.copy (Array.sort data sorter))]
+          sorted (Array.sort @data)]
       (if (= n 0)
         0.0
         @(Array.nth data (/ n 2)))))
 
   (defn grouped-median [data interval]
     (let [n (Array.count data)
-          sorted (Array.copy (Array.sort data sorter))]
+          sorted (Array.sort @data)]
       (cond (= n 0) 0.0
             (= n 1) @(Array.nth data 0)
             (let [x @(Array.nth data (/ n 2)) ; else
@@ -159,13 +156,13 @@
         (Double.+ lo (Double.* d (Double.- hi lo))))))
 
   (defn quartiles [data]
-    (let [tmp (Array.sort data sorter)
+    (let [tmp (Array.sort @data)
           first 25.0
           second 50.0
           third 75.0
-          a (percentile-of-sorted tmp first)
-          b (percentile-of-sorted tmp second)
-          c (percentile-of-sorted tmp third)]
+          a (percentile-of-sorted &tmp first)
+          b (percentile-of-sorted &tmp second)
+          c (percentile-of-sorted &tmp third)]
       [a b c]))
 
   (defn iqr [data]
@@ -173,7 +170,7 @@
       (the Double (- @(Array.nth s 2) @(Array.nth s 0)))))
 
   (defn winsorize [samples pct]
-    (let [tmp (the (Ref (Array Double)) (Array.sort samples sorter))
+    (let [tmp &(Array.sort @samples)
           lo (Statistics.percentile-of-sorted tmp pct)
           hi (Statistics.percentile-of-sorted tmp (Double.- 100.0 pct))]
       (do

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -169,7 +169,7 @@ templateNth =
 
 templateSort :: (String, Binder)
 templateSort = defineTypeParameterizedTemplate templateCreator path t
-  where path = (SymPath ["Array"] "sort")
+  where path = (SymPath ["Array"] "sort-with")
         vt = VarTy "t"
         t = (FuncTy [StructTy "Array" [vt], FuncTy [RefTy vt, RefTy vt] IntTy] (StructTy "Array" [vt]))
         templateCreator = TemplateCreator $

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -171,17 +171,17 @@ templateSort :: (String, Binder)
 templateSort = defineTypeParameterizedTemplate templateCreator path t
   where path = (SymPath ["Array"] "sort")
         vt = VarTy "t"
-        t = (FuncTy [RefTy (StructTy "Array" [vt]), FuncTy [RefTy vt, RefTy vt] IntTy] (RefTy (StructTy "Array" [vt])))
+        t = (FuncTy [StructTy "Array" [vt], FuncTy [RefTy vt, RefTy vt] IntTy] (StructTy "Array" [vt]))
         templateCreator = TemplateCreator $
           \typeEnv env ->
             Template
             t
-            (const (toTemplate "Array* $NAME (Array *a, $(Fn [(Ref t), (Ref t)] Int) f)"))
+            (const (toTemplate "Array $NAME (Array a, $(Fn [(Ref t), (Ref t)] Int) f)"))
             (const (toTemplate $ unlines ["$DECL {"
-                                         ,"    qsort(a->data, a->len, sizeof($t), (int(*)(const void*, const void*))f);"
+                                         ,"    qsort(a.data, a.len, sizeof($t), (int(*)(const void*, const void*))f);"
                                          ,"    return a;"
                                          ,"}"]))
-            (\(FuncTy [(RefTy arrayType), sortType] _) ->
+            (\(FuncTy [arrayType, sortType] _) ->
                [defineFunctionTypeAlias sortType
                ,defineArrayTypeAlias arrayType] ++
                depsForDeleteFunc typeEnv env arrayType)

--- a/test/array.carp
+++ b/test/array.carp
@@ -12,11 +12,6 @@
 
 (defn inc-ref [x] (+ @x 1))
 
-(defn cmp [a b]
-  (if (= @a @b)
-    0
-    (if (> @a @b) 1 -1)))
-
 (defn main []
   (let [a (range 0 9 1)
         b (Array.replicate 5 "Hi")]
@@ -98,7 +93,7 @@
       )
       (assert-equal test
                     &[1 2 3 4 5 6 7 8 9]
-                    (sort &(range 9 1 -1) cmp)
+                    &(sort (range 9 1 -1) cmp)
                     "sort works as expected"
       )
       (assert-equal test

--- a/test/array.carp
+++ b/test/array.carp
@@ -93,7 +93,7 @@
       )
       (assert-equal test
                     &[1 2 3 4 5 6 7 8 9]
-                    &(sort (range 9 1 -1) cmp)
+                    &(sort (range 9 1 -1))
                     "sort works as expected"
       )
       (assert-equal test


### PR DESCRIPTION
This PR canges the interface of `sort` from `Ref Array` to `Array`. We also introduce a function `cmp` that returns `0` when both of its arguments are equal, `-1` when the first is smaller than the second, and `1` otherwise. For this to work we also have to define `=`, `<`, and `>` for references to numeric types. In the long run, we should also implement `<` and `>` for other types (e.g. characters), in which case we should then also backport this change.

Cheers