### PR TITLE
Print macro error (warning) when using more then one expression in body

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -44,21 +44,23 @@
   (cond-internal xs))
 
 (defmacro for [settings body] ;; settings = variable, from, to, <step>
-  (list
-   'let
-   (array (car settings) (cadr settings))
-   (list
-    'while
-    (list 'Int.< (car settings) (caddr settings))
-    (list 'do
-          body
-          (list
-           'set! (list 'ref (car settings))
-           (list 'Int.+
-                 (car settings)
-                 (if (= 4 (count settings)) ;; optional arg for step
-                   (cadddr settings)
-                   1)))))))
+  (if (> (count body) 1) 
+    (macro-error "Warning: the body of the 'for' loop can only contain one expression")
+    (list
+     'let
+     (array (car settings) (cadr settings))
+     (list
+      'while
+      (list 'Int.< (car settings) (caddr settings))
+      (list 'do
+            body
+            (list
+             'set! (list 'ref (car settings))
+             (list 'Int.+
+                   (car settings)
+                   (if (= 4 (count settings)) ;; optional arg for step
+                     (cadddr settings)
+                     1))))))))
 
 (defmacro refstr [x]
   (list 'ref

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -43,7 +43,7 @@
 (defmacro cond [:rest xs]
   (cond-internal xs))
 
-(defmacro for [settings body] ;; settings = variable, from, to, <step>
+(defmacro for [settings :rest body] ;; settings = variable, from, to, <step>
   (if (> (count body) 1) 
     (macro-error "Warning: the body of the 'for' loop can only contain one expression")
     (list
@@ -53,7 +53,11 @@
       'while
       (list 'Int.< (car settings) (caddr settings))
       (list 'do
-            body
+            (if (= (count body) 0)
+              ()
+              (if (list? body)
+                (car body)
+                body))
             (list
              'set! (list 'ref (car settings))
              (list 'Int.+


### PR DESCRIPTION
Running this:
```
(use IO)

(defn main []
	(for [x 0 10]
		(println "test")
		(println "other")))
```
Prints lots of (10) `test`s, but **no** `other`: the rest of the for "body" is ignored in the macro.

I feel that `for` should be a `do` by default, though.