### PR TITLE
Array allocation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -116,6 +116,7 @@ arrayModule :: Env
 arrayModule = Env { envBindings = bindings, envParent = Nothing, envModuleName = Just "Array", envUseModules = [], envMode = ExternalEnv }
   where bindings = Map.fromList [ templateNth
                                 , templateAllocate
+                                , templateEMap
                                 , templateFilter
                                 , templateRaw
                                 , templateAset

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -116,8 +116,6 @@ arrayModule :: Env
 arrayModule = Env { envBindings = bindings, envParent = Nothing, envModuleName = Just "Array", envUseModules = [], envMode = ExternalEnv }
   where bindings = Map.fromList [ templateNth
                                 , templateAllocate
-                                , templateCopyingMap
-                                , templateEMap
                                 , templateFilter
                                 , templateRaw
                                 , templateAset

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,9 +115,7 @@ repl context readSoFar =
 arrayModule :: Env
 arrayModule = Env { envBindings = bindings, envParent = Nothing, envModuleName = Just "Array", envUseModules = [], envMode = ExternalEnv }
   where bindings = Map.fromList [ templateNth
-                                , templateReplicate
-                                , templateRepeat
-                                , templateRepeatIndexed
+                                , templateAllocate
                                 , templateCopyingMap
                                 , templateEMap
                                 , templateFilter

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -118,9 +118,6 @@
           (set! &e (+ e step))))
       x))
 
-  ;(defmacro push-back! [a e]
-  ;  (list 'set! a (list 'Array.push-back (list 'copy a) e)))
-
   (defn sort [a]
     (sort-with a cmp))
 
@@ -137,12 +134,6 @@
   (defn replicate [n e]
     (let-do [a (allocate n)]
       (for [i 0 n] (aset! &a i @e))
-      a))
-
-  (defn endo-map [f a]
-    (do
-      (for [i 0 (count &a)]
-        (aset! &a i (f @(nth &a i))))
       a))
 
   (defn copy-map [f a]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -138,4 +138,16 @@
     (let-do [a (allocate n)]
       (for [i 0 n] (aset! &a i @e))
       a))
+
+  (defn endo-map [f a]
+    (do
+      (for [i 0 (count &a)]
+        (aset! &a i (f @(nth &a i))))
+      a))
+
+  (defn copy-map [f a]
+    (let-do [na (allocate (count a))]
+      (for [i 0 (count a)]
+        (aset! &na i (f (nth a i))))
+      na))
 )

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -107,12 +107,14 @@
 
   ; cannot use for, because we want also be able to go downwards
   (defn range [start end step]
-    (let-do [x []
+    (let-do [x (allocate (Int.inc (Int.abs (/ (- end start) step))))
              e start
+             i 0
              op (if (< start end) <= >=)]
       (while (op e end)
         (do
-          (set! &x (push-back x e))
+          (aset! &x i e)
+          (set! &i (Int.inc i))
           (set! &e (+ e step))))
       x))
 
@@ -121,4 +123,19 @@
 
   (defn sort [a]
     (sort-with a cmp))
+
+  (defn repeat [n f]
+    (let-do [a (allocate n)]
+      (for [i 0 n] (aset! &a i (f)))
+      a))
+
+  (defn repeat-indexed [n f]
+    (let-do [a (allocate n)]
+      (for [i 0 n] (aset! &a i (f i)))
+      a))
+
+  (defn replicate [n e]
+    (let-do [a (allocate n)]
+      (for [i 0 n] (aset! &a i @e))
+      a))
 )

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -11,6 +11,28 @@ import Polymorphism
 import Concretize
 import Debug.Trace
 
+-- | "Endofunctor Map"
+templateEMap :: (String, Binder)
+templateEMap =
+  let fTy = FuncTy [VarTy "a"] (VarTy "a")
+      aTy = StructTy "Array" [VarTy "a"]
+      bTy = StructTy "Array" [VarTy "a"]
+  in  defineTemplate
+      (SymPath ["Array"] "endo-map")
+      (FuncTy [fTy, aTy] bTy)
+      (toTemplate "Array $NAME($(Fn [a] a) f, Array a)")
+      (toTemplate $ unlines
+        ["$DECL { "
+        ,"    for(int i = 0; i < a.len; ++i) {"
+        ,"        (($a*)a.data)[i] = f((($a*)a.data)[i]); "
+        ,"    }"
+        ,"    return a;"
+        ,"}"
+        ])
+      (\(FuncTy [t, arrayType] _) ->
+         [defineFunctionTypeAlias t,
+          defineArrayTypeAlias arrayType])
+
 templateFilter :: (String, Binder)
 templateFilter = defineTypeParameterizedTemplate templateCreator path t
   where

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -186,87 +186,6 @@ templateSort = defineTypeParameterizedTemplate templateCreator path t
                ,defineArrayTypeAlias arrayType] ++
                depsForDeleteFunc typeEnv env arrayType)
 
-templateReplicate :: (String, Binder)
-templateReplicate = defineTypeParameterizedTemplate templateCreator path t
-  where path = SymPath ["Array"] "replicate"
-        t = FuncTy [IntTy, RefTy (VarTy "t")] (StructTy "Array" [VarTy "t"])
-        templateCreator = TemplateCreator $
-          \typeEnv env ->
-             Template
-             t
-             (const (toTemplate "Array $NAME(int n, $t *elem)"))
-             (\(FuncTy [_, _] arrayType) ->
-                let StructTy _ [insideType] = arrayType
-                    copierType = FuncTy [RefTy insideType] insideType
-                    copierPath = if isManaged typeEnv insideType -- TODO: also check if it's an external function
-                                 then case nameOfPolymorphicFunction typeEnv env copierType "copy" of
-                                        Just p -> Just p
-                                        Nothing -> error ("Can't find copy function for array type: " ++ show insideType)
-                                 else Nothing
-                in
-                toTemplate $ unlines [ "$DECL {"
-                        , "    Array a; a.len = n; a.data = CARP_MALLOC(sizeof($t) * n);"
-                        , "    for(int i = 0; i < n; ++i) {"
-                        , "      (($t*)a.data)[i] = " ++ case copierPath of
-                                                           Just p -> pathToC p ++ "(elem);"
-                                                           Nothing -> "*elem;"
-                        , "    }"
-                        , "    return a;"
-                        , "}"])
-             (\(FuncTy [_, _] arrayType) ->
-                let StructTy _ [insideType] = arrayType
-                in defineArrayTypeAlias arrayType :
-                   depsForDeleteFunc typeEnv env arrayType ++
-                   depsForCopyFunc typeEnv env insideType)
-
-templateRepeat :: (String, Binder)
-templateRepeat = defineTypeParameterizedTemplate templateCreator path t
-  where path = SymPath ["Array"] "repeat"
-        t = FuncTy [IntTy, FuncTy [] (VarTy "t")] (StructTy "Array" [VarTy "t"])
-        templateCreator = TemplateCreator $
-          \typeEnv env ->
-             Template
-             t
-             (const (toTemplate "Array $NAME(int n, $(Fn [] t) f)"))
-             (const
-                (toTemplate $ unlines
-                  [ "$DECL {"
-                  , "    Array a; a.len = n; a.data = CARP_MALLOC(sizeof($t) * n);"
-                  , "    for(int i = 0; i < n; ++i) {"
-                  , "      (($t*)a.data)[i] = f();"
-                  , "    }"
-                  , "    return a;"
-                  , "}"]))
-             (\(FuncTy [_, ft] arrayType) ->
-                let StructTy _ [insideType] = arrayType
-                in  defineArrayTypeAlias arrayType : defineFunctionTypeAlias ft :
-                    depsForDeleteFunc typeEnv env arrayType)
-
-
-templateRepeatIndexed :: (String, Binder)
-templateRepeatIndexed = defineTypeParameterizedTemplate templateCreator path t
-  where path = SymPath ["Array"] "repeat-indexed"
-        t = FuncTy [IntTy, FuncTy [IntTy] (VarTy "t")] (StructTy "Array" [VarTy "t"])
-        templateCreator = TemplateCreator $
-          \typeEnv env ->
-             Template
-             t
-             (const (toTemplate "Array $NAME(int n, $(Fn [int] t) f)"))
-             (const
-                (toTemplate $ unlines
-                  [ "$DECL {"
-                  , "    Array a; a.len = n; a.data = CARP_MALLOC(sizeof($t) * n);"
-                  , "    for(int i = 0; i < n; ++i) {"
-                  , "      (($t*)a.data)[i] = f(i);"
-                  , "    }"
-                  , "    return a;"
-                  , "}"]))
-             (\(FuncTy [_, ft] arrayType) ->
-                let StructTy _ [insideType] = arrayType
-                in  defineArrayTypeAlias arrayType : defineFunctionTypeAlias ft :
-                    depsForDeleteFunc typeEnv env arrayType)
-
-
 templateRaw :: (String, Binder)
 templateRaw = defineTemplate
   (SymPath ["Array"] "raw")
@@ -320,6 +239,25 @@ templateCount = defineTypeParameterizedTemplate templateCreator path t
             (\(FuncTy [(RefTy arrayType)] _) ->
                [defineArrayTypeAlias arrayType] ++
               depsForDeleteFunc typeEnv env arrayType)
+
+templateAllocate :: (String, Binder)
+templateAllocate = defineTypeParameterizedTemplate templateCreator path t
+  where path = (SymPath ["Array"] "allocate")
+        t = (FuncTy [IntTy] (StructTy "Array" [VarTy "t"]))
+        templateCreator = TemplateCreator $
+          \typeEnv env ->
+            Template
+            t
+            (const (toTemplate "Array $NAME (int n)"))
+            (const (toTemplate $ unlines ["$DECL {"
+                                         ,"    Array a;"
+                                         ,"    a.len = n;"
+                                         ,"    a.data = CARP_MALLOC(n*sizeof($t));"
+                                         ,"    return a;"
+                                         ,"}"]))
+            (\(FuncTy [_] arrayType) ->
+               [defineArrayTypeAlias arrayType] ++
+               depsForDeleteFunc typeEnv env arrayType)
 
 templateDeleteArray :: (String, Binder)
 templateDeleteArray = defineTypeParameterizedTemplate templateCreator path t

--- a/test/array.carp
+++ b/test/array.carp
@@ -9,6 +9,7 @@
    [7 8 9]])
 
 (defn excl [x] (String.append x @"!"))
+(defn excl-ref [x] (String.append @x @"!"))
 
 (defn inc-ref [x] (+ @x 1))
 
@@ -105,6 +106,11 @@
                     &[1 2 3 4 5 6 7 8 9]
                     &(sort (range 9 1 -1))
                     "sort works as expected"
+      )
+      (assert-equal test
+                    &[@"Hi!" @"Hi!" @"Hi!" @"Hi!" @"Hi!"]
+                    &(copy-map excl-ref &b)
+                    "copy-map works as expected"
       )
       (assert-equal test
                     &[@"Hi!" @"Hi!" @"Hi!" @"Hi!" @"Hi!"]

--- a/test/array.carp
+++ b/test/array.carp
@@ -14,6 +14,7 @@
 (defn inc-ref [x] (+ @x 1))
 
 (defn make-zero [] 0)
+(defn make-idx [i] i)
 
 (defn main []
   (let [a (range 0 9 1)
@@ -36,6 +37,10 @@
                     &[0 0 0 0]
                     &(repeat 4 make-zero)
                     "repeat works as expected")
+      (assert-equal test
+                    &[0 1 2 3]
+                    &(repeat-indexed 4 make-idx)
+                    "repeat-indexed works as expected")
       (assert-equal test
                     1
                     (first &[1 2 3])

--- a/test/array.carp
+++ b/test/array.carp
@@ -12,6 +12,8 @@
 
 (defn inc-ref [x] (+ @x 1))
 
+(defn make-zero [] 0)
+
 (defn main []
   (let [a (range 0 9 1)
         b (Array.replicate 5 "Hi")]
@@ -25,6 +27,14 @@
       (assert-false test
                     (= &[1 2 3] &[1 2 34])
                     "= works as expected")
+      (assert-equal test
+                    &[0 0 0 0]
+                    &(replicate 4 &0)
+                    "replicate works as expected")
+      (assert-equal test
+                    &[0 0 0 0]
+                    &(repeat 4 make-zero)
+                    "repeat works as expected")
       (assert-equal test
                     1
                     (first &[1 2 3])


### PR DESCRIPTION
This PR addresses #125 by rewriting `repeat`, `replicate`, and both flavors of `map` in Carp. It also introduces `allocate` to obtain a fixed size array.

Test cases are included.

Cheers