### PR TITLE
Better loop start for Array.max/min

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -28,7 +28,7 @@
     (let [result (first xs)
           n (count xs)]
       (do
-        (for [i 0 n]
+        (for [i 1 n]
           (let [x @(nth xs i)]
             (if (< result x)
               (set! &result x)
@@ -39,7 +39,7 @@
     (let [result (first xs)
           n (count xs)]
       (do
-        (for [i 0 n]
+        (for [i 1 n]
           (let [x @(nth xs i)]
             (if (> result x)
               (set! &result x)


### PR DESCRIPTION
This PR fixes the loop start point for `Array.max` and `Array.min`. The loop used to start at `0`, but we already take the head of the array as a start point for the accumulator, so we don’t have to visit it again.

Cheers