### PR TITLE
Honor project title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,7 @@
 
 /CarpHask-exe.prof
 
-/out/*.so
-/out/.DS_Store
-/out/a.out
-/out/main.c
+/out/
 /.DS_Store
 /Carp.prof
 dist/

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -83,6 +83,7 @@ commandProjectSet [XObj (Str key) _ _, value] =
                       "echoC" -> return ctx { contextProj = proj { projectEchoC = (valueStr == "true") } }
                       "echoCompilationCommand" -> return ctx { contextProj = proj { projectEchoCompilationCommand = (valueStr == "true") } }
                       "compiler" -> return ctx { contextProj = proj { projectCompiler = valueStr } }
+                      "title"    -> return ctx { contextProj = proj { projectTitle = valueStr } }
                       _ -> err ("Unrecognized key: '" ++ key ++ "'") ctx
           put newCtx
           return dynamicNil
@@ -110,7 +111,7 @@ commandRunExe :: CommandCallback
 commandRunExe args =
   do ctx <- get
      let outDir = projectOutDir (contextProj ctx)
-         outExe = outDir ++ "a.out"
+         outExe = outDir ++ projectTitle (contextProj ctx)
      liftIO $ do handle <- spawnCommand outExe
                  exitCode <- waitForProcess handle
                  case exitCode of
@@ -146,8 +147,8 @@ commandBuild args =
                          flags = projectFlags proj ++ includeCorePath ++ switches
                          outDir = projectOutDir proj
                          outMain = outDir ++ "main.c"
-                         outExe = outDir ++ "a.out"
-                         outLib = outDir ++ "lib.so"
+                         outExe = outDir ++ projectTitle proj
+                         outLib = outDir ++ projectTitle proj
                      createDirectoryIfMissing False outDir
                      writeFile outMain (incl ++ okSrc)
                      case Map.lookup "main" (envBindings env) of


### PR DESCRIPTION
This PR changes the commands to actually honor the project title. This means that compilates will now not be named `a.out` or `lib.so` anymore, but will actually be called the project title.

I also simplified the handling of the `out/` directory in .gitignore. Because `keep.txt` is already part of the repository, that won’t change anything.

Cheers