### PR TITLE
Add defcompose macro

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -197,3 +197,11 @@
 
 (defmacro ignore [form]
   (let [_ form] ()))
+
+(defdynamic defcompose-internal [forms]
+  (if (= (count forms) 0)
+    'arg
+    (list (car forms) (defcompose-internal (cdr forms)))))
+
+(defmacro defcompose [name :rest forms]
+  (list 'defn name (array 'arg) (defcompose-internal forms)))

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -28,6 +28,8 @@
 (defmacro test-> [a b] (> a b))
 (defmacro test-= [a b] (= a b))
 
+(defcompose test-compose Int.inc Array.first)
+
 (defn main []
   (with-test test
     (assert-true test
@@ -211,5 +213,10 @@
                   "1@\" thing \"2@\" things\""
                   &(str* 1 " thing " 2 " things")
                   "str* macro works as expected"
+    )
+    (assert-equal test
+                  10
+                  (test-compose &[9])
+                  "defcompose macro expands as expected"
     )
     (print-test-results test)))


### PR DESCRIPTION
This PR adds the `defcompose` macro. It enables us to define functions in terms of compositions.

A test case is included.

Cheers