### PR TITLE
Fix errors in pattern parsing

### DIFF
--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -97,7 +97,7 @@ parseInternalPattern = do maybeAnchor <- Parsec.optionMaybe (Parsec.char '^')
             c <- Parsec.oneOf ['1', '2', '3', '4', '5', '6', '7', '8', '9',
                                'a', 'c', 'd', 'g', 'l', 'p', 's', 'u', 'w',
                                'x', 'n', 't', 'b', 'f', '[', ']', '\\', '$',
-                               '^']
+                               '(', ')', '^']
             case c of
               'b' -> do c1 <- Parsec.noneOf ['"']
                         c2 <- Parsec.noneOf ['"']
@@ -124,7 +124,8 @@ parseInternalPattern = do maybeAnchor <- Parsec.optionMaybe (Parsec.char '^')
             opening <- Parsec.char '['
             maybeAnchor <- Parsec.optionMaybe (Parsec.char '^')
             str <- Parsec.many (Parsec.try range <|>
-                                Parsec.many (Parsec.noneOf "-^$()[]\\\""))
+                                Parsec.try patternEscaped <|>
+                                Parsec.many1 (Parsec.noneOf "-^$()[]\\\""))
             closing <- Parsec.char ']'
             return $ "[" ++ unwrapMaybe maybeAnchor ++ concat str ++ "]"
 

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -97,7 +97,7 @@ parseInternalPattern = do maybeAnchor <- Parsec.optionMaybe (Parsec.char '^')
             c <- Parsec.oneOf ['1', '2', '3', '4', '5', '6', '7', '8', '9',
                                'a', 'c', 'd', 'g', 'l', 'p', 's', 'u', 'w',
                                'x', 'n', 't', 'b', 'f', '[', ']', '\\', '$',
-                               '(', ')', '^']
+                               '(', ')', '^', '"']
             case c of
               'b' -> do c1 <- Parsec.noneOf ['"']
                         c2 <- Parsec.noneOf ['"']


### PR DESCRIPTION
This PR fixes two bugs in the pattern parser.

The first bug is that the main parser of bracket classes was allowed to parse empty sequences infinitely (fixed by making the `many` catch-all parser a `many1`).

The second error was that within the escapes, I forgot to add a few characters that are allowed to be escaped.

Cheers