### PR TITLE
Update license notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Are you missing from the contributors list? Please send a pull request!
 
 ## License
 
-Copyright 2016 - 2017 Erik Svedäng
+Copyright 2016 - 2018 Erik Svedäng
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the license notice to 2018. We’re in March already! 😸 

Cheers