### PR TITLE
Add useful string functions

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -16,3 +16,41 @@
   (register delete     (Fn [Pattern] ()))
   (register copy       (Fn [&Pattern] Pattern))
 )
+
+(defmodule String
+  (defn in? [s sub]
+    (Pattern.matches? &(Pattern.init sub) s))
+
+  (defn upper? [s]
+    (Pattern.matches? #"^[\u\s\p]*$" s))
+
+  (defn lower? [s]
+    (Pattern.matches? #"^[\l\s\p]*$" s))
+
+  (defn num? [s]
+    (Pattern.matches? #"^[0-9]*$" s))
+
+  (defn alpha? [s]
+    (Pattern.matches? #"^[\u\l]*$" s))
+
+  (defn alphanum? [s]
+    (Pattern.matches? #"^[\w]*$" s))
+
+  (defn hex? [s]
+    (Pattern.matches? #"^[\x]*$" s))
+
+  (defn trim-left [s]
+    (Pattern.substitute #"^\s+" s "" 1))
+
+  (defn trim-right [s]
+    (Pattern.substitute #"\s+$" s "" 1))
+
+  (defn trim [s]
+    (trim-left &(trim-right s)))
+
+  (defn chomp [s]
+    (Pattern.substitute #"\n$" s "" 1))
+
+  (defn collapse-whitespace [s]
+    (Pattern.substitute #"\s+" s " " -1))
+)

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -622,6 +622,9 @@ string Pattern_substitute(pattern* p, string *s, string *t, int ns) {
     else break;  /* end of subject */
     if (anchor) break;
   }
+
+  if (!res) return String_copy(&str);
+
   int l = strlen(res)+strlen(str)+1;
   res = realloc(res, l);
   snprintf(res, l, "%s%s", res, str);

--- a/test/string.carp
+++ b/test/string.carp
@@ -45,10 +45,9 @@
                   (empty? "lisp")
                   "empty? returns false on non-empty string"
     )
-    (assert-equal test
-                  true
-                  (empty? "")
-                  "empty? returns true on empty string"
+    (assert-true test
+                 (empty? "")
+                 "empty? returns true on empty string"
     )
     (assert-equal test
                   &[\e \r \i \k]
@@ -75,20 +74,114 @@
                   &(suffix-string "svedang" 3)
                   "suffix-string works as expected"
     )
-    (assert-equal test
-                  true
-                  (ends-with? "heller" "ler")
-                  "ends-with? works as expected"
+    (assert-true test
+                 (ends-with? "heller" "ler")
+                 "ends-with? works as expected"
+    )
+    (assert-true test
+                 (ends-with? "ller" "ler")
+                 "ends-with? works (regression test for #157)"
+    )
+    (assert-true test
+                 (starts-with? "heller" "hell")
+                 "starts-with? works as expected"
+    )
+    (assert-true test
+                 (in? "metacarpenter" "carp")
+                 "in? works on matching pattern"
+    )
+    (assert-false test
+                  (in? "metabolism" "carp")
+                  "in? works on non-matching pattern"
+    )
+    (assert-true test
+                 (upper? "I AM SCREAMING!")
+                 "upper? works on matching pattern"
+    )
+    (assert-false test
+                  (upper? "I am not screaming.")
+                  "upper? works on non-matching pattern"
+    )
+    (assert-true test
+                 (lower? "i am not screaming.")
+                 "lower? works on matching pattern"
+    )
+    (assert-false test
+                  (lower? "I am not screaming!")
+                  "lower? works on non-matching pattern"
+    )
+    (assert-true test
+                 (num? "11123456789123")
+                 "num? works on matching pattern"
+    )
+    (assert-false test
+                  (num? "111l23456789123")
+                  "num? works on non-matching pattern"
+    )
+    (assert-true test
+                 (alpha? "abcdefghijklmz")
+                 "alpha? works on matching pattern"
+    )
+    (assert-false test
+                  (alpha? "abcdefghijklm1234567")
+                  "alpha? works on non-matching pattern"
+    )
+    (assert-true test
+                 (alphanum? "abcdefghijklm1234567")
+                 "alphanum? works on matching pattern"
+    )
+    (assert-false test
+                  (alphanum? "abcdefghijklm1234567?")
+                  "alphanum? works on non-matching pattern"
+    )
+    (assert-true test
+                 (hex? "c0ffee")
+                 "hex? works on matching pattern"
+    )
+    (assert-false test
+                  (hex? "c0ffeebar")
+                  "hex? works on non-matching pattern"
     )
     (assert-equal test
-                  true
-                  (ends-with? "ller" "ler")
-                  "ends-with? works (regression test for #157)"
+                  "string  "
+                  &(trim-left "   string  ")
+                  "trim-left works as expected"
     )
     (assert-equal test
-                  true
-                  (starts-with? "heller" "hell")
-                  "starts-with? works as expected"
+                  "   string"
+                  &(trim-right "   string  ")
+                  "trim-right works as expected"
+    )
+    (assert-equal test
+                  "string"
+                  &(trim "   string  ")
+                  "trim works as expected"
+    )
+    (assert-equal test
+                  "string"
+                  &(chomp "string\n")
+                  "chomp works as expected I"
+    )
+    (assert-equal test
+                  "string\n"
+                  &(chomp "string\n\n")
+                  "chomp works as expected II"
+    )
+    (assert-equal test
+                  "string"
+                  &(chomp "string\r\n")
+                  "chomp works as expected III"
+    )
+    (assert-equal test
+                  "string"
+                  &(chomp "string\r")
+                  "chomp works as expected IV"
+    )
+    (assert-equal test
+                  "too much whitespace."
+                  &(collapse-whitespace "too   much  whitespace.")
+                  "collapse-whitespace works as expected"
     )
     (print-test-results test)
-))
+  )
+)


### PR DESCRIPTION
This PR adds a few useful string functions, as asked for in #94. It is not a complete port of the Emacs string library, but we’re getting there.

This PR introduces:
- `(in? s sub) : (Fn [&String &String] Bool)`: checks whether `sub` is contained in `sub`
- `(upper? s) : (Fn [&String] Bool)`: checks whether `s` only contains upper-case characters (or rather, anything but lower-case).
- `(lower? s) : (Fn [&String] Bool)`: checks whether `s` only contains lower-case characters (or rather, anything but upper-case).
- `(num? s) : (Fn [&String] Bool)`: checks whether `s` is numerical.
- `(alpha? s) : (Fn [&String] Bool)`: checks whether `s` is alphabetical.
- `(alphanum? s) : (Fn [&String] Bool)`: checks whether `s` is alphanumerical.
- `(hex? s) : (Fn [&String] Bool)`: checks whether `s` is hexadecimal.
- `(trim-left s) : (Fn [&String] String)`: Trims whitespace on the left side of `s`.
- `(trim-right s) : (Fn [&String] String)`: Trims whitespace on the right side of `s`.
- `(trim s) : (Fn [&String] String)`: Trims whitespace on both sides of `s`.
- `(chomp s) : (Fn [&String] String)`: Removes trailing `\n`, `\r`, or `\r\n`.
- `(collapse-whitespace s) : (Fn [&String] String)`: Collapses whitespace clusters into single whitespace.

Test cases are included.

Cheers