### PR TITLE
Simplify split-by

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -15,6 +15,9 @@
   (register =    (Fn [&Pattern &Pattern] Bool))
   (register delete     (Fn [Pattern] ()))
   (register copy       (Fn [&Pattern] Pattern))
+
+  (defn from-chars [chars]
+    (Pattern.init &(string-join @"[" (String.from-chars chars) @"]")))
 )
 
 (defmodule String
@@ -53,4 +56,22 @@
 
   (defn collapse-whitespace [s]
     (Pattern.substitute #"\s+" s " " -1))
+
+  (defn split-by [_s separators]
+    (let-do [s @_s
+             result (the (Array String) [])
+             pat (Pattern.from-chars separators)
+             idx (Pattern.find &pat &s)]
+      (while (Int./= idx -1)
+        (do
+          (set! result (Array.push-back result (prefix-string &s idx)))
+          (set! s (suffix-string &s (+ idx 1)))
+          (set! idx (Pattern.find &pat &s))))
+      (Array.push-back result s)))
+
+  (defn words [s]
+    (split-by s &[\tab \space]))
+
+  (defn lines [s]
+    (split-by s &[\newline]))
 )

--- a/core/String.carp
+++ b/core/String.carp
@@ -30,35 +30,6 @@
           (set! str (append str @inpt)))
         str)))
 
-  ;; A temporary version of this function, until we have some nicer way to write it
-  (defn split-by [s separators]
-    (let [len (count &s)
-          result (the (Array String) [])
-          cs (chars &s)
-          word @""]
-      (do
-        (for [i 0 len]
-          (let [c (Array.nth &cs i)]
-            (do
-              (if (Int.< 0 (Array.element-count &(the (Array Char) @&separators) c))
-                (if (= 0 (String.count &word))
-                  () ;; no word
-                  (do (set! result (Array.push-back @&result @&word))
-                      (set! word @"")))
-                (set! word (append @&word (from-chars &[@c])))))))
-        ;; Some sweet code duplication for the final word:
-        (if (= 0 (String.count &word))
-          ()
-          (do (set! result (Array.push-back @&result @&word))
-              (set! word @"")))
-        result)))
-
-  (defn words [s]
-    (split-by s [\space \tab]))
-
-  (defn lines [s]
-    (split-by s [\newline]))
-
   (defn pad-left [len pad s]
     (let [x (Int.max 0 (- len (count s)))]
       (append (from-chars &(Array.replicate x &pad)) @s)))

--- a/test/string.carp
+++ b/test/string.carp
@@ -182,6 +182,21 @@
                   &(collapse-whitespace "too   much  whitespace.")
                   "collapse-whitespace works as expected"
     )
+    (assert-equal test
+                  &[@"erik" @"sved" @"hej" @"foo"]
+                  &(words "erik sved hej\tfoo")
+                  "words works correctly"
+    )
+    (assert-equal test
+                  &[@"erik" @"sved" @"hej" @"foo"]
+                  &(lines "erik\nsved\nhej\nfoo")
+                  "lines works correctly"
+    )
+    (assert-equal test
+                  &[@"erik" @"sved" @"hej" @"foo"]
+                  &(split-by "erikmsvedlhejxfoo" &[\m \l \x])
+                  "split-by works correctly"
+    )
     (print-test-results test)
   )
 )


### PR DESCRIPTION
This PR simplifies `split-by`. To that end, it introduces the function `Pattern.from-chars`.

Cheers