### PR TITLE
Adding time.h header to carp_bench.h to resolve bug #208

### DIFF
--- a/core/carp_bench.h
+++ b/core/carp_bench.h
@@ -1,4 +1,4 @@
-#include <sys/time.h>
+#include <time.h>
 
 double get_MINUS_time_MINUS_elapsed() {
   struct timespec tv;


### PR DESCRIPTION
Under POSIX clock_gettime and timespec are defined in time.h
I don't think we need sys/time.h