### PR TITLE
Add System.args

### DIFF
--- a/core/System.carp
+++ b/core/System.carp
@@ -7,6 +7,7 @@
   (register sleep-seconds (Fn [Int] ()))
   (register sleep-micros (Fn [Int] ()))
   (register system (Fn [&String] ()))
+  (register args (Array String))
 )
 
 (defmodule Int

--- a/core/System.carp
+++ b/core/System.carp
@@ -7,7 +7,8 @@
   (register sleep-seconds (Fn [Int] ()))
   (register sleep-micros (Fn [Int] ()))
   (register system (Fn [&String] ()))
-  (register args (Array String))
+  (register get-arg (Fn [Int] (Ref String)))
+  (register get-args-len (Fn [] Int))
 )
 
 (defmodule Int

--- a/core/carp_system.h
+++ b/core/carp_system.h
@@ -40,3 +40,14 @@ int Int_random_MINUS_between(int lower, int upper) {
 void System_system(String *command) {
     system(*command);
 }
+
+Array System_args;
+
+String* System_get_MINUS_arg(int idx) {
+    assert(idx < System_args.len);
+    return &(((String*)System_args.data)[idx]);
+}
+
+int System_get_MINUS_args_MINUS_len() {
+    return System_args.len;
+}

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -168,8 +168,6 @@ toC toCMode root = emitterSrc (execState (visit startingIndent root) (EmitterSta
                      delete innerIndent i
                      when (retTy /= UnitTy) $
                        appendToSrc (addIndent innerIndent ++ "return " ++ ret ++ ";\n")
-                     when (name == "main") $
-                       appendToSrc (addIndent innerIndent ++ "Array_delete__String(System_args);\n")
                      appendToSrc "}\n\n"
                      return ""
 
@@ -637,14 +635,9 @@ checkForUnresolvedSymbols = visit
 
 wrapInInitFunction :: String -> String
 wrapInInitFunction src =
-  "Array System_args;\n\n" ++
   "void carp_init_globals(int argc, char** argv) {\n" ++
   "  System_args.len = argc;\n" ++
-  "  System_args.data = CARP_MALLOC(argc*sizeof(String));\n" ++
-  "  for (int i = 0; i < argc; i++) {\n" ++
-  "    ((String*)System_args.data)[i] = malloc(strlen(argv[i])+1);\n" ++
-  "    strcpy(((String*)System_args.data)[i], argv[i]);\n" ++
-  "  }\n" ++
+  "  System_args.data = argv;\n" ++
   src ++
   "}"
 

--- a/test/args.carp
+++ b/test/args.carp
@@ -1,3 +1,3 @@
 (defn main []
-  (for [i 0 (Array.count &System.args)]
-    (IO.println (Array.nth &System.args i))))
+  (for [i 0 (System.get-args-len)]
+    (IO.println (System.get-arg i))))

--- a/test/args.carp
+++ b/test/args.carp
@@ -1,0 +1,3 @@
+(defn main []
+  (for [i 0 (Array.count &System.args)]
+    (IO.println (Array.nth &System.args i))))


### PR DESCRIPTION
**This should be considered a WIP/RFC.**

This PR adds `System.args`, which is a Carp version of C’s `argc`/`argv` pair.

The system with which these are injected are pretty shoddy and rely on handrolled C, because I wasn’t entirely sure how to reuse the array templates here. It also relies on `Array_delete__String`, but doesn’t require it (again because I’m not sure how to do that when we’re emitting C).

Another open question for now: this requires us to readd a `malloc` dependency in `main`. We explicitly removed this a while ago to make it possible to rewrite a bunch of `core` for embedded systems if desired. How can we make sure this doesn’t break then? We could wrap it in an `ifdef` or such...

Cheers