### PR TITLE
Test for signals and exit stati

### DIFF
--- a/core/System.carp
+++ b/core/System.carp
@@ -15,5 +15,8 @@
   (register get-arg (Fn [Int] (Ref String)))
   (doc get-arg "Gets the number of command line arguments.")
   (register get-args-len (Fn [] Int))
+  (register fork (Fn [] Int) "fork")
+  (register wait (Fn [(Ptr Int)] Int) "wait")
+  (register get-exit-status (Fn [Int] Int) "WEXITSTATUS")
 )
 

--- a/core/System.carp
+++ b/core/System.carp
@@ -18,5 +18,12 @@
   (register fork (Fn [] Int) "fork")
   (register wait (Fn [(Ptr Int)] Int) "wait")
   (register get-exit-status (Fn [Int] Int) "WEXITSTATUS")
+  (register signal (Fn [Int (Fn [Int] ())] ()) "signal")
+  (register signal-abort Int "SIGABRT")
+  (register signal-fpe Int "SIGFPE")
+  (register signal-ill Int "SIGILL")
+  (register signal-int Int "SIGINT")
+  (register signal-segv Int "SIGSEGV")
+  (register signal-term Int "SIGTERM")
 )
 

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -77,6 +77,18 @@
   (defn reset [state]
     (State.set-failed (State.set-passed state 0) 0))
 
+  (defn run-child [x]
+    (let [pid (System.fork)
+          status 0]
+      (if (= pid 0)
+        (x)
+        (do
+          (ignore (System.wait (address status)))
+          (System.get-exit-status status)))))
+
+  (defn assert-fails [state exit-code x descr]
+    (assert-equal state exit-code (run-child x) descr))
+
   (defn print-test-results [state]
     (let [passed @(State.passed state)
           failed @(State.failed state)]

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -81,13 +81,36 @@
     (let [pid (System.fork)
           status 0]
       (if (= pid 0)
-        (x)
+        (do
+          (x)
+          0)
         (do
           (ignore (System.wait (address status)))
           (System.get-exit-status status)))))
 
-  (defn assert-fails [state exit-code x descr]
+  (defn handle-signal [x] (System.exit x))
+
+  (defn run-child-signals [x]
+    (let [pid (System.fork)
+          status 0]
+      (if (= pid 0)
+        (do
+          (System.signal System.signal-abort handle-signal)
+          (System.signal System.signal-fpe handle-signal)
+          (System.signal System.signal-ill handle-signal)
+          (System.signal System.signal-segv handle-signal)
+          (System.signal System.signal-term handle-signal)
+          (x)
+          0)
+        (do
+          (ignore (System.wait (address status)))
+          (System.get-exit-status status)))))
+
+  (defn assert-exit [state exit-code x descr]
     (assert-equal state exit-code (run-child x) descr))
+
+  (defn assert-signal [state signal x descr]
+    (assert-equal state signal (run-child-signals x) descr))
 
   (defn print-test-results [state]
     (let [passed @(State.passed state)


### PR DESCRIPTION
This PR introduces two functions into the test suite, called `Test.assert-exit` and `Test.assert-signal` that assert that a given function exits with a given status code or creates a certain signal, respectively.

This is useful for testing error conditions.

To make this work a few functions had to be added to the `System` module—but none to C—, namely `fork`, `wait`, and `signal`. A macro for getting the exit status of a child process called `WEXITSTATUS` had to be wrapped (we call it `get-exit-status`). So did the various signals; in Carp they were renamed from `SIG*` to `signal-*` to make the interface a little more idiomatic.

Cheers