### PR TITLE
Adding missing includes headers for POSIX wait and signals

### DIFF
--- a/core/core.h
+++ b/core/core.h
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <sys/wait.h>
+#include <signal.h>
 
 typedef char* String;
 typedef char* Pattern;


### PR DESCRIPTION
Fixing build & test on Linux.

These headers are required as part of POSIX, so it is surprising it ever worked on Mac.

This built and passed all tests on my Travis for Linux and Mac.