### PR TITLE
repl: put history file into .carp dir

### DIFF
--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -72,7 +72,7 @@ readlineSettings = do
   home <- getHomeDirectory
   return $ Settings {
     complete = completeWordWithPrev Nothing ['(', ')', '[', ']', ' ', '\t', '\n'] completeKeywords,
-    historyFile = Just $ home ++ "/.carp_history",
+    historyFile = Just $ home ++ "/.carp/history",
     autoAddHistory = True
   }
 


### PR DESCRIPTION
This PR moves the Carp history file from `~/.carp_history` to `~/.carp/history`. This removes clutter from the home directory and puts all of the things into one place.

Cheers