### PR TITLE
docs: Change to pretty rendering

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -51,7 +51,8 @@ library
                      , filepath
                      , split
                      , haskeline
-                     , lucid
+                     , blaze-html
+                     , blaze-markup
                      , text
 
   default-language:    Haskell2010

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -1,1 +1,1060 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Array</h1><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), (Ref (Array a))] Bool)</p><pre class="args">(/= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), (Ref (Array a))] Bool)</p><pre class="args">(= a b)</pre><p class="doc">Compare two arrays.</p></div><div class="binder"><a href="#allocate" class="anchor"><h3 id="allocate">allocate</h3></a><div class="description">template</div><p class="sig">(λ [Int] (Array t))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#aset" class="anchor"><h3 id="aset">aset</h3></a><div class="description">template</div><p class="sig">(λ [(Array t), Int, t] (Array t))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#aset!" class="anchor"><h3 id="aset!">aset!</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array t)), Int, t] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#aset-uninitialized!" class="anchor"><h3 id="aset-uninitialized!">aset-uninitialized!</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array t)), Int, t] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#aupdate" class="anchor"><h3 id="aupdate">aupdate</h3></a><div class="description">defn</div><p class="sig">(λ [(Array a), Int, (λ [&amp;a] a)] (Array a))</p><pre class="args">(aupdate a i f)</pre><p class="doc">Transmute the element at index i of array a using function f.</p></div><div class="binder"><a href="#aupdate!" class="anchor"><h3 id="aupdate!">aupdate!</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), Int, (λ [&amp;a] a)] ())</p><pre class="args">(aupdate! a i f)</pre><p class="doc">Transmute the element at index i of array a using function f in place.</p></div><div class="binder"><a href="#concat" class="anchor"><h3 id="concat">concat</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array (Array a)))] (Array a))</p><pre class="args">(concat xs)</pre><p class="doc">Returns a new Array which is the concatenation of the provided `xs`.</p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array a))] (Array a))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#copy-map" class="anchor"><h3 id="copy-map">copy-map</h3></a><div class="description">defn</div><p class="sig">(λ [(λ [&amp;a] b), (Ref (Array a))] (Array b))</p><pre class="args">(copy-map f a)</pre><p class="doc">Map over array a using function f (copies the array).</p></div><div class="binder"><a href="#delete" class="anchor"><h3 id="delete">delete</h3></a><div class="description">template</div><p class="sig">(λ [(Array a)] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#element-count" class="anchor"><h3 id="element-count">element-count</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), &amp;a] Int)</p><pre class="args">(element-count a e)</pre><p class="doc">Count occurrences of element e in an array.</p></div><div class="binder"><a href="#endo-map" class="anchor"><h3 id="endo-map">endo-map</h3></a><div class="description">template</div><p class="sig">(λ [(λ [a] a), (Array a)] (Array a))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#enumerated" class="anchor"><h3 id="enumerated">enumerated</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] (Array (Pair Int a)))</p><pre class="args">(enumerated xs)</pre><p class="doc">Create a new array of Pair:s where the first position is the index and the second position is the element from the original array.</p></div><div class="binder"><a href="#filter" class="anchor"><h3 id="filter">filter</h3></a><div class="description">template</div><p class="sig">(λ [(λ [&amp;a] Bool), (Array a)] (Array a))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#first" class="anchor"><h3 id="first">first</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] a)</p><pre class="args">(first a)</pre><p class="doc">Take the first element of an array.</p></div><div class="binder"><a href="#index-of" class="anchor"><h3 id="index-of">index-of</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), a] Int)</p><pre class="args">(index-of a e)</pre><p class="doc">Get the index of element e in an array.</p></div><div class="binder"><a href="#last" class="anchor"><h3 id="last">last</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] a)</p><pre class="args">(last a)</pre><p class="doc">Take the last element of an array.</p></div><div class="binder"><a href="#length" class="anchor"><h3 id="length">length</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array t))] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#maximum" class="anchor"><h3 id="maximum">maximum</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] a)</p><pre class="args">(maximum xs)</pre><p class="doc">Get the maximum in an array (elements must support &lt;).</p></div><div class="binder"><a href="#minimum" class="anchor"><h3 id="minimum">minimum</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] a)</p><pre class="args">(minimum xs)</pre><p class="doc">Sum an array (elements must support + and zero).</p></div><div class="binder"><a href="#nth" class="anchor"><h3 id="nth">nth</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array t)), Int] &amp;t)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#pop-back" class="anchor"><h3 id="pop-back">pop-back</h3></a><div class="description">template</div><p class="sig">(λ [(Array a)] (Array a))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#pop-back!" class="anchor"><h3 id="pop-back!">pop-back!</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array a))] a)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#prefix-array" class="anchor"><h3 id="prefix-array">prefix-array</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), Int] (Array a))</p><pre class="args">(prefix-array xs end-index)</pre><p class="doc">Get prefix-array to end-index.</p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] String)</p><pre class="args">(prn x)</pre><p class="doc"></p></div><div class="binder"><a href="#push-back" class="anchor"><h3 id="push-back">push-back</h3></a><div class="description">template</div><p class="sig">(λ [(Array a), a] (Array a))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#push-back!" class="anchor"><h3 id="push-back!">push-back!</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array a)), a] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#range" class="anchor"><h3 id="range">range</h3></a><div class="description">defn</div><p class="sig">(λ [Int, Int, Int] (Array Int))</p><pre class="args">(range start end step)</pre><p class="doc">Create an array from start to end with step between them (the elements must support &lt;, &lt;=, and &gt;=).</p></div><div class="binder"><a href="#raw" class="anchor"><h3 id="raw">raw</h3></a><div class="description">template</div><p class="sig">(λ [(Array t)] (Ptr t))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#reduce" class="anchor"><h3 id="reduce">reduce</h3></a><div class="description">defn</div><p class="sig">(λ [(λ [&amp;a, &amp;b] a), a, (Ref (Array b))] a)</p><pre class="args">(reduce f x xs)</pre><p class="doc">Reduce an array, using the function f.</p></div><div class="binder"><a href="#repeat" class="anchor"><h3 id="repeat">repeat</h3></a><div class="description">defn</div><p class="sig">(λ [Int, (λ [] a)] (Array a))</p><pre class="args">(repeat n f)</pre><p class="doc">Repeat function f n times and store the results in an array.</p></div><div class="binder"><a href="#repeat-indexed" class="anchor"><h3 id="repeat-indexed">repeat-indexed</h3></a><div class="description">defn</div><p class="sig">(λ [Int, (λ [Int] a)] (Array a))</p><pre class="args">(repeat-indexed n f)</pre><p class="doc">Repeat function f n times and store the results in an array (will be supplied with the index).</p></div><div class="binder"><a href="#replicate" class="anchor"><h3 id="replicate">replicate</h3></a><div class="description">defn</div><p class="sig">(λ [Int, &amp;a] (Array a))</p><pre class="args">(replicate n e)</pre><p class="doc">Repeat element e n times and store the results in an array.</p></div><div class="binder"><a href="#reverse" class="anchor"><h3 id="reverse">reverse</h3></a><div class="description">defn</div><p class="sig">(λ [(Array a)] (Array a))</p><pre class="args">(reverse a)</pre><p class="doc">Reverse an array.</p></div><div class="binder"><a href="#sort" class="anchor"><h3 id="sort">sort</h3></a><div class="description">defn</div><p class="sig">(λ [(Array a)] (Array a))</p><pre class="args">(sort arr)</pre><p class="doc">Perform an in-place heapsort of a given owned array.</p></div><div class="binder"><a href="#sort!" class="anchor"><h3 id="sort!">sort!</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] ())</p><pre class="args">(sort! arr)</pre><p class="doc">Perform an in-place heapsort of a given array.</p></div><div class="binder"><a href="#sorted" class="anchor"><h3 id="sorted">sorted</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] (Array a))</p><pre class="args">(sorted arr)</pre><p class="doc">Perform a heapsort in a new copy of given array.</p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Array a))] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#subarray" class="anchor"><h3 id="subarray">subarray</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), Int, Int] (Array a))</p><pre class="args">(subarray xs start-index end-index)</pre><p class="doc">Get subarray from start-index to end-index.</p></div><div class="binder"><a href="#suffix-array" class="anchor"><h3 id="suffix-array">suffix-array</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), Int] (Array a))</p><pre class="args">(suffix-array xs start-index)</pre><p class="doc">Get subarray from start-index.</p></div><div class="binder"><a href="#sum" class="anchor"><h3 id="sum">sum</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a))] a)</p><pre class="args">(sum xs)</pre><p class="doc"></p></div><div class="binder"><a href="#sum-length" class="anchor"><h3 id="sum-length">sum-length</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array (Array a)))] Int)</p><pre class="args">(sum-length xs)</pre><p class="doc">Returns the sum of lengths from an Array of Arrays.</p></div><div class="binder"><a href="#swap" class="anchor"><h3 id="swap">swap</h3></a><div class="description">defn</div><p class="sig">(λ [(Array a), Int, Int] (Array a))</p><pre class="args">(swap a i j)</pre><p class="doc">Swap indices i and j of array a.</p></div><div class="binder"><a href="#swap!" class="anchor"><h3 id="swap!">swap!</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array a)), Int, Int] ())</p><pre class="args">(swap! a i j)</pre><p class="doc">Swap indices i and j of array a in place.</p></div><div class="binder"><a href="#zero" class="anchor"><h3 id="zero">zero</h3></a><div class="description">defn</div><p class="sig">(λ [] (Array a))</p><pre class="args">(zero)</pre><p class="doc">Returns the empty array.</p></div><div class="binder"><a href="#zip" class="anchor"><h3 id="zip">zip</h3></a><div class="description">defn</div><p class="sig">(λ [(λ [&amp;a, &amp;b] c), (Ref (Array a)), (Ref (Array b))] (Array c))</p><pre class="args">(zip f a b)</pre><p class="doc">Map over two arrays using a function that takes two arguments. Produces a new array with the length of the shorter input.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Array
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), (Ref (Array a))] Bool)
+                </p>
+                <pre class="args">
+                    (/= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), (Ref (Array a))] Bool)
+                </p>
+                <pre class="args">
+                    (= a b)
+                </pre>
+                <p class="doc">
+                    Compare two arrays.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#allocate">
+                    <h3 id="allocate">
+                        allocate
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [Int] (Array t))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#aset">
+                    <h3 id="aset">
+                        aset
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Array t), Int, t] (Array t))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#aset!">
+                    <h3 id="aset!">
+                        aset!
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array t)), Int, t] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#aset-uninitialized!">
+                    <h3 id="aset-uninitialized!">
+                        aset-uninitialized!
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array t)), Int, t] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#aupdate">
+                    <h3 id="aupdate">
+                        aupdate
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Array a), Int, (λ [&amp;a] a)] (Array a))
+                </p>
+                <pre class="args">
+                    (aupdate a i f)
+                </pre>
+                <p class="doc">
+                    Transmute the element at index i of array a using function f.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#aupdate!">
+                    <h3 id="aupdate!">
+                        aupdate!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), Int, (λ [&amp;a] a)] ())
+                </p>
+                <pre class="args">
+                    (aupdate! a i f)
+                </pre>
+                <p class="doc">
+                    Transmute the element at index i of array a using function f in place.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#concat">
+                    <h3 id="concat">
+                        concat
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array (Array a)))] (Array a))
+                </p>
+                <pre class="args">
+                    (concat xs)
+                </pre>
+                <p class="doc">
+                    Returns a new Array which is the concatenation of the provided `xs`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] (Array a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy-map">
+                    <h3 id="copy-map">
+                        copy-map
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(λ [&amp;a] b), (Ref (Array a))] (Array b))
+                </p>
+                <pre class="args">
+                    (copy-map f a)
+                </pre>
+                <p class="doc">
+                    Map over array a using function f (copies the array).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Array a)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#element-count">
+                    <h3 id="element-count">
+                        element-count
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), &amp;a] Int)
+                </p>
+                <pre class="args">
+                    (element-count a e)
+                </pre>
+                <p class="doc">
+                    Count occurrences of element e in an array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#endo-map">
+                    <h3 id="endo-map">
+                        endo-map
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(λ [a] a), (Array a)] (Array a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#enumerated">
+                    <h3 id="enumerated">
+                        enumerated
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] (Array (Pair Int a)))
+                </p>
+                <pre class="args">
+                    (enumerated xs)
+                </pre>
+                <p class="doc">
+                    Create a new array of Pair:s where the first position is the index and the second position is the element from the original array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#filter">
+                    <h3 id="filter">
+                        filter
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(λ [&amp;a] Bool), (Array a)] (Array a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#first">
+                    <h3 id="first">
+                        first
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] a)
+                </p>
+                <pre class="args">
+                    (first a)
+                </pre>
+                <p class="doc">
+                    Take the first element of an array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#index-of">
+                    <h3 id="index-of">
+                        index-of
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), a] Int)
+                </p>
+                <pre class="args">
+                    (index-of a e)
+                </pre>
+                <p class="doc">
+                    Get the index of element e in an array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#last">
+                    <h3 id="last">
+                        last
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] a)
+                </p>
+                <pre class="args">
+                    (last a)
+                </pre>
+                <p class="doc">
+                    Take the last element of an array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#length">
+                    <h3 id="length">
+                        length
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array t))] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#maximum">
+                    <h3 id="maximum">
+                        maximum
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] a)
+                </p>
+                <pre class="args">
+                    (maximum xs)
+                </pre>
+                <p class="doc">
+                    Get the maximum in an array (elements must support &lt;).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#minimum">
+                    <h3 id="minimum">
+                        minimum
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] a)
+                </p>
+                <pre class="args">
+                    (minimum xs)
+                </pre>
+                <p class="doc">
+                    Sum an array (elements must support + and zero).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#nth">
+                    <h3 id="nth">
+                        nth
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array t)), Int] &amp;t)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pop-back">
+                    <h3 id="pop-back">
+                        pop-back
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Array a)] (Array a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pop-back!">
+                    <h3 id="pop-back!">
+                        pop-back!
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] a)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prefix-array">
+                    <h3 id="prefix-array">
+                        prefix-array
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), Int] (Array a))
+                </p>
+                <pre class="args">
+                    (prefix-array xs end-index)
+                </pre>
+                <p class="doc">
+                    Get prefix-array to end-index.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] String)
+                </p>
+                <pre class="args">
+                    (prn x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#push-back">
+                    <h3 id="push-back">
+                        push-back
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Array a), a] (Array a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#push-back!">
+                    <h3 id="push-back!">
+                        push-back!
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), a] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#range">
+                    <h3 id="range">
+                        range
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, Int, Int] (Array Int))
+                </p>
+                <pre class="args">
+                    (range start end step)
+                </pre>
+                <p class="doc">
+                    Create an array from start to end with step between them (the elements must support &lt;, &lt;=, and &gt;=).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#raw">
+                    <h3 id="raw">
+                        raw
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Array t)] (Ptr t))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#reduce">
+                    <h3 id="reduce">
+                        reduce
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(λ [&amp;a, &amp;b] a), a, (Ref (Array b))] a)
+                </p>
+                <pre class="args">
+                    (reduce f x xs)
+                </pre>
+                <p class="doc">
+                    Reduce an array, using the function f.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#repeat">
+                    <h3 id="repeat">
+                        repeat
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, (λ [] a)] (Array a))
+                </p>
+                <pre class="args">
+                    (repeat n f)
+                </pre>
+                <p class="doc">
+                    Repeat function f n times and store the results in an array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#repeat-indexed">
+                    <h3 id="repeat-indexed">
+                        repeat-indexed
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, (λ [Int] a)] (Array a))
+                </p>
+                <pre class="args">
+                    (repeat-indexed n f)
+                </pre>
+                <p class="doc">
+                    Repeat function f n times and store the results in an array (will be supplied with the index).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#replicate">
+                    <h3 id="replicate">
+                        replicate
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, &amp;a] (Array a))
+                </p>
+                <pre class="args">
+                    (replicate n e)
+                </pre>
+                <p class="doc">
+                    Repeat element e n times and store the results in an array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#reverse">
+                    <h3 id="reverse">
+                        reverse
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Array a)] (Array a))
+                </p>
+                <pre class="args">
+                    (reverse a)
+                </pre>
+                <p class="doc">
+                    Reverse an array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sort">
+                    <h3 id="sort">
+                        sort
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Array a)] (Array a))
+                </p>
+                <pre class="args">
+                    (sort arr)
+                </pre>
+                <p class="doc">
+                    Perform an in-place heapsort of a given owned array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sort!">
+                    <h3 id="sort!">
+                        sort!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] ())
+                </p>
+                <pre class="args">
+                    (sort! arr)
+                </pre>
+                <p class="doc">
+                    Perform an in-place heapsort of a given array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sorted">
+                    <h3 id="sorted">
+                        sorted
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] (Array a))
+                </p>
+                <pre class="args">
+                    (sorted arr)
+                </pre>
+                <p class="doc">
+                    Perform a heapsort in a new copy of given array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#subarray">
+                    <h3 id="subarray">
+                        subarray
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), Int, Int] (Array a))
+                </p>
+                <pre class="args">
+                    (subarray xs start-index end-index)
+                </pre>
+                <p class="doc">
+                    Get subarray from start-index to end-index.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#suffix-array">
+                    <h3 id="suffix-array">
+                        suffix-array
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), Int] (Array a))
+                </p>
+                <pre class="args">
+                    (suffix-array xs start-index)
+                </pre>
+                <p class="doc">
+                    Get subarray from start-index.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sum">
+                    <h3 id="sum">
+                        sum
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a))] a)
+                </p>
+                <pre class="args">
+                    (sum xs)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sum-length">
+                    <h3 id="sum-length">
+                        sum-length
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array (Array a)))] Int)
+                </p>
+                <pre class="args">
+                    (sum-length xs)
+                </pre>
+                <p class="doc">
+                    Returns the sum of lengths from an Array of Arrays.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#swap">
+                    <h3 id="swap">
+                        swap
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Array a), Int, Int] (Array a))
+                </p>
+                <pre class="args">
+                    (swap a i j)
+                </pre>
+                <p class="doc">
+                    Swap indices i and j of array a.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#swap!">
+                    <h3 id="swap!">
+                        swap!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array a)), Int, Int] ())
+                </p>
+                <pre class="args">
+                    (swap! a i j)
+                </pre>
+                <p class="doc">
+                    Swap indices i and j of array a in place.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero">
+                    <h3 id="zero">
+                        zero
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] (Array a))
+                </p>
+                <pre class="args">
+                    (zero)
+                </pre>
+                <p class="doc">
+                    Returns the empty array.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zip">
+                    <h3 id="zip">
+                        zip
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(λ [&amp;a, &amp;b] c), (Ref (Array a)), (Ref (Array b))] (Array c))
+                </p>
+                <pre class="args">
+                    (zip f a b)
+                </pre>
+                <p class="doc">
+                    Map over two arrays using a function that takes two arguments. Produces a new array with the length of the shorter input.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -1,1 +1,186 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Bench</h1><div class="binder"><a href="#bench" class="anchor"><h3 id="bench">bench</h3></a><div class="description">defn</div><p class="sig">(λ [(λ [] a)] ())</p><pre class="args">(bench f)</pre><p class="doc">Benchmark function f and print the results.</p></div><div class="binder"><a href="#set-min-runs!" class="anchor"><h3 id="set-min-runs!">set-min-runs!</h3></a><div class="description">defn</div><p class="sig">(λ [Int] ())</p><pre class="args">(set-min-runs! n)</pre><p class="doc">Set the minimum number of runs. If your functions takes a large amount of time, experimenting with this might make sense.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Bench
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#bench">
+                    <h3 id="bench">
+                        bench
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(λ [] a)] ())
+                </p>
+                <pre class="args">
+                    (bench f)
+                </pre>
+                <p class="doc">
+                    Benchmark function f and print the results.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-min-runs!">
+                    <h3 id="set-min-runs!">
+                        set-min-runs!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int] ())
+                </p>
+                <pre class="args">
+                    (set-min-runs! n)
+                </pre>
+                <p class="doc">
+                    Set the minimum number of runs. If your functions takes a large amount of time, experimenting with this might make sense.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -1,1 +1,281 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Bool</h1><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">external</div><p class="sig">(λ [Bool, Bool] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [Bool, Bool] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Bool] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#format" class="anchor"><h3 id="format">format</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Bool] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#hash" class="anchor"><h3 id="hash">hash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Bool] Int)</p><pre class="args">(hash k)</pre><p class="doc"></p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">defn</div><p class="sig">(λ [Bool] String)</p><pre class="args">(prn x)</pre><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [Bool] String)</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Bool
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Bool, Bool] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Bool, Bool] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Bool] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Bool] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Bool] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Bool] String)
+                </p>
+                <pre class="args">
+                    (prn x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Bool] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -1,1 +1,414 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Char</h1><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [Char, Char] Bool)</p><pre class="args">(/= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#&lt;" class="anchor"><h3 id="&lt;">&lt;</h3></a><div class="description">external</div><p class="sig">(λ [Char, Char] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [Char, Char] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&gt;" class="anchor"><h3 id="&gt;">&gt;</h3></a><div class="description">external</div><p class="sig">(λ [Char, Char] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Char] Char)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#format" class="anchor"><h3 id="format">format</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Char] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-int" class="anchor"><h3 id="from-int">from-int</h3></a><div class="description">external</div><p class="sig">(λ [Int] Char)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#hash" class="anchor"><h3 id="hash">hash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Char] Int)</p><pre class="args">(hash k)</pre><p class="doc"></p></div><div class="binder"><a href="#meaning" class="anchor"><h3 id="meaning">meaning</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Char] Int)</p><pre class="args">(meaning char-ref)</pre><p class="doc">Convert a numerical char into the appropriate number.</p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">external</div><p class="sig">(λ [Char] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#random" class="anchor"><h3 id="random">random</h3></a><div class="description">defn</div><p class="sig">(λ [] Char)</p><pre class="args">(random)</pre><p class="doc"></p></div><div class="binder"><a href="#random-between" class="anchor"><h3 id="random-between">random-between</h3></a><div class="description">defn</div><p class="sig">(λ [Char, Char] Char)</p><pre class="args">(random-between a b)</pre><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [Char] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-int" class="anchor"><h3 id="to-int">to-int</h3></a><div class="description">external</div><p class="sig">(λ [Char] Int)</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Char
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char, Char] Bool)
+                </p>
+                <pre class="args">
+                    (/= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Char, Char] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Char, Char] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Char, Char] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Char] Char)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Char] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-int">
+                    <h3 id="from-int">
+                        from-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Char)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Char] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#meaning">
+                    <h3 id="meaning">
+                        meaning
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Char] Int)
+                </p>
+                <pre class="args">
+                    (meaning char-ref)
+                </pre>
+                <p class="doc">
+                    Convert a numerical char into the appropriate number.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Char] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Char)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-between">
+                    <h3 id="random-between">
+                        random-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char, Char] Char)
+                </p>
+                <pre class="args">
+                    (random-between a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Char] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-int">
+                    <h3 id="to-int">
+                        to-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Char] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -1,1 +1,300 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Debug</h1><div class="binder"><a href="#assert-balanced" class="anchor"><h3 id="assert-balanced">assert-balanced</h3></a><div class="description">macro</div><p class="sig">Macro</p><pre class="args">(assert-balanced form)</pre><p class="doc">Raises an error if the memory balance (numberr of alloc:s - number of free:s) isn&#39;t 0. Requires compiling with --log-memory.</p></div><div class="binder"><a href="#leak-array" class="anchor"><h3 id="leak-array">leak-array</h3></a><div class="description">external</div><p class="sig">(λ [a] ())</p><span></span><p class="doc">Leak some memory. Useful for testing tools that detect leaks.</p></div><div class="binder"><a href="#log-memory-balance!" class="anchor"><h3 id="log-memory-balance!">log-memory-balance!</h3></a><div class="description">external</div><p class="sig">(λ [Bool] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#memory-balance" class="anchor"><h3 id="memory-balance">memory-balance</h3></a><div class="description">external</div><p class="sig">(λ [] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#memory-logged" class="anchor"><h3 id="memory-logged">memory-logged</h3></a><div class="description">macro</div><p class="sig">Macro</p><pre class="args">(memory-logged form)</pre><p class="doc">Log all calls to memory allocation within te form. Requires compiling with --log-memory.</p></div><div class="binder"><a href="#reset-memory-balance!" class="anchor"><h3 id="reset-memory-balance!">reset-memory-balance!</h3></a><div class="description">external</div><p class="sig">(λ [] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#sanitize-addresses" class="anchor"><h3 id="sanitize-addresses">sanitize-addresses</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(sanitize-addresses)</pre><p class="doc">Instruct the compiler to sanitize addresses.</p></div><div class="binder"><a href="#trace" class="anchor"><h3 id="trace">trace</h3></a><div class="description">defn</div><p class="sig">(λ [a] a)</p><pre class="args">(trace x)</pre><p class="doc">Print the value of an expression to stdout, then return its value.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Debug
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#assert-balanced">
+                    <h3 id="assert-balanced">
+                        assert-balanced
+                    </h3>
+                </a>
+                <div class="description">
+                    macro
+                </div>
+                <p class="sig">
+                    Macro
+                </p>
+                <pre class="args">
+                    (assert-balanced form)
+                </pre>
+                <p class="doc">
+                    Raises an error if the memory balance (numberr of alloc:s - number of free:s) isn&#39;t 0. Requires compiling with --log-memory.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#leak-array">
+                    <h3 id="leak-array">
+                        leak-array
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [a] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Leak some memory. Useful for testing tools that detect leaks.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#log-memory-balance!">
+                    <h3 id="log-memory-balance!">
+                        log-memory-balance!
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Bool] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#memory-balance">
+                    <h3 id="memory-balance">
+                        memory-balance
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#memory-logged">
+                    <h3 id="memory-logged">
+                        memory-logged
+                    </h3>
+                </a>
+                <div class="description">
+                    macro
+                </div>
+                <p class="sig">
+                    Macro
+                </p>
+                <pre class="args">
+                    (memory-logged form)
+                </pre>
+                <p class="doc">
+                    Log all calls to memory allocation within te form. Requires compiling with --log-memory.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#reset-memory-balance!">
+                    <h3 id="reset-memory-balance!">
+                        reset-memory-balance!
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sanitize-addresses">
+                    <h3 id="sanitize-addresses">
+                        sanitize-addresses
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (sanitize-addresses)
+                </pre>
+                <p class="doc">
+                    Instruct the compiler to sanitize addresses.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#trace">
+                    <h3 id="trace">
+                        trace
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a] a)
+                </p>
+                <pre class="args">
+                    (trace x)
+                </pre>
+                <p class="doc">
+                    Print the value of an expression to stdout, then return its value.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -1,1 +1,1098 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Double</h1><div class="binder"><a href="#*" class="anchor"><h3 id="*">*</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#+" class="anchor"><h3 id="+">+</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#-" class="anchor"><h3 id="-">-</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/" class="anchor"><h3 id="/">/</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [Double, Double] Bool)</p><pre class="args">(/= x y)</pre><p class="doc"></p></div><div class="binder"><a href="#&lt;" class="anchor"><h3 id="&lt;">&lt;</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&gt;" class="anchor"><h3 id="&gt;">&gt;</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#abs" class="anchor"><h3 id="abs">abs</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#acos" class="anchor"><h3 id="acos">acos</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#add-ref" class="anchor"><h3 id="add-ref">add-ref</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Double, &amp;Double] Double)</p><pre class="args">(add-ref x y)</pre><p class="doc"></p></div><div class="binder"><a href="#approx" class="anchor"><h3 id="approx">approx</h3></a><div class="description">defn</div><p class="sig">(λ [Double, Double] Bool)</p><pre class="args">(approx x y)</pre><p class="doc">checks whether x and y are approximately (i.e. margin of error of 0.00001) equal</p></div><div class="binder"><a href="#asin" class="anchor"><h3 id="asin">asin</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#atan" class="anchor"><h3 id="atan">atan</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#atan2" class="anchor"><h3 id="atan2">atan2</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#ceil" class="anchor"><h3 id="ceil">ceil</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#clamp" class="anchor"><h3 id="clamp">clamp</h3></a><div class="description">defn</div><p class="sig">(λ [a, a, a] a)</p><pre class="args">(clamp min max val)</pre><p class="doc"></p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cos" class="anchor"><h3 id="cos">cos</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cosh" class="anchor"><h3 id="cosh">cosh</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#e" class="anchor"><h3 id="e">e</h3></a><div class="description">def</div><p class="sig">Double</p><span></span><p class="doc"></p></div><div class="binder"><a href="#exp" class="anchor"><h3 id="exp">exp</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#floor" class="anchor"><h3 id="floor">floor</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#format" class="anchor"><h3 id="format">format</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Double] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#frexp" class="anchor"><h3 id="frexp">frexp</h3></a><div class="description">external</div><p class="sig">(λ [Double, &amp;Int] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-float" class="anchor"><h3 id="from-float">from-float</h3></a><div class="description">external</div><p class="sig">(λ [Float] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-int" class="anchor"><h3 id="from-int">from-int</h3></a><div class="description">external</div><p class="sig">(λ [Int] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-long" class="anchor"><h3 id="from-long">from-long</h3></a><div class="description">external</div><p class="sig">(λ [Long] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#hash" class="anchor"><h3 id="hash">hash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Double] Int)</p><pre class="args">(hash k)</pre><p class="doc"></p></div><div class="binder"><a href="#ldexp" class="anchor"><h3 id="ldexp">ldexp</h3></a><div class="description">external</div><p class="sig">(λ [Double, Int] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#log" class="anchor"><h3 id="log">log</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#log10" class="anchor"><h3 id="log10">log10</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#mod" class="anchor"><h3 id="mod">mod</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#modf" class="anchor"><h3 id="modf">modf</h3></a><div class="description">external</div><p class="sig">(λ [Double, &amp;Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#neg" class="anchor"><h3 id="neg">neg</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#pi" class="anchor"><h3 id="pi">pi</h3></a><div class="description">def</div><p class="sig">Double</p><span></span><p class="doc"></p></div><div class="binder"><a href="#pow" class="anchor"><h3 id="pow">pow</h3></a><div class="description">external</div><p class="sig">(λ [Double, Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#random" class="anchor"><h3 id="random">random</h3></a><div class="description">defn</div><p class="sig">(λ [] Double)</p><pre class="args">(random)</pre><p class="doc"></p></div><div class="binder"><a href="#random-between" class="anchor"><h3 id="random-between">random-between</h3></a><div class="description">defn</div><p class="sig">(λ [Double, Double] Double)</p><pre class="args">(random-between lower upper)</pre><p class="doc"></p></div><div class="binder"><a href="#sin" class="anchor"><h3 id="sin">sin</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#sinh" class="anchor"><h3 id="sinh">sinh</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#sqrt" class="anchor"><h3 id="sqrt">sqrt</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [Double] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#tan" class="anchor"><h3 id="tan">tan</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#tanh" class="anchor"><h3 id="tanh">tanh</h3></a><div class="description">external</div><p class="sig">(λ [Double] Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-bytes" class="anchor"><h3 id="to-bytes">to-bytes</h3></a><div class="description">external</div><p class="sig">(λ [Double] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-float" class="anchor"><h3 id="to-float">to-float</h3></a><div class="description">external</div><p class="sig">(λ [Double] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-int" class="anchor"><h3 id="to-int">to-int</h3></a><div class="description">external</div><p class="sig">(λ [Double] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-long" class="anchor"><h3 id="to-long">to-long</h3></a><div class="description">external</div><p class="sig">(λ [Double] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#zero" class="anchor"><h3 id="zero">zero</h3></a><div class="description">defn</div><p class="sig">(λ [] Double)</p><pre class="args">(zero)</pre><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Double
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#*">
+                    <h3 id="*">
+                        *
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#+">
+                    <h3 id="+">
+                        +
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#-">
+                    <h3 id="-">
+                        -
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/">
+                    <h3 id="/">
+                        /
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Bool)
+                </p>
+                <pre class="args">
+                    (/= x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#abs">
+                    <h3 id="abs">
+                        abs
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#acos">
+                    <h3 id="acos">
+                        acos
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add-ref">
+                    <h3 id="add-ref">
+                        add-ref
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Double, &amp;Double] Double)
+                </p>
+                <pre class="args">
+                    (add-ref x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#approx">
+                    <h3 id="approx">
+                        approx
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Bool)
+                </p>
+                <pre class="args">
+                    (approx x y)
+                </pre>
+                <p class="doc">
+                    checks whether x and y are approximately (i.e. margin of error of 0.00001) equal
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#asin">
+                    <h3 id="asin">
+                        asin
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#atan">
+                    <h3 id="atan">
+                        atan
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#atan2">
+                    <h3 id="atan2">
+                        atan2
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ceil">
+                    <h3 id="ceil">
+                        ceil
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#clamp">
+                    <h3 id="clamp">
+                        clamp
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, a, a] a)
+                </p>
+                <pre class="args">
+                    (clamp min max val)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cos">
+                    <h3 id="cos">
+                        cos
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cosh">
+                    <h3 id="cosh">
+                        cosh
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#e">
+                    <h3 id="e">
+                        e
+                    </h3>
+                </a>
+                <div class="description">
+                    def
+                </div>
+                <p class="sig">
+                    Double
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#exp">
+                    <h3 id="exp">
+                        exp
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#floor">
+                    <h3 id="floor">
+                        floor
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Double] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#frexp">
+                    <h3 id="frexp">
+                        frexp
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, &amp;Int] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-float">
+                    <h3 id="from-float">
+                        from-float
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-int">
+                    <h3 id="from-int">
+                        from-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-long">
+                    <h3 id="from-long">
+                        from-long
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Double] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ldexp">
+                    <h3 id="ldexp">
+                        ldexp
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Int] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#log">
+                    <h3 id="log">
+                        log
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#log10">
+                    <h3 id="log10">
+                        log10
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mod">
+                    <h3 id="mod">
+                        mod
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#modf">
+                    <h3 id="modf">
+                        modf
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, &amp;Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#neg">
+                    <h3 id="neg">
+                        neg
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pi">
+                    <h3 id="pi">
+                        pi
+                    </h3>
+                </a>
+                <div class="description">
+                    def
+                </div>
+                <p class="sig">
+                    Double
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pow">
+                    <h3 id="pow">
+                        pow
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Double)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-between">
+                    <h3 id="random-between">
+                        random-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] Double)
+                </p>
+                <pre class="args">
+                    (random-between lower upper)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sin">
+                    <h3 id="sin">
+                        sin
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sinh">
+                    <h3 id="sinh">
+                        sinh
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sqrt">
+                    <h3 id="sqrt">
+                        sqrt
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#tan">
+                    <h3 id="tan">
+                        tan
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#tanh">
+                    <h3 id="tanh">
+                        tanh
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-bytes">
+                    <h3 id="to-bytes">
+                        to-bytes
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-float">
+                    <h3 id="to-float">
+                        to-float
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-int">
+                    <h3 id="to-int">
+                        to-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-long">
+                    <h3 id="to-long">
+                        to-long
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Double] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero">
+                    <h3 id="zero">
+                        zero
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Double)
+                </p>
+                <pre class="args">
+                    (zero)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -1,1 +1,1535 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Dynamic</h1><div class="binder"><a href="#*" class="anchor"><h3 id="*">*</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#+" class="anchor"><h3 id="+">+</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#-" class="anchor"><h3 id="-">-</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/" class="anchor"><h3 id="/">/</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&lt;" class="anchor"><h3 id="&lt;">&lt;</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&gt;" class="anchor"><h3 id="&gt;">&gt;</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#Project" class="anchor"><h3 id="Project">Project</h3></a><div class="description">module</div><p class="sig"></p><span></span><p class="doc"></p></div><div class="binder"><a href="#String" class="anchor"><h3 id="String">String</h3></a><div class="description">module</div><p class="sig"></p><span></span><p class="doc"></p></div><div class="binder"><a href="#all-but-last" class="anchor"><h3 id="all-but-last">all-but-last</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#append" class="anchor"><h3 id="append">append</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#array?" class="anchor"><h3 id="array?">array?</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#build" class="anchor"><h3 id="build">build</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#c" class="anchor"><h3 id="c">c</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#caaaar" class="anchor"><h3 id="caaaar">caaaar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caaaar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caaadr" class="anchor"><h3 id="caaadr">caaadr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caaadr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caaar" class="anchor"><h3 id="caaar">caaar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caaar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caadar" class="anchor"><h3 id="caadar">caadar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caadar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caaddr" class="anchor"><h3 id="caaddr">caaddr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caaddr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caadr" class="anchor"><h3 id="caadr">caadr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caadr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caar" class="anchor"><h3 id="caar">caar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cadaar" class="anchor"><h3 id="cadaar">cadaar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cadaar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cadadr" class="anchor"><h3 id="cadadr">cadadr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cadadr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cadar" class="anchor"><h3 id="cadar">cadar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cadar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caddar" class="anchor"><h3 id="caddar">caddar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caddar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cadddr" class="anchor"><h3 id="cadddr">cadddr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cadddr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#caddr" class="anchor"><h3 id="caddr">caddr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(caddr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cadr" class="anchor"><h3 id="cadr">cadr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cadr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#car" class="anchor"><h3 id="car">car</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cat" class="anchor"><h3 id="cat">cat</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cdaaar" class="anchor"><h3 id="cdaaar">cdaaar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdaaar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdaadr" class="anchor"><h3 id="cdaadr">cdaadr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdaadr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdaar" class="anchor"><h3 id="cdaar">cdaar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdaar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdadar" class="anchor"><h3 id="cdadar">cdadar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdadar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdaddr" class="anchor"><h3 id="cdaddr">cdaddr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdaddr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdadr" class="anchor"><h3 id="cdadr">cdadr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdadr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdar" class="anchor"><h3 id="cdar">cdar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cddaar" class="anchor"><h3 id="cddaar">cddaar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cddaar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cddadr" class="anchor"><h3 id="cddadr">cddadr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cddadr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cddar" class="anchor"><h3 id="cddar">cddar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cddar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdddar" class="anchor"><h3 id="cdddar">cdddar</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdddar pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cddddr" class="anchor"><h3 id="cddddr">cddddr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cddddr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdddr" class="anchor"><h3 id="cdddr">cdddr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cdddr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cddr" class="anchor"><h3 id="cddr">cddr</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(cddr pair)</pre><p class="doc"></p></div><div class="binder"><a href="#cdr" class="anchor"><h3 id="cdr">cdr</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cons" class="anchor"><h3 id="cons">cons</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cons-last" class="anchor"><h3 id="cons-last">cons-last</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#dec" class="anchor"><h3 id="dec">dec</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(dec x)</pre><p class="doc"></p></div><div class="binder"><a href="#e" class="anchor"><h3 id="e">e</h3></a><div class="description">macro</div><p class="sig">Macro</p><pre class="args">(e form)</pre><p class="doc"></p></div><div class="binder"><a href="#env" class="anchor"><h3 id="env">env</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#eval" class="anchor"><h3 id="eval">eval</h3></a><div class="description">macro</div><p class="sig">Macro</p><pre class="args">(eval form)</pre><p class="doc"></p></div><div class="binder"><a href="#eval-internal" class="anchor"><h3 id="eval-internal">eval-internal</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(eval-internal form)</pre><p class="doc"></p></div><div class="binder"><a href="#expand" class="anchor"><h3 id="expand">expand</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#help" class="anchor"><h3 id="help">help</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#inc" class="anchor"><h3 id="inc">inc</h3></a><div class="description">dynamic</div><p class="sig">Dynamic</p><pre class="args">(inc x)</pre><p class="doc"></p></div><div class="binder"><a href="#last" class="anchor"><h3 id="last">last</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#length" class="anchor"><h3 id="length">length</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#list?" class="anchor"><h3 id="list?">list?</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#load" class="anchor"><h3 id="load">load</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#local-include" class="anchor"><h3 id="local-include">local-include</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#macro-error" class="anchor"><h3 id="macro-error">macro-error</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#macro-log" class="anchor"><h3 id="macro-log">macro-log</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#not" class="anchor"><h3 id="not">not</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#os" class="anchor"><h3 id="os">os</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#project" class="anchor"><h3 id="project">project</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#project-set!" class="anchor"><h3 id="project-set!">project-set!</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#quit" class="anchor"><h3 id="quit">quit</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#reload" class="anchor"><h3 id="reload">reload</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#run" class="anchor"><h3 id="run">run</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#save-docs-internal" class="anchor"><h3 id="save-docs-internal">save-docs-internal</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#symbol?" class="anchor"><h3 id="symbol?">symbol?</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div><div class="binder"><a href="#system-include" class="anchor"><h3 id="system-include">system-include</h3></a><div class="description">command</div><p class="sig">Dynamic</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Dynamic
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#*">
+                    <h3 id="*">
+                        *
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#+">
+                    <h3 id="+">
+                        +
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#-">
+                    <h3 id="-">
+                        -
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/">
+                    <h3 id="/">
+                        /
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#Project">
+                    <h3 id="Project">
+                        Project
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#String">
+                    <h3 id="String">
+                        String
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#all-but-last">
+                    <h3 id="all-but-last">
+                        all-but-last
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#append">
+                    <h3 id="append">
+                        append
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#array?">
+                    <h3 id="array?">
+                        array?
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#build">
+                    <h3 id="build">
+                        build
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#c">
+                    <h3 id="c">
+                        c
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caaaar">
+                    <h3 id="caaaar">
+                        caaaar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caaaar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caaadr">
+                    <h3 id="caaadr">
+                        caaadr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caaadr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caaar">
+                    <h3 id="caaar">
+                        caaar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caaar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caadar">
+                    <h3 id="caadar">
+                        caadar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caadar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caaddr">
+                    <h3 id="caaddr">
+                        caaddr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caaddr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caadr">
+                    <h3 id="caadr">
+                        caadr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caadr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caar">
+                    <h3 id="caar">
+                        caar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cadaar">
+                    <h3 id="cadaar">
+                        cadaar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cadaar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cadadr">
+                    <h3 id="cadadr">
+                        cadadr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cadadr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cadar">
+                    <h3 id="cadar">
+                        cadar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cadar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caddar">
+                    <h3 id="caddar">
+                        caddar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caddar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cadddr">
+                    <h3 id="cadddr">
+                        cadddr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cadddr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#caddr">
+                    <h3 id="caddr">
+                        caddr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (caddr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cadr">
+                    <h3 id="cadr">
+                        cadr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cadr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#car">
+                    <h3 id="car">
+                        car
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cat">
+                    <h3 id="cat">
+                        cat
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdaaar">
+                    <h3 id="cdaaar">
+                        cdaaar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdaaar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdaadr">
+                    <h3 id="cdaadr">
+                        cdaadr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdaadr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdaar">
+                    <h3 id="cdaar">
+                        cdaar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdaar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdadar">
+                    <h3 id="cdadar">
+                        cdadar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdadar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdaddr">
+                    <h3 id="cdaddr">
+                        cdaddr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdaddr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdadr">
+                    <h3 id="cdadr">
+                        cdadr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdadr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdar">
+                    <h3 id="cdar">
+                        cdar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cddaar">
+                    <h3 id="cddaar">
+                        cddaar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cddaar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cddadr">
+                    <h3 id="cddadr">
+                        cddadr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cddadr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cddar">
+                    <h3 id="cddar">
+                        cddar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cddar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdddar">
+                    <h3 id="cdddar">
+                        cdddar
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdddar pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cddddr">
+                    <h3 id="cddddr">
+                        cddddr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cddddr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdddr">
+                    <h3 id="cdddr">
+                        cdddr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cdddr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cddr">
+                    <h3 id="cddr">
+                        cddr
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (cddr pair)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cdr">
+                    <h3 id="cdr">
+                        cdr
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cons">
+                    <h3 id="cons">
+                        cons
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cons-last">
+                    <h3 id="cons-last">
+                        cons-last
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dec">
+                    <h3 id="dec">
+                        dec
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (dec x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#e">
+                    <h3 id="e">
+                        e
+                    </h3>
+                </a>
+                <div class="description">
+                    macro
+                </div>
+                <p class="sig">
+                    Macro
+                </p>
+                <pre class="args">
+                    (e form)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#env">
+                    <h3 id="env">
+                        env
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#eval">
+                    <h3 id="eval">
+                        eval
+                    </h3>
+                </a>
+                <div class="description">
+                    macro
+                </div>
+                <p class="sig">
+                    Macro
+                </p>
+                <pre class="args">
+                    (eval form)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#eval-internal">
+                    <h3 id="eval-internal">
+                        eval-internal
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (eval-internal form)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#expand">
+                    <h3 id="expand">
+                        expand
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#help">
+                    <h3 id="help">
+                        help
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#inc">
+                    <h3 id="inc">
+                        inc
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (inc x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#last">
+                    <h3 id="last">
+                        last
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#length">
+                    <h3 id="length">
+                        length
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#list?">
+                    <h3 id="list?">
+                        list?
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#load">
+                    <h3 id="load">
+                        load
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#local-include">
+                    <h3 id="local-include">
+                        local-include
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#macro-error">
+                    <h3 id="macro-error">
+                        macro-error
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#macro-log">
+                    <h3 id="macro-log">
+                        macro-log
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#not">
+                    <h3 id="not">
+                        not
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#os">
+                    <h3 id="os">
+                        os
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#project">
+                    <h3 id="project">
+                        project
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#project-set!">
+                    <h3 id="project-set!">
+                        project-set!
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#quit">
+                    <h3 id="quit">
+                        quit
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#reload">
+                    <h3 id="reload">
+                        reload
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#run">
+                    <h3 id="run">
+                        run
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#save-docs-internal">
+                    <h3 id="save-docs-internal">
+                        save-docs-internal
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#symbol?">
+                    <h3 id="symbol?">
+                        symbol?
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#system-include">
+                    <h3 id="system-include">
+                        system-include
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -1,1 +1,1022 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Float</h1><div class="binder"><a href="#*" class="anchor"><h3 id="*">*</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#+" class="anchor"><h3 id="+">+</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#-" class="anchor"><h3 id="-">-</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/" class="anchor"><h3 id="/">/</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [Float, Float] Bool)</p><pre class="args">(/= x y)</pre><p class="doc"></p></div><div class="binder"><a href="#&lt;" class="anchor"><h3 id="&lt;">&lt;</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&gt;" class="anchor"><h3 id="&gt;">&gt;</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#abs" class="anchor"><h3 id="abs">abs</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#acos" class="anchor"><h3 id="acos">acos</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#add-ref" class="anchor"><h3 id="add-ref">add-ref</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Float, &amp;Float] Float)</p><pre class="args">(add-ref x y)</pre><p class="doc"></p></div><div class="binder"><a href="#approx" class="anchor"><h3 id="approx">approx</h3></a><div class="description">defn</div><p class="sig">(λ [Float, Float] Bool)</p><pre class="args">(approx x y)</pre><p class="doc">checks whether x and y are approximately (i.e. margin of error of 0.00001) equal</p></div><div class="binder"><a href="#asin" class="anchor"><h3 id="asin">asin</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#atan" class="anchor"><h3 id="atan">atan</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#atan2" class="anchor"><h3 id="atan2">atan2</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#ceil" class="anchor"><h3 id="ceil">ceil</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#clamp" class="anchor"><h3 id="clamp">clamp</h3></a><div class="description">defn</div><p class="sig">(λ [a, a, a] a)</p><pre class="args">(clamp min max val)</pre><p class="doc"></p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cos" class="anchor"><h3 id="cos">cos</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#cosh" class="anchor"><h3 id="cosh">cosh</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#exp" class="anchor"><h3 id="exp">exp</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#floor" class="anchor"><h3 id="floor">floor</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#format" class="anchor"><h3 id="format">format</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Float] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#frexp" class="anchor"><h3 id="frexp">frexp</h3></a><div class="description">external</div><p class="sig">(λ [Float, &amp;Int] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-int" class="anchor"><h3 id="from-int">from-int</h3></a><div class="description">external</div><p class="sig">(λ [Int] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#hash" class="anchor"><h3 id="hash">hash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Float] Int)</p><pre class="args">(hash k)</pre><p class="doc"></p></div><div class="binder"><a href="#ldexp" class="anchor"><h3 id="ldexp">ldexp</h3></a><div class="description">external</div><p class="sig">(λ [Float, Int] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#log" class="anchor"><h3 id="log">log</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#log10" class="anchor"><h3 id="log10">log10</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#mod" class="anchor"><h3 id="mod">mod</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#modf" class="anchor"><h3 id="modf">modf</h3></a><div class="description">external</div><p class="sig">(λ [Float, &amp;Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#neg" class="anchor"><h3 id="neg">neg</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#pi" class="anchor"><h3 id="pi">pi</h3></a><div class="description">def</div><p class="sig">Float</p><span></span><p class="doc"></p></div><div class="binder"><a href="#pow" class="anchor"><h3 id="pow">pow</h3></a><div class="description">external</div><p class="sig">(λ [Float, Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">defn</div><p class="sig">(λ [Float] String)</p><pre class="args">(prn x)</pre><p class="doc"></p></div><div class="binder"><a href="#random" class="anchor"><h3 id="random">random</h3></a><div class="description">defn</div><p class="sig">(λ [] Float)</p><pre class="args">(random)</pre><p class="doc"></p></div><div class="binder"><a href="#random-between" class="anchor"><h3 id="random-between">random-between</h3></a><div class="description">defn</div><p class="sig">(λ [Float, Float] Float)</p><pre class="args">(random-between lower upper)</pre><p class="doc"></p></div><div class="binder"><a href="#sin" class="anchor"><h3 id="sin">sin</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#sinh" class="anchor"><h3 id="sinh">sinh</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#sqrt" class="anchor"><h3 id="sqrt">sqrt</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [Float] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#tan" class="anchor"><h3 id="tan">tan</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#tanh" class="anchor"><h3 id="tanh">tanh</h3></a><div class="description">external</div><p class="sig">(λ [Float] Float)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-bytes" class="anchor"><h3 id="to-bytes">to-bytes</h3></a><div class="description">external</div><p class="sig">(λ [Float] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-int" class="anchor"><h3 id="to-int">to-int</h3></a><div class="description">external</div><p class="sig">(λ [Float] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#zero" class="anchor"><h3 id="zero">zero</h3></a><div class="description">defn</div><p class="sig">(λ [] Float)</p><pre class="args">(zero)</pre><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Float
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#*">
+                    <h3 id="*">
+                        *
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#+">
+                    <h3 id="+">
+                        +
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#-">
+                    <h3 id="-">
+                        -
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/">
+                    <h3 id="/">
+                        /
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Bool)
+                </p>
+                <pre class="args">
+                    (/= x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#abs">
+                    <h3 id="abs">
+                        abs
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#acos">
+                    <h3 id="acos">
+                        acos
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add-ref">
+                    <h3 id="add-ref">
+                        add-ref
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Float, &amp;Float] Float)
+                </p>
+                <pre class="args">
+                    (add-ref x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#approx">
+                    <h3 id="approx">
+                        approx
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Bool)
+                </p>
+                <pre class="args">
+                    (approx x y)
+                </pre>
+                <p class="doc">
+                    checks whether x and y are approximately (i.e. margin of error of 0.00001) equal
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#asin">
+                    <h3 id="asin">
+                        asin
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#atan">
+                    <h3 id="atan">
+                        atan
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#atan2">
+                    <h3 id="atan2">
+                        atan2
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ceil">
+                    <h3 id="ceil">
+                        ceil
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#clamp">
+                    <h3 id="clamp">
+                        clamp
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, a, a] a)
+                </p>
+                <pre class="args">
+                    (clamp min max val)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cos">
+                    <h3 id="cos">
+                        cos
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cosh">
+                    <h3 id="cosh">
+                        cosh
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#exp">
+                    <h3 id="exp">
+                        exp
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#floor">
+                    <h3 id="floor">
+                        floor
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Float] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#frexp">
+                    <h3 id="frexp">
+                        frexp
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, &amp;Int] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-int">
+                    <h3 id="from-int">
+                        from-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Float] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ldexp">
+                    <h3 id="ldexp">
+                        ldexp
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Int] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#log">
+                    <h3 id="log">
+                        log
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#log10">
+                    <h3 id="log10">
+                        log10
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mod">
+                    <h3 id="mod">
+                        mod
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#modf">
+                    <h3 id="modf">
+                        modf
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, &amp;Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#neg">
+                    <h3 id="neg">
+                        neg
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pi">
+                    <h3 id="pi">
+                        pi
+                    </h3>
+                </a>
+                <div class="description">
+                    def
+                </div>
+                <p class="sig">
+                    Float
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pow">
+                    <h3 id="pow">
+                        pow
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Float] String)
+                </p>
+                <pre class="args">
+                    (prn x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Float)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-between">
+                    <h3 id="random-between">
+                        random-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Float, Float] Float)
+                </p>
+                <pre class="args">
+                    (random-between lower upper)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sin">
+                    <h3 id="sin">
+                        sin
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sinh">
+                    <h3 id="sinh">
+                        sinh
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sqrt">
+                    <h3 id="sqrt">
+                        sqrt
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#tan">
+                    <h3 id="tan">
+                        tan
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#tanh">
+                    <h3 id="tanh">
+                        tanh
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Float)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-bytes">
+                    <h3 id="to-bytes">
+                        to-bytes
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-int">
+                    <h3 id="to-int">
+                        to-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Float] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero">
+                    <h3 id="zero">
+                        zero
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Float)
+                </p>
+                <pre class="args">
+                    (zero)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -1,1 +1,186 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Geometry</h1><div class="binder"><a href="#degree-to-radians" class="anchor"><h3 id="degree-to-radians">degree-to-radians</h3></a><div class="description">defn</div><p class="sig">(λ [Double] Double)</p><pre class="args">(degree-to-radians n)</pre><p class="doc">Converts degrees expressed as a double into radians.</p></div><div class="binder"><a href="#radians-to-degree" class="anchor"><h3 id="radians-to-degree">radians-to-degree</h3></a><div class="description">defn</div><p class="sig">(λ [Double] Double)</p><pre class="args">(radians-to-degree n)</pre><p class="doc">Converts radians expressed as a double into degree.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Geometry
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#degree-to-radians">
+                    <h3 id="degree-to-radians">
+                        degree-to-radians
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <pre class="args">
+                    (degree-to-radians n)
+                </pre>
+                <p class="doc">
+                    Converts degrees expressed as a double into radians.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#radians-to-degree">
+                    <h3 id="radians-to-degree">
+                        radians-to-degree
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Double] Double)
+                </p>
+                <pre class="args">
+                    (radians-to-degree n)
+                </pre>
+                <p class="doc">
+                    Converts radians expressed as a double into degree.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -1,1 +1,376 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>IO</h1><div class="binder"><a href="#EOF" class="anchor"><h3 id="EOF">EOF</h3></a><div class="description">external</div><p class="sig">Char</p><span></span><p class="doc">the End-Of-File character as a literal.</p></div><div class="binder"><a href="#exit" class="anchor"><h3 id="exit">exit</h3></a><div class="description">external</div><p class="sig">(λ [Int] a)</p><span></span><p class="doc">exit the current program with a return code.</p></div><div class="binder"><a href="#fclose" class="anchor"><h3 id="fclose">fclose</h3></a><div class="description">external</div><p class="sig">(λ [(Ptr FILE)] ())</p><span></span><p class="doc">closes a file pointer.</p></div><div class="binder"><a href="#fgetc" class="anchor"><h3 id="fgetc">fgetc</h3></a><div class="description">external</div><p class="sig">(λ [(Ptr FILE)] Char)</p><span></span><p class="doc">gets a character from a file pointer.</p></div><div class="binder"><a href="#fopen" class="anchor"><h3 id="fopen">fopen</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, &amp;String] (Ptr FILE))</p><span></span><p class="doc">opens a file by name using a mode (one or multiple of [r]ead, [w]rite, and [a]ppend), returns a file pointer.</p></div><div class="binder"><a href="#fwrite" class="anchor"><h3 id="fwrite">fwrite</h3></a><div class="description">external</div><p class="sig">(λ [a, Int, Int, (Ptr FILE)] ())</p><span></span><p class="doc">writes to a file pointer.</p></div><div class="binder"><a href="#get-char" class="anchor"><h3 id="get-char">get-char</h3></a><div class="description">external</div><p class="sig">(λ [] Char)</p><span></span><p class="doc">gets a character from stdin.</p></div><div class="binder"><a href="#get-line" class="anchor"><h3 id="get-line">get-line</h3></a><div class="description">external</div><p class="sig">(λ [] String)</p><span></span><p class="doc">gets a line from stdin.</p></div><div class="binder"><a href="#print" class="anchor"><h3 id="print">print</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] ())</p><span></span><p class="doc">prints a string ref to stdout, does not append a newline.</p></div><div class="binder"><a href="#println" class="anchor"><h3 id="println">println</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] ())</p><span></span><p class="doc">prints a string ref to stdout, appends a newline.</p></div><div class="binder"><a href="#read-&gt;EOF" class="anchor"><h3 id="read-&gt;EOF">read-&gt;EOF</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] String)</p><pre class="args">(read-&gt;EOF filename)</pre><p class="doc">reads a file given by name until the End-Of-File character is reached.</p></div><div class="binder"><a href="#read-file" class="anchor"><h3 id="read-file">read-file</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] String)</p><span></span><p class="doc">returns the contents of a file passed as argument as a string.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                IO
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#EOF">
+                    <h3 id="EOF">
+                        EOF
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Char
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    the End-Of-File character as a literal.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#exit">
+                    <h3 id="exit">
+                        exit
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] a)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    exit the current program with a return code.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#fclose">
+                    <h3 id="fclose">
+                        fclose
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr FILE)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    closes a file pointer.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#fgetc">
+                    <h3 id="fgetc">
+                        fgetc
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr FILE)] Char)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    gets a character from a file pointer.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#fopen">
+                    <h3 id="fopen">
+                        fopen
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] (Ptr FILE))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    opens a file by name using a mode (one or multiple of [r]ead, [w]rite, and [a]ppend), returns a file pointer.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#fwrite">
+                    <h3 id="fwrite">
+                        fwrite
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [a, Int, Int, (Ptr FILE)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    writes to a file pointer.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get-char">
+                    <h3 id="get-char">
+                        get-char
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] Char)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    gets a character from stdin.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get-line">
+                    <h3 id="get-line">
+                        get-line
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    gets a line from stdin.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#print">
+                    <h3 id="print">
+                        print
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    prints a string ref to stdout, does not append a newline.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#println">
+                    <h3 id="println">
+                        println
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    prints a string ref to stdout, appends a newline.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#read-&gt;EOF">
+                    <h3 id="read-&gt;EOF">
+                        read-&gt;EOF
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <pre class="args">
+                    (read-&gt;EOF filename)
+                </pre>
+                <p class="doc">
+                    reads a file given by name until the End-Of-File character is reached.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#read-file">
+                    <h3 id="read-file">
+                        read-file
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    returns the contents of a file passed as argument as a string.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -1,1 +1,851 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Int</h1><div class="binder"><a href="#*" class="anchor"><h3 id="*">*</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#+" class="anchor"><h3 id="+">+</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#-" class="anchor"><h3 id="-">-</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/" class="anchor"><h3 id="/">/</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&lt;" class="anchor"><h3 id="&lt;">&lt;</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&gt;" class="anchor"><h3 id="&gt;">&gt;</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#MAX" class="anchor"><h3 id="MAX">MAX</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#MIN" class="anchor"><h3 id="MIN">MIN</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#abs" class="anchor"><h3 id="abs">abs</h3></a><div class="description">external</div><p class="sig">(λ [Int] Int)</p><span></span><p class="doc">The absolute value (removes the negative sign) of an Int.</p></div><div class="binder"><a href="#add-ref" class="anchor"><h3 id="add-ref">add-ref</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Int, &amp;Int] Int)</p><pre class="args">(add-ref x y)</pre><p class="doc"></p></div><div class="binder"><a href="#bit-and" class="anchor"><h3 id="bit-and">bit-and</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-not" class="anchor"><h3 id="bit-not">bit-not</h3></a><div class="description">external</div><p class="sig">(λ [Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-or" class="anchor"><h3 id="bit-or">bit-or</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-shift-left" class="anchor"><h3 id="bit-shift-left">bit-shift-left</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-shift-right" class="anchor"><h3 id="bit-shift-right">bit-shift-right</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-xor" class="anchor"><h3 id="bit-xor">bit-xor</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#clamp" class="anchor"><h3 id="clamp">clamp</h3></a><div class="description">defn</div><p class="sig">(λ [a, a, a] a)</p><pre class="args">(clamp min max val)</pre><p class="doc"></p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#dec" class="anchor"><h3 id="dec">dec</h3></a><div class="description">external</div><p class="sig">(λ [Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#even?" class="anchor"><h3 id="even?">even?</h3></a><div class="description">defn</div><p class="sig">(λ [Int] Bool)</p><pre class="args">(even? a)</pre><p class="doc"></p></div><div class="binder"><a href="#format" class="anchor"><h3 id="format">format</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Int] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-string" class="anchor"><h3 id="from-string">from-string</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#hash" class="anchor"><h3 id="hash">hash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Int] Int)</p><pre class="args">(hash k)</pre><p class="doc"></p></div><div class="binder"><a href="#inc" class="anchor"><h3 id="inc">inc</h3></a><div class="description">external</div><p class="sig">(λ [Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#mod" class="anchor"><h3 id="mod">mod</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#neg" class="anchor"><h3 id="neg">neg</h3></a><div class="description">external</div><p class="sig">(λ [Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#odd?" class="anchor"><h3 id="odd?">odd?</h3></a><div class="description">defn</div><p class="sig">(λ [Int] Bool)</p><pre class="args">(odd? a)</pre><p class="doc"></p></div><div class="binder"><a href="#pow" class="anchor"><h3 id="pow">pow</h3></a><div class="description">defn</div><p class="sig">(λ [Int, Int] Int)</p><pre class="args">(pow x y)</pre><p class="doc">Raise x to the power of y.</p></div><div class="binder"><a href="#random" class="anchor"><h3 id="random">random</h3></a><div class="description">defn</div><p class="sig">(λ [] Int)</p><pre class="args">(random)</pre><p class="doc"></p></div><div class="binder"><a href="#random-between" class="anchor"><h3 id="random-between">random-between</h3></a><div class="description">defn</div><p class="sig">(λ [Int, Int] Int)</p><pre class="args">(random-between lower upper)</pre><p class="doc"></p></div><div class="binder"><a href="#safe-add" class="anchor"><h3 id="safe-add">safe-add</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int, &amp;Int] Bool)</p><span></span><p class="doc">Performs an addition and checks whether it overflowed.</p></div><div class="binder"><a href="#safe-mul" class="anchor"><h3 id="safe-mul">safe-mul</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int, &amp;Int] Bool)</p><span></span><p class="doc">Performs an multiplication and checks whether it overflowed.</p></div><div class="binder"><a href="#safe-sub" class="anchor"><h3 id="safe-sub">safe-sub</h3></a><div class="description">external</div><p class="sig">(λ [Int, Int, &amp;Int] Bool)</p><span></span><p class="doc">Performs an substraction and checks whether it overflowed.</p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [Int] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#zero" class="anchor"><h3 id="zero">zero</h3></a><div class="description">defn</div><p class="sig">(λ [] Int)</p><pre class="args">(zero)</pre><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Int
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#*">
+                    <h3 id="*">
+                        *
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#+">
+                    <h3 id="+">
+                        +
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#-">
+                    <h3 id="-">
+                        -
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/">
+                    <h3 id="/">
+                        /
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#MAX">
+                    <h3 id="MAX">
+                        MAX
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#MIN">
+                    <h3 id="MIN">
+                        MIN
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#abs">
+                    <h3 id="abs">
+                        abs
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    The absolute value (removes the negative sign) of an Int.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add-ref">
+                    <h3 id="add-ref">
+                        add-ref
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Int, &amp;Int] Int)
+                </p>
+                <pre class="args">
+                    (add-ref x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-and">
+                    <h3 id="bit-and">
+                        bit-and
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-not">
+                    <h3 id="bit-not">
+                        bit-not
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-or">
+                    <h3 id="bit-or">
+                        bit-or
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-shift-left">
+                    <h3 id="bit-shift-left">
+                        bit-shift-left
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-shift-right">
+                    <h3 id="bit-shift-right">
+                        bit-shift-right
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-xor">
+                    <h3 id="bit-xor">
+                        bit-xor
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#clamp">
+                    <h3 id="clamp">
+                        clamp
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, a, a] a)
+                </p>
+                <pre class="args">
+                    (clamp min max val)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dec">
+                    <h3 id="dec">
+                        dec
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#even?">
+                    <h3 id="even?">
+                        even?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int] Bool)
+                </p>
+                <pre class="args">
+                    (even? a)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-string">
+                    <h3 id="from-string">
+                        from-string
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Int] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#inc">
+                    <h3 id="inc">
+                        inc
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mod">
+                    <h3 id="mod">
+                        mod
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#neg">
+                    <h3 id="neg">
+                        neg
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#odd?">
+                    <h3 id="odd?">
+                        odd?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int] Bool)
+                </p>
+                <pre class="args">
+                    (odd? a)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pow">
+                    <h3 id="pow">
+                        pow
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <pre class="args">
+                    (pow x y)
+                </pre>
+                <p class="doc">
+                    Raise x to the power of y.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Int)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-between">
+                    <h3 id="random-between">
+                        random-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, Int] Int)
+                </p>
+                <pre class="args">
+                    (random-between lower upper)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#safe-add">
+                    <h3 id="safe-add">
+                        safe-add
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int, &amp;Int] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Performs an addition and checks whether it overflowed.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#safe-mul">
+                    <h3 id="safe-mul">
+                        safe-mul
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int, &amp;Int] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Performs an multiplication and checks whether it overflowed.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#safe-sub">
+                    <h3 id="safe-sub">
+                        safe-sub
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Int, &amp;Int] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Performs an substraction and checks whether it overflowed.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero">
+                    <h3 id="zero">
+                        zero
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Int)
+                </p>
+                <pre class="args">
+                    (zero)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -1,1 +1,813 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Long</h1><div class="binder"><a href="#*" class="anchor"><h3 id="*">*</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#+" class="anchor"><h3 id="+">+</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#-" class="anchor"><h3 id="-">-</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/" class="anchor"><h3 id="/">/</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [Long, Long] Bool)</p><pre class="args">(/= x y)</pre><p class="doc"></p></div><div class="binder"><a href="#&lt;" class="anchor"><h3 id="&lt;">&lt;</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&gt;" class="anchor"><h3 id="&gt;">&gt;</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#abs" class="anchor"><h3 id="abs">abs</h3></a><div class="description">external</div><p class="sig">(λ [Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-and" class="anchor"><h3 id="bit-and">bit-and</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-not" class="anchor"><h3 id="bit-not">bit-not</h3></a><div class="description">external</div><p class="sig">(λ [Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-or" class="anchor"><h3 id="bit-or">bit-or</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-shift-left" class="anchor"><h3 id="bit-shift-left">bit-shift-left</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-shift-right" class="anchor"><h3 id="bit-shift-right">bit-shift-right</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#bit-xor" class="anchor"><h3 id="bit-xor">bit-xor</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#dec" class="anchor"><h3 id="dec">dec</h3></a><div class="description">external</div><p class="sig">(λ [Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#even?" class="anchor"><h3 id="even?">even?</h3></a><div class="description">defn</div><p class="sig">(λ [Long] Bool)</p><pre class="args">(even? a)</pre><p class="doc"></p></div><div class="binder"><a href="#format" class="anchor"><h3 id="format">format</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Long] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-int" class="anchor"><h3 id="from-int">from-int</h3></a><div class="description">external</div><p class="sig">(λ [Int] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-string" class="anchor"><h3 id="from-string">from-string</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#hash" class="anchor"><h3 id="hash">hash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Long] Int)</p><pre class="args">(hash k)</pre><p class="doc"></p></div><div class="binder"><a href="#inc" class="anchor"><h3 id="inc">inc</h3></a><div class="description">external</div><p class="sig">(λ [Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#mod" class="anchor"><h3 id="mod">mod</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#neg" class="anchor"><h3 id="neg">neg</h3></a><div class="description">external</div><p class="sig">(λ [Long] Long)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#odd?" class="anchor"><h3 id="odd?">odd?</h3></a><div class="description">defn</div><p class="sig">(λ [Long] Bool)</p><pre class="args">(odd? a)</pre><p class="doc"></p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">defn</div><p class="sig">(λ [Long] String)</p><pre class="args">(prn x)</pre><p class="doc"></p></div><div class="binder"><a href="#random" class="anchor"><h3 id="random">random</h3></a><div class="description">defn</div><p class="sig">(λ [] Long)</p><pre class="args">(random)</pre><p class="doc"></p></div><div class="binder"><a href="#random-between" class="anchor"><h3 id="random-between">random-between</h3></a><div class="description">defn</div><p class="sig">(λ [Long, Long] Long)</p><pre class="args">(random-between lower upper)</pre><p class="doc"></p></div><div class="binder"><a href="#safe-add" class="anchor"><h3 id="safe-add">safe-add</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long, &amp;Long] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#safe-mul" class="anchor"><h3 id="safe-mul">safe-mul</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long, &amp;Long] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#safe-sub" class="anchor"><h3 id="safe-sub">safe-sub</h3></a><div class="description">external</div><p class="sig">(λ [Long, Long, &amp;Long] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#seed" class="anchor"><h3 id="seed">seed</h3></a><div class="description">external</div><p class="sig">(λ [Long] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [Long] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#to-int" class="anchor"><h3 id="to-int">to-int</h3></a><div class="description">external</div><p class="sig">(λ [Long] Int)</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Long
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#*">
+                    <h3 id="*">
+                        *
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#+">
+                    <h3 id="+">
+                        +
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#-">
+                    <h3 id="-">
+                        -
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/">
+                    <h3 id="/">
+                        /
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Bool)
+                </p>
+                <pre class="args">
+                    (/= x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#abs">
+                    <h3 id="abs">
+                        abs
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-and">
+                    <h3 id="bit-and">
+                        bit-and
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-not">
+                    <h3 id="bit-not">
+                        bit-not
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-or">
+                    <h3 id="bit-or">
+                        bit-or
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-shift-left">
+                    <h3 id="bit-shift-left">
+                        bit-shift-left
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-shift-right">
+                    <h3 id="bit-shift-right">
+                        bit-shift-right
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-xor">
+                    <h3 id="bit-xor">
+                        bit-xor
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dec">
+                    <h3 id="dec">
+                        dec
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#even?">
+                    <h3 id="even?">
+                        even?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Long] Bool)
+                </p>
+                <pre class="args">
+                    (even? a)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Long] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-int">
+                    <h3 id="from-int">
+                        from-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-string">
+                    <h3 id="from-string">
+                        from-string
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Long] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#inc">
+                    <h3 id="inc">
+                        inc
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mod">
+                    <h3 id="mod">
+                        mod
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#neg">
+                    <h3 id="neg">
+                        neg
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#odd?">
+                    <h3 id="odd?">
+                        odd?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Long] Bool)
+                </p>
+                <pre class="args">
+                    (odd? a)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Long] String)
+                </p>
+                <pre class="args">
+                    (prn x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Long)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-between">
+                    <h3 id="random-between">
+                        random-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Long, Long] Long)
+                </p>
+                <pre class="args">
+                    (random-between lower upper)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#safe-add">
+                    <h3 id="safe-add">
+                        safe-add
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long, &amp;Long] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#safe-mul">
+                    <h3 id="safe-mul">
+                        safe-mul
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long, &amp;Long] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#safe-sub">
+                    <h3 id="safe-sub">
+                        safe-sub
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long, Long, &amp;Long] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#seed">
+                    <h3 id="seed">
+                        seed
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-int">
+                    <h3 id="to-int">
+                        to-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Long] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -1,1 +1,585 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Map</h1><div class="binder"><a href="#buckets" class="anchor"><h3 id="buckets">buckets</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref (Map a b))] (Ref (Array (Bucket a b))))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#contains?" class="anchor"><h3 id="contains?">contains?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Map a b)), &amp;a] Bool)</p><pre class="args">(contains? m k)</pre><p class="doc">Check whether the map m contains the key k.</p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Map a b))] (Map a b))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#create" class="anchor"><h3 id="create">create</h3></a><div class="description">defn</div><p class="sig">(λ [] (Map a b))</p><pre class="args">(create)</pre><p class="doc">Create an empty hashmap.</p></div><div class="binder"><a href="#create-with-len" class="anchor"><h3 id="create-with-len">create-with-len</h3></a><div class="description">defn</div><p class="sig">(λ [Int] (Map a b))</p><pre class="args">(create-with-len len)</pre><p class="doc">Create an empty hashmap with a given minimum size.</p></div><div class="binder"><a href="#delete" class="anchor"><h3 id="delete">delete</h3></a><div class="description">template</div><p class="sig">(λ [(Map a b)] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#empty?" class="anchor"><h3 id="empty?">empty?</h3></a><div class="description">defn</div><p class="sig">(λ [a] Bool)</p><pre class="args">(empty? m)</pre><p class="doc"></p></div><div class="binder"><a href="#for-each" class="anchor"><h3 id="for-each">for-each</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Map a b)), (λ [&amp;a, &amp;b] ())] ())</p><pre class="args">(for-each m f)</pre><p class="doc">Execute the binary function f for all keys and value in map m.</p></div><div class="binder"><a href="#from-array" class="anchor"><h3 id="from-array">from-array</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array (Pair a b)))] (Map a b))</p><pre class="args">(from-array a)</pre><p class="doc">Create a map from the array a containing key-value pairs.</p></div><div class="binder"><a href="#get" class="anchor"><h3 id="get">get</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Map a b)), &amp;a] b)</p><pre class="args">(get m k)</pre><p class="doc">Get the value for the key k from map m. If it isn’t found, a zero element is returned.</p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">template</div><p class="sig">(λ [Int, (Array (Bucket a b))] (Map a b))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#length" class="anchor"><h3 id="length">length</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Map a b))] Int)</p><pre class="args">(length m)</pre><p class="doc">Check whether the map m is empty.</p></div><div class="binder"><a href="#n-buckets" class="anchor"><h3 id="n-buckets">n-buckets</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref (Map a b))] &amp;Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">template</div><p class="sig">(λ [(Ref (Map a b))] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#put" class="anchor"><h3 id="put">put</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Map a b)), &amp;a, &amp;b] (Map a b))</p><pre class="args">(put m k v)</pre><p class="doc">Put a a value v into map m, using the key k.</p></div><div class="binder"><a href="#remove" class="anchor"><h3 id="remove">remove</h3></a><div class="description">defn</div><p class="sig">(λ [(Map a b), &amp;a] (Map a b))</p><pre class="args">(remove m k)</pre><p class="doc">Remove the value under the key k from the map m.</p></div><div class="binder"><a href="#set-buckets" class="anchor"><h3 id="set-buckets">set-buckets</h3></a><div class="description">template</div><p class="sig">(λ [(Map a b), (Array (Bucket a b))] (Map a b))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-buckets!" class="anchor"><h3 id="set-buckets!">set-buckets!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref (Map a b)), (Array (Bucket a b))] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-n-buckets" class="anchor"><h3 id="set-n-buckets">set-n-buckets</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Map a b), Int] (Map a b))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-n-buckets!" class="anchor"><h3 id="set-n-buckets!">set-n-buckets!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref (Map a b)), Int] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Map a b))] String)</p><pre class="args">(str m)</pre><p class="doc"></p></div><div class="binder"><a href="#update-buckets" class="anchor"><h3 id="update-buckets">update-buckets</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Map a b), (λ [(Array (Bucket a b))] (Array (Bucket a b)))] (Map a b))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-n-buckets" class="anchor"><h3 id="update-n-buckets">update-n-buckets</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Map a b), (λ [Int] Int)] (Map a b))</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Map
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#buckets">
+                    <h3 id="buckets">
+                        buckets
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b))] (Ref (Array (Bucket a b))))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#contains?">
+                    <h3 id="contains?">
+                        contains?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b)), &amp;a] Bool)
+                </p>
+                <pre class="args">
+                    (contains? m k)
+                </pre>
+                <p class="doc">
+                    Check whether the map m contains the key k.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b))] (Map a b))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#create">
+                    <h3 id="create">
+                        create
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] (Map a b))
+                </p>
+                <pre class="args">
+                    (create)
+                </pre>
+                <p class="doc">
+                    Create an empty hashmap.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#create-with-len">
+                    <h3 id="create-with-len">
+                        create-with-len
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int] (Map a b))
+                </p>
+                <pre class="args">
+                    (create-with-len len)
+                </pre>
+                <p class="doc">
+                    Create an empty hashmap with a given minimum size.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Map a b)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#empty?">
+                    <h3 id="empty?">
+                        empty?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a] Bool)
+                </p>
+                <pre class="args">
+                    (empty? m)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#for-each">
+                    <h3 id="for-each">
+                        for-each
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b)), (λ [&amp;a, &amp;b] ())] ())
+                </p>
+                <pre class="args">
+                    (for-each m f)
+                </pre>
+                <p class="doc">
+                    Execute the binary function f for all keys and value in map m.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-array">
+                    <h3 id="from-array">
+                        from-array
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array (Pair a b)))] (Map a b))
+                </p>
+                <pre class="args">
+                    (from-array a)
+                </pre>
+                <p class="doc">
+                    Create a map from the array a containing key-value pairs.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get">
+                    <h3 id="get">
+                        get
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b)), &amp;a] b)
+                </p>
+                <pre class="args">
+                    (get m k)
+                </pre>
+                <p class="doc">
+                    Get the value for the key k from map m. If it isn’t found, a zero element is returned.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [Int, (Array (Bucket a b))] (Map a b))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#length">
+                    <h3 id="length">
+                        length
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b))] Int)
+                </p>
+                <pre class="args">
+                    (length m)
+                </pre>
+                <p class="doc">
+                    Check whether the map m is empty.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#n-buckets">
+                    <h3 id="n-buckets">
+                        n-buckets
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b))] &amp;Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b))] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#put">
+                    <h3 id="put">
+                        put
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b)), &amp;a, &amp;b] (Map a b))
+                </p>
+                <pre class="args">
+                    (put m k v)
+                </pre>
+                <p class="doc">
+                    Put a a value v into map m, using the key k.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#remove">
+                    <h3 id="remove">
+                        remove
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Map a b), &amp;a] (Map a b))
+                </p>
+                <pre class="args">
+                    (remove m k)
+                </pre>
+                <p class="doc">
+                    Remove the value under the key k from the map m.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-buckets">
+                    <h3 id="set-buckets">
+                        set-buckets
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Map a b), (Array (Bucket a b))] (Map a b))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-buckets!">
+                    <h3 id="set-buckets!">
+                        set-buckets!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b)), (Array (Bucket a b))] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-n-buckets">
+                    <h3 id="set-n-buckets">
+                        set-n-buckets
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Map a b), Int] (Map a b))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-n-buckets!">
+                    <h3 id="set-n-buckets!">
+                        set-n-buckets!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b)), Int] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b))] String)
+                </p>
+                <pre class="args">
+                    (str m)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-buckets">
+                    <h3 id="update-buckets">
+                        update-buckets
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Map a b), (λ [(Array (Bucket a b))] (Array (Bucket a b)))] (Map a b))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-n-buckets">
+                    <h3 id="update-n-buckets">
+                        update-n-buckets
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Map a b), (λ [Int] Int)] (Map a b))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -1,1 +1,376 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Pattern</h1><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern, &amp;Pattern] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern] Pattern)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#find" class="anchor"><h3 id="find">find</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern, &amp;String] Int)</p><span></span><p class="doc">Finds the index of a pattern in a string. Returns -1 otherwise.</p></div><div class="binder"><a href="#from-chars" class="anchor"><h3 id="from-chars">from-chars</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Char))] Pattern)</p><pre class="args">(from-chars chars)</pre><p class="doc">Creates a pattern that matches a group of characters from a list of those characters.</p></div><div class="binder"><a href="#global-match" class="anchor"><h3 id="global-match">global-match</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern, &amp;String] (Array (Array String)))</p><span></span><p class="doc">Finds all matches of a pattern in a string as a nested array. Returns [] otherwise.</p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] Pattern)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#match" class="anchor"><h3 id="match">match</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern, &amp;String] (Array String))</p><span></span><p class="doc">Finds the match groups of the first match of a pattern in a string. Returns [] otherwise.</p></div><div class="binder"><a href="#match-str" class="anchor"><h3 id="match-str">match-str</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern, &amp;String] String)</p><span></span><p class="doc">Finds the first match of a pattern in a string. Returns [] otherwise.</p></div><div class="binder"><a href="#matches?" class="anchor"><h3 id="matches?">matches?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;Pattern, &amp;String] Bool)</p><pre class="args">(matches? pat s)</pre><p class="doc">Checks whether a pattern matches a string.</p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#substitute" class="anchor"><h3 id="substitute">substitute</h3></a><div class="description">external</div><p class="sig">(λ [&amp;Pattern, &amp;String, &amp;String, Int] String)</p><span></span><p class="doc">Finds all matches of a pattern in a string and replaces it by another n times (-1 for all occurrences).</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Pattern
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern, &amp;Pattern] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern] Pattern)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#find">
+                    <h3 id="find">
+                        find
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern, &amp;String] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Finds the index of a pattern in a string. Returns -1 otherwise.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-chars">
+                    <h3 id="from-chars">
+                        from-chars
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Char))] Pattern)
+                </p>
+                <pre class="args">
+                    (from-chars chars)
+                </pre>
+                <p class="doc">
+                    Creates a pattern that matches a group of characters from a list of those characters.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#global-match">
+                    <h3 id="global-match">
+                        global-match
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern, &amp;String] (Array (Array String)))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Finds all matches of a pattern in a string as a nested array. Returns [] otherwise.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Pattern)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#match">
+                    <h3 id="match">
+                        match
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern, &amp;String] (Array String))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Finds the match groups of the first match of a pattern in a string. Returns [] otherwise.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#match-str">
+                    <h3 id="match-str">
+                        match-str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern, &amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Finds the first match of a pattern in a string. Returns [] otherwise.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#matches?">
+                    <h3 id="matches?">
+                        matches?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern, &amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (matches? pat s)
+                </pre>
+                <p class="doc">
+                    Checks whether a pattern matches a string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#substitute">
+                    <h3 id="substitute">
+                        substitute
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;Pattern, &amp;String, &amp;String, Int] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Finds all matches of a pattern in a string and replaces it by another n times (-1 for all occurrences).
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -1,1 +1,433 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Statistics</h1><div class="binder"><a href="#Summary" class="anchor"><h3 id="Summary">Summary</h3></a><div class="description">module</div><p class="sig">Module</p><span></span><p class="doc"></p></div><div class="binder"><a href="#grouped-median" class="anchor"><h3 id="grouped-median">grouped-median</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double)), Int] Double)</p><pre class="args">(grouped-median data interval)</pre><p class="doc">Compute the grouped median of the samples data.</p></div><div class="binder"><a href="#high-median" class="anchor"><h3 id="high-median">high-median</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(high-median data)</pre><p class="doc">Compute the high median of the samples data.</p></div><div class="binder"><a href="#iqr" class="anchor"><h3 id="iqr">iqr</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(iqr data)</pre><p class="doc">Compute the interquartile range.</p></div><div class="binder"><a href="#low-median" class="anchor"><h3 id="low-median">low-median</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(low-median data)</pre><p class="doc">Compute the low median of the samples data.</p></div><div class="binder"><a href="#mean" class="anchor"><h3 id="mean">mean</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(mean data)</pre><p class="doc">Compute the mean of the samples data.</p></div><div class="binder"><a href="#median" class="anchor"><h3 id="median">median</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(median data)</pre><p class="doc">Compute the median of the samples data.</p></div><div class="binder"><a href="#pstdev" class="anchor"><h3 id="pstdev">pstdev</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(pstdev data)</pre><p class="doc">Compute the population standard deviation of the samples data.</p></div><div class="binder"><a href="#pstdev-pct" class="anchor"><h3 id="pstdev-pct">pstdev-pct</h3></a><div class="description">external</div><p class="sig">a</p><span></span><p class="doc">Compute the standard deviation of the samples data as a percentile.</p></div><div class="binder"><a href="#pvariance" class="anchor"><h3 id="pvariance">pvariance</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(pvariance data)</pre><p class="doc">Compute the population variance of the samples data.</p></div><div class="binder"><a href="#quartiles" class="anchor"><h3 id="quartiles">quartiles</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] (Array Double))</p><pre class="args">(quartiles data)</pre><p class="doc">Compute the quartiles of the samples data.</p></div><div class="binder"><a href="#stdev" class="anchor"><h3 id="stdev">stdev</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(stdev data)</pre><p class="doc">Compute the standard deviation of the samples data.</p></div><div class="binder"><a href="#stdev-pct" class="anchor"><h3 id="stdev-pct">stdev-pct</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(stdev-pct data)</pre><p class="doc"></p></div><div class="binder"><a href="#summary" class="anchor"><h3 id="summary">summary</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Summary)</p><pre class="args">(summary samples)</pre><p class="doc">Compute a variety of statistical values from a list of samples.</p></div><div class="binder"><a href="#variance" class="anchor"><h3 id="variance">variance</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array Double))] Double)</p><pre class="args">(variance data)</pre><p class="doc">Compute the variance of the samples data.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Statistics
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#Summary">
+                    <h3 id="Summary">
+                        Summary
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    Module
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#grouped-median">
+                    <h3 id="grouped-median">
+                        grouped-median
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double)), Int] Double)
+                </p>
+                <pre class="args">
+                    (grouped-median data interval)
+                </pre>
+                <p class="doc">
+                    Compute the grouped median of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#high-median">
+                    <h3 id="high-median">
+                        high-median
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (high-median data)
+                </pre>
+                <p class="doc">
+                    Compute the high median of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#iqr">
+                    <h3 id="iqr">
+                        iqr
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (iqr data)
+                </pre>
+                <p class="doc">
+                    Compute the interquartile range.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#low-median">
+                    <h3 id="low-median">
+                        low-median
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (low-median data)
+                </pre>
+                <p class="doc">
+                    Compute the low median of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mean">
+                    <h3 id="mean">
+                        mean
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (mean data)
+                </pre>
+                <p class="doc">
+                    Compute the mean of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#median">
+                    <h3 id="median">
+                        median
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (median data)
+                </pre>
+                <p class="doc">
+                    Compute the median of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pstdev">
+                    <h3 id="pstdev">
+                        pstdev
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (pstdev data)
+                </pre>
+                <p class="doc">
+                    Compute the population standard deviation of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pstdev-pct">
+                    <h3 id="pstdev-pct">
+                        pstdev-pct
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    a
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Compute the standard deviation of the samples data as a percentile.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pvariance">
+                    <h3 id="pvariance">
+                        pvariance
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (pvariance data)
+                </pre>
+                <p class="doc">
+                    Compute the population variance of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#quartiles">
+                    <h3 id="quartiles">
+                        quartiles
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] (Array Double))
+                </p>
+                <pre class="args">
+                    (quartiles data)
+                </pre>
+                <p class="doc">
+                    Compute the quartiles of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#stdev">
+                    <h3 id="stdev">
+                        stdev
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (stdev data)
+                </pre>
+                <p class="doc">
+                    Compute the standard deviation of the samples data.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#stdev-pct">
+                    <h3 id="stdev-pct">
+                        stdev-pct
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (stdev-pct data)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#summary">
+                    <h3 id="summary">
+                        summary
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Summary)
+                </p>
+                <pre class="args">
+                    (summary samples)
+                </pre>
+                <p class="doc">
+                    Compute a variety of statistical values from a list of samples.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#variance">
+                    <h3 id="variance">
+                        variance
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Double))] Double)
+                </p>
+                <pre class="args">
+                    (variance data)
+                </pre>
+                <p class="doc">
+                    Compute the variance of the samples data.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -1,1 +1,1193 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>String</h1><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, &amp;String] Bool)</p><pre class="args">(/= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#&lt;" class="anchor"><h3 id="&lt;">&lt;</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, &amp;String] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, &amp;String] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#&gt;" class="anchor"><h3 id="&gt;">&gt;</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, &amp;String] Bool)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#allocate" class="anchor"><h3 id="allocate">allocate</h3></a><div class="description">external</div><p class="sig">(λ [Int, Char] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#alpha?" class="anchor"><h3 id="alpha?">alpha?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Bool)</p><pre class="args">(alpha? s)</pre><p class="doc">Check if a string contains only alpha characters (a-Z).</p></div><div class="binder"><a href="#alphanum?" class="anchor"><h3 id="alphanum?">alphanum?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Bool)</p><pre class="args">(alphanum? s)</pre><p class="doc">Checks whether a string is alphanumerical.</p></div><div class="binder"><a href="#append" class="anchor"><h3 id="append">append</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, &amp;String] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#char-at" class="anchor"><h3 id="char-at">char-at</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Int] Char)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#chars" class="anchor"><h3 id="chars">chars</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] (Array Char))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#chomp" class="anchor"><h3 id="chomp">chomp</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] String)</p><pre class="args">(chomp s)</pre><p class="doc">Trims newline from the end of a string.</p></div><div class="binder"><a href="#collapse-whitespace" class="anchor"><h3 id="collapse-whitespace">collapse-whitespace</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] String)</p><pre class="args">(collapse-whitespace s)</pre><p class="doc">Collapse groups of whitespace into single spaces.</p></div><div class="binder"><a href="#concat" class="anchor"><h3 id="concat">concat</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array String))] String)</p><pre class="args">(concat strings)</pre><p class="doc">Returns a new string which is the concatenation of the provided `strings`.</p></div><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#count-char" class="anchor"><h3 id="count-char">count-char</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, Char] Int)</p><pre class="args">(count-char s c)</pre><p class="doc">Returns the number of occurrences of `c` in the string `s`.</p></div><div class="binder"><a href="#cstr" class="anchor"><h3 id="cstr">cstr</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] (Ptr Char))</p><span></span><p class="doc"></p></div><div class="binder"><a href="#empty?" class="anchor"><h3 id="empty?">empty?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Bool)</p><pre class="args">(empty? s)</pre><p class="doc">Check if the string is the empty string.</p></div><div class="binder"><a href="#ends-with?" class="anchor"><h3 id="ends-with?">ends-with?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, &amp;String] Bool)</p><pre class="args">(ends-with? s sub)</pre><p class="doc">Check if the string `s` ends with the string `sub`.</p></div><div class="binder"><a href="#format" class="anchor"><h3 id="format">format</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, &amp;String] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#from-chars" class="anchor"><h3 id="from-chars">from-chars</h3></a><div class="description">external</div><p class="sig">(λ [(Ref (Array Char))] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#hash" class="anchor"><h3 id="hash">hash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Int)</p><pre class="args">(hash k)</pre><p class="doc"></p></div><div class="binder"><a href="#head" class="anchor"><h3 id="head">head</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Char)</p><pre class="args">(head s)</pre><p class="doc">Returns the character at start of string.</p></div><div class="binder"><a href="#hex?" class="anchor"><h3 id="hex?">hex?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Bool)</p><pre class="args">(hex? s)</pre><p class="doc">Checks whether a string is hexadecimal.</p></div><div class="binder"><a href="#in?" class="anchor"><h3 id="in?">in?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, &amp;String] Bool)</p><pre class="args">(in? s sub)</pre><p class="doc">Checks whether a string contains another string.</p></div><div class="binder"><a href="#index-of" class="anchor"><h3 id="index-of">index-of</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Char] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#index-of-from" class="anchor"><h3 id="index-of-from">index-of-from</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Char, Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#join" class="anchor"><h3 id="join">join</h3></a><div class="description">defn</div><p class="sig">(λ [String, (Ref (Array String))] String)</p><pre class="args">(join sep strings)</pre><p class="doc">Returns a new string which is the concatenation of the provided `strings` separated by string `sep`.</p></div><div class="binder"><a href="#join-with-char" class="anchor"><h3 id="join-with-char">join-with-char</h3></a><div class="description">defn</div><p class="sig">(λ [Char, (Ref (Array String))] String)</p><pre class="args">(join-with-char sep strings)</pre><p class="doc">Returns a new string which is the concatenation of the provided `strings` separated by char `sep`.</p></div><div class="binder"><a href="#length" class="anchor"><h3 id="length">length</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#lines" class="anchor"><h3 id="lines">lines</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] (Array String))</p><pre class="args">(lines s)</pre><p class="doc">Split a string into lines.</p></div><div class="binder"><a href="#lower?" class="anchor"><h3 id="lower?">lower?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Bool)</p><pre class="args">(lower? s)</pre><p class="doc">Checks whether a string is all lowercase.</p></div><div class="binder"><a href="#num?" class="anchor"><h3 id="num?">num?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Bool)</p><pre class="args">(num? s)</pre><p class="doc">Checks whether a string is numerical.</p></div><div class="binder"><a href="#pad-left" class="anchor"><h3 id="pad-left">pad-left</h3></a><div class="description">defn</div><p class="sig">(λ [Int, Char, &amp;String] String)</p><pre class="args">(pad-left len pad s)</pre><p class="doc">Pads the left of a string with len bytes using the padding pad.</p></div><div class="binder"><a href="#pad-right" class="anchor"><h3 id="pad-right">pad-right</h3></a><div class="description">defn</div><p class="sig">(λ [Int, Char, &amp;String] String)</p><pre class="args">(pad-right len pad s)</pre><p class="doc">Pads the right of a string with len bytes using the padding pad.</p></div><div class="binder"><a href="#prefix-string" class="anchor"><h3 id="prefix-string">prefix-string</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, Int] String)</p><pre class="args">(prefix-string s a)</pre><p class="doc">Return the first `a` characters of the string `s`.</p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#random-sized" class="anchor"><h3 id="random-sized">random-sized</h3></a><div class="description">defn</div><p class="sig">(λ [Int] String)</p><pre class="args">(random-sized n)</pre><p class="doc"></p></div><div class="binder"><a href="#rehash" class="anchor"><h3 id="rehash">rehash</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, Int] Int)</p><pre class="args">(rehash k l)</pre><p class="doc"></p></div><div class="binder"><a href="#repeat" class="anchor"><h3 id="repeat">repeat</h3></a><div class="description">defn</div><p class="sig">(λ [Int, &amp;String] String)</p><pre class="args">(repeat n inpt)</pre><p class="doc">Returns a new string which is `inpt` repeated `n` times.</p></div><div class="binder"><a href="#reverse" class="anchor"><h3 id="reverse">reverse</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] String)</p><pre class="args">(reverse s)</pre><p class="doc">Produce a new string which is `s` reversed.</p></div><div class="binder"><a href="#split-by" class="anchor"><h3 id="split-by">split-by</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, (Ref (Array Char))] (Array String))</p><pre class="args">(split-by _s separators)</pre><p class="doc">Split a string by separators.</p></div><div class="binder"><a href="#starts-with?" class="anchor"><h3 id="starts-with?">starts-with?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, &amp;String] Bool)</p><pre class="args">(starts-with? s sub)</pre><p class="doc">Check if the string `s` begins with the string `sub`.</p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#string-set!" class="anchor"><h3 id="string-set!">string-set!</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Int, Char] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#string-set-at!" class="anchor"><h3 id="string-set-at!">string-set-at!</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String, Int, &amp;String] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#substring" class="anchor"><h3 id="substring">substring</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, Int, Int] String)</p><pre class="args">(substring s a b)</pre><p class="doc"></p></div><div class="binder"><a href="#suffix-string" class="anchor"><h3 id="suffix-string">suffix-string</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String, Int] String)</p><pre class="args">(suffix-string s b)</pre><p class="doc">Return the last `b` characters of the string `s`.</p></div><div class="binder"><a href="#sum-length" class="anchor"><h3 id="sum-length">sum-length</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref (Array String))] Int)</p><pre class="args">(sum-length strings)</pre><p class="doc">Returns the sum of lengths from an array of Strings.</p></div><div class="binder"><a href="#tail" class="anchor"><h3 id="tail">tail</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#trim" class="anchor"><h3 id="trim">trim</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] String)</p><pre class="args">(trim s)</pre><p class="doc">Trims whitespace from both sides of a string.</p></div><div class="binder"><a href="#trim-left" class="anchor"><h3 id="trim-left">trim-left</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] String)</p><pre class="args">(trim-left s)</pre><p class="doc">Trims whitespace from the left of a string.</p></div><div class="binder"><a href="#trim-right" class="anchor"><h3 id="trim-right">trim-right</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] String)</p><pre class="args">(trim-right s)</pre><p class="doc">Trims whitespace from the right of a string.</p></div><div class="binder"><a href="#upper?" class="anchor"><h3 id="upper?">upper?</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] Bool)</p><pre class="args">(upper? s)</pre><p class="doc">Checks whether a string is all uppercase.</p></div><div class="binder"><a href="#words" class="anchor"><h3 id="words">words</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;String] (Array String))</p><pre class="args">(words s)</pre><p class="doc">Split a string into words.</p></div><div class="binder"><a href="#zero" class="anchor"><h3 id="zero">zero</h3></a><div class="description">defn</div><p class="sig">(λ [] String)</p><pre class="args">(zero)</pre><p class="doc">The empty string.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                String
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (/= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#allocate">
+                    <h3 id="allocate">
+                        allocate
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, Char] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#alpha?">
+                    <h3 id="alpha?">
+                        alpha?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (alpha? s)
+                </pre>
+                <p class="doc">
+                    Check if a string contains only alpha characters (a-Z).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#alphanum?">
+                    <h3 id="alphanum?">
+                        alphanum?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (alphanum? s)
+                </pre>
+                <p class="doc">
+                    Checks whether a string is alphanumerical.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#append">
+                    <h3 id="append">
+                        append
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#char-at">
+                    <h3 id="char-at">
+                        char-at
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int] Char)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#chars">
+                    <h3 id="chars">
+                        chars
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] (Array Char))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#chomp">
+                    <h3 id="chomp">
+                        chomp
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <pre class="args">
+                    (chomp s)
+                </pre>
+                <p class="doc">
+                    Trims newline from the end of a string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#collapse-whitespace">
+                    <h3 id="collapse-whitespace">
+                        collapse-whitespace
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <pre class="args">
+                    (collapse-whitespace s)
+                </pre>
+                <p class="doc">
+                    Collapse groups of whitespace into single spaces.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#concat">
+                    <h3 id="concat">
+                        concat
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array String))] String)
+                </p>
+                <pre class="args">
+                    (concat strings)
+                </pre>
+                <p class="doc">
+                    Returns a new string which is the concatenation of the provided `strings`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#count-char">
+                    <h3 id="count-char">
+                        count-char
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Char] Int)
+                </p>
+                <pre class="args">
+                    (count-char s c)
+                </pre>
+                <p class="doc">
+                    Returns the number of occurrences of `c` in the string `s`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cstr">
+                    <h3 id="cstr">
+                        cstr
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] (Ptr Char))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#empty?">
+                    <h3 id="empty?">
+                        empty?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (empty? s)
+                </pre>
+                <p class="doc">
+                    Check if the string is the empty string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ends-with?">
+                    <h3 id="ends-with?">
+                        ends-with?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (ends-with? s sub)
+                </pre>
+                <p class="doc">
+                    Check if the string `s` ends with the string `sub`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#from-chars">
+                    <h3 id="from-chars">
+                        from-chars
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array Char))] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#head">
+                    <h3 id="head">
+                        head
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Char)
+                </p>
+                <pre class="args">
+                    (head s)
+                </pre>
+                <p class="doc">
+                    Returns the character at start of string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#hex?">
+                    <h3 id="hex?">
+                        hex?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (hex? s)
+                </pre>
+                <p class="doc">
+                    Checks whether a string is hexadecimal.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#in?">
+                    <h3 id="in?">
+                        in?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (in? s sub)
+                </pre>
+                <p class="doc">
+                    Checks whether a string contains another string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#index-of">
+                    <h3 id="index-of">
+                        index-of
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Char] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#index-of-from">
+                    <h3 id="index-of-from">
+                        index-of-from
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Char, Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#join">
+                    <h3 id="join">
+                        join
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [String, (Ref (Array String))] String)
+                </p>
+                <pre class="args">
+                    (join sep strings)
+                </pre>
+                <p class="doc">
+                    Returns a new string which is the concatenation of the provided `strings` separated by string `sep`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#join-with-char">
+                    <h3 id="join-with-char">
+                        join-with-char
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char, (Ref (Array String))] String)
+                </p>
+                <pre class="args">
+                    (join-with-char sep strings)
+                </pre>
+                <p class="doc">
+                    Returns a new string which is the concatenation of the provided `strings` separated by char `sep`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#length">
+                    <h3 id="length">
+                        length
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#lines">
+                    <h3 id="lines">
+                        lines
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] (Array String))
+                </p>
+                <pre class="args">
+                    (lines s)
+                </pre>
+                <p class="doc">
+                    Split a string into lines.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#lower?">
+                    <h3 id="lower?">
+                        lower?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (lower? s)
+                </pre>
+                <p class="doc">
+                    Checks whether a string is all lowercase.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#num?">
+                    <h3 id="num?">
+                        num?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (num? s)
+                </pre>
+                <p class="doc">
+                    Checks whether a string is numerical.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pad-left">
+                    <h3 id="pad-left">
+                        pad-left
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, Char, &amp;String] String)
+                </p>
+                <pre class="args">
+                    (pad-left len pad s)
+                </pre>
+                <p class="doc">
+                    Pads the left of a string with len bytes using the padding pad.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#pad-right">
+                    <h3 id="pad-right">
+                        pad-right
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, Char, &amp;String] String)
+                </p>
+                <pre class="args">
+                    (pad-right len pad s)
+                </pre>
+                <p class="doc">
+                    Pads the right of a string with len bytes using the padding pad.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prefix-string">
+                    <h3 id="prefix-string">
+                        prefix-string
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int] String)
+                </p>
+                <pre class="args">
+                    (prefix-string s a)
+                </pre>
+                <p class="doc">
+                    Return the first `a` characters of the string `s`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-sized">
+                    <h3 id="random-sized">
+                        random-sized
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int] String)
+                </p>
+                <pre class="args">
+                    (random-sized n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#rehash">
+                    <h3 id="rehash">
+                        rehash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int] Int)
+                </p>
+                <pre class="args">
+                    (rehash k l)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#repeat">
+                    <h3 id="repeat">
+                        repeat
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, &amp;String] String)
+                </p>
+                <pre class="args">
+                    (repeat n inpt)
+                </pre>
+                <p class="doc">
+                    Returns a new string which is `inpt` repeated `n` times.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#reverse">
+                    <h3 id="reverse">
+                        reverse
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <pre class="args">
+                    (reverse s)
+                </pre>
+                <p class="doc">
+                    Produce a new string which is `s` reversed.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#split-by">
+                    <h3 id="split-by">
+                        split-by
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, (Ref (Array Char))] (Array String))
+                </p>
+                <pre class="args">
+                    (split-by _s separators)
+                </pre>
+                <p class="doc">
+                    Split a string by separators.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#starts-with?">
+                    <h3 id="starts-with?">
+                        starts-with?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, &amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (starts-with? s sub)
+                </pre>
+                <p class="doc">
+                    Check if the string `s` begins with the string `sub`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#string-set!">
+                    <h3 id="string-set!">
+                        string-set!
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int, Char] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#string-set-at!">
+                    <h3 id="string-set-at!">
+                        string-set-at!
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int, &amp;String] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#substring">
+                    <h3 id="substring">
+                        substring
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int, Int] String)
+                </p>
+                <pre class="args">
+                    (substring s a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#suffix-string">
+                    <h3 id="suffix-string">
+                        suffix-string
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String, Int] String)
+                </p>
+                <pre class="args">
+                    (suffix-string s b)
+                </pre>
+                <p class="doc">
+                    Return the last `b` characters of the string `s`.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sum-length">
+                    <h3 id="sum-length">
+                        sum-length
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array String))] Int)
+                </p>
+                <pre class="args">
+                    (sum-length strings)
+                </pre>
+                <p class="doc">
+                    Returns the sum of lengths from an array of Strings.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#tail">
+                    <h3 id="tail">
+                        tail
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#trim">
+                    <h3 id="trim">
+                        trim
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <pre class="args">
+                    (trim s)
+                </pre>
+                <p class="doc">
+                    Trims whitespace from both sides of a string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#trim-left">
+                    <h3 id="trim-left">
+                        trim-left
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <pre class="args">
+                    (trim-left s)
+                </pre>
+                <p class="doc">
+                    Trims whitespace from the left of a string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#trim-right">
+                    <h3 id="trim-right">
+                        trim-right
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] String)
+                </p>
+                <pre class="args">
+                    (trim-right s)
+                </pre>
+                <p class="doc">
+                    Trims whitespace from the right of a string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#upper?">
+                    <h3 id="upper?">
+                        upper?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Bool)
+                </p>
+                <pre class="args">
+                    (upper? s)
+                </pre>
+                <p class="doc">
+                    Checks whether a string is all uppercase.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#words">
+                    <h3 id="words">
+                        words
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] (Array String))
+                </p>
+                <pre class="args">
+                    (words s)
+                </pre>
+                <p class="doc">
+                    Split a string into words.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero">
+                    <h3 id="zero">
+                        zero
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] String)
+                </p>
+                <pre class="args">
+                    (zero)
+                </pre>
+                <p class="doc">
+                    The empty string.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -1,1 +1,490 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>System</h1><div class="binder"><a href="#exit" class="anchor"><h3 id="exit">exit</h3></a><div class="description">template</div><p class="sig">(λ [Int] a)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#fork" class="anchor"><h3 id="fork">fork</h3></a><div class="description">external</div><p class="sig">(λ [] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#free" class="anchor"><h3 id="free">free</h3></a><div class="description">external</div><p class="sig">(λ [t] ())</p><span></span><p class="doc">Frees an object. Should not be called except in direst circumstances.</p></div><div class="binder"><a href="#get-arg" class="anchor"><h3 id="get-arg">get-arg</h3></a><div class="description">external</div><p class="sig">(λ [Int] &amp;String)</p><span></span><p class="doc">Gets the number of command line arguments.</p></div><div class="binder"><a href="#get-args-len" class="anchor"><h3 id="get-args-len">get-args-len</h3></a><div class="description">external</div><p class="sig">(λ [] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#get-exit-status" class="anchor"><h3 id="get-exit-status">get-exit-status</h3></a><div class="description">external</div><p class="sig">(λ [Int] Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#signal" class="anchor"><h3 id="signal">signal</h3></a><div class="description">external</div><p class="sig">(λ [Int, (λ [Int] ())] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#signal-abort" class="anchor"><h3 id="signal-abort">signal-abort</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#signal-fpe" class="anchor"><h3 id="signal-fpe">signal-fpe</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#signal-ill" class="anchor"><h3 id="signal-ill">signal-ill</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#signal-int" class="anchor"><h3 id="signal-int">signal-int</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#signal-segv" class="anchor"><h3 id="signal-segv">signal-segv</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#signal-term" class="anchor"><h3 id="signal-term">signal-term</h3></a><div class="description">external</div><p class="sig">Int</p><span></span><p class="doc"></p></div><div class="binder"><a href="#sleep-micros" class="anchor"><h3 id="sleep-micros">sleep-micros</h3></a><div class="description">external</div><p class="sig">(λ [Int] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#sleep-seconds" class="anchor"><h3 id="sleep-seconds">sleep-seconds</h3></a><div class="description">external</div><p class="sig">(λ [Int] ())</p><span></span><p class="doc">Sleeps for a specified number of microseconds.</p></div><div class="binder"><a href="#system" class="anchor"><h3 id="system">system</h3></a><div class="description">external</div><p class="sig">(λ [&amp;String] ())</p><span></span><p class="doc">Performs a system command.</p></div><div class="binder"><a href="#time" class="anchor"><h3 id="time">time</h3></a><div class="description">external</div><p class="sig">(λ [] Int)</p><span></span><p class="doc">Gets the current system time as an integer.</p></div><div class="binder"><a href="#wait" class="anchor"><h3 id="wait">wait</h3></a><div class="description">external</div><p class="sig">(λ [(Ptr Int)] Int)</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                System
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#exit">
+                    <h3 id="exit">
+                        exit
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [Int] a)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#fork">
+                    <h3 id="fork">
+                        fork
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#free">
+                    <h3 id="free">
+                        free
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [t] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Frees an object. Should not be called except in direst circumstances.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get-arg">
+                    <h3 id="get-arg">
+                        get-arg
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] &amp;String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Gets the number of command line arguments.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get-args-len">
+                    <h3 id="get-args-len">
+                        get-args-len
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get-exit-status">
+                    <h3 id="get-exit-status">
+                        get-exit-status
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#signal">
+                    <h3 id="signal">
+                        signal
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int, (λ [Int] ())] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#signal-abort">
+                    <h3 id="signal-abort">
+                        signal-abort
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#signal-fpe">
+                    <h3 id="signal-fpe">
+                        signal-fpe
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#signal-ill">
+                    <h3 id="signal-ill">
+                        signal-ill
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#signal-int">
+                    <h3 id="signal-int">
+                        signal-int
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#signal-segv">
+                    <h3 id="signal-segv">
+                        signal-segv
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#signal-term">
+                    <h3 id="signal-term">
+                        signal-term
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sleep-micros">
+                    <h3 id="sleep-micros">
+                        sleep-micros
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sleep-seconds">
+                    <h3 id="sleep-seconds">
+                        sleep-seconds
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Int] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Sleeps for a specified number of microseconds.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#system">
+                    <h3 id="system">
+                        system
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Performs a system command.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#time">
+                    <h3 id="time">
+                        time
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Gets the current system time as an integer.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#wait">
+                    <h3 id="wait">
+                        wait
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr Int)] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -1,1 +1,338 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Test</h1><div class="binder"><a href="#State" class="anchor"><h3 id="State">State</h3></a><div class="description">module</div><p class="sig">Module</p><span></span><p class="doc"></p></div><div class="binder"><a href="#assert-equal" class="anchor"><h3 id="assert-equal">assert-equal</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State), a, a, &amp;b] State)</p><pre class="args">(assert-equal state x y descr)</pre><p class="doc">Assert that x and y are equal. Equality needs to be implemented for their type.</p></div><div class="binder"><a href="#assert-exit" class="anchor"><h3 id="assert-exit">assert-exit</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State), Int, (λ [] ()), &amp;a] State)</p><pre class="args">(assert-exit state exit-code f descr)</pre><p class="doc">Assert that function f aborts with OS signal signal.</p></div><div class="binder"><a href="#assert-false" class="anchor"><h3 id="assert-false">assert-false</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State), Bool, &amp;a] State)</p><pre class="args">(assert-false state x descr)</pre><p class="doc">Assert that x is false.</p></div><div class="binder"><a href="#assert-not-equal" class="anchor"><h3 id="assert-not-equal">assert-not-equal</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State), a, a, &amp;b] State)</p><pre class="args">(assert-not-equal state x y descr)</pre><p class="doc">Assert that x and y are not equal. Equality needs to be implemented for their type.</p></div><div class="binder"><a href="#assert-op" class="anchor"><h3 id="assert-op">assert-op</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State), a, b, &amp;c, (λ [a, b] Bool)] State)</p><pre class="args">(assert-op state x y descr op)</pre><p class="doc">Assert that op returns true when given x and y.</p></div><div class="binder"><a href="#assert-signal" class="anchor"><h3 id="assert-signal">assert-signal</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State), Int, (λ [] ()), &amp;a] State)</p><pre class="args">(assert-signal state signal x descr)</pre><p class="doc"></p></div><div class="binder"><a href="#assert-true" class="anchor"><h3 id="assert-true">assert-true</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State), Bool, &amp;a] State)</p><pre class="args">(assert-true state x descr)</pre><p class="doc">Assert that x is true.</p></div><div class="binder"><a href="#print-test-results" class="anchor"><h3 id="print-test-results">print-test-results</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref State)] State)</p><pre class="args">(print-test-results state)</pre><p class="doc">Print test results.</p></div><div class="binder"><a href="#reset" class="anchor"><h3 id="reset">reset</h3></a><div class="description">defn</div><p class="sig">(λ [State] State)</p><pre class="args">(reset state)</pre><p class="doc">Reset test state.</p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Test
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#State">
+                    <h3 id="State">
+                        State
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    Module
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-equal">
+                    <h3 id="assert-equal">
+                        assert-equal
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State), a, a, &amp;b] State)
+                </p>
+                <pre class="args">
+                    (assert-equal state x y descr)
+                </pre>
+                <p class="doc">
+                    Assert that x and y are equal. Equality needs to be implemented for their type.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-exit">
+                    <h3 id="assert-exit">
+                        assert-exit
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State), Int, (λ [] ()), &amp;a] State)
+                </p>
+                <pre class="args">
+                    (assert-exit state exit-code f descr)
+                </pre>
+                <p class="doc">
+                    Assert that function f aborts with OS signal signal.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-false">
+                    <h3 id="assert-false">
+                        assert-false
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State), Bool, &amp;a] State)
+                </p>
+                <pre class="args">
+                    (assert-false state x descr)
+                </pre>
+                <p class="doc">
+                    Assert that x is false.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-not-equal">
+                    <h3 id="assert-not-equal">
+                        assert-not-equal
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State), a, a, &amp;b] State)
+                </p>
+                <pre class="args">
+                    (assert-not-equal state x y descr)
+                </pre>
+                <p class="doc">
+                    Assert that x and y are not equal. Equality needs to be implemented for their type.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-op">
+                    <h3 id="assert-op">
+                        assert-op
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State), a, b, &amp;c, (λ [a, b] Bool)] State)
+                </p>
+                <pre class="args">
+                    (assert-op state x y descr op)
+                </pre>
+                <p class="doc">
+                    Assert that op returns true when given x and y.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-signal">
+                    <h3 id="assert-signal">
+                        assert-signal
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State), Int, (λ [] ()), &amp;a] State)
+                </p>
+                <pre class="args">
+                    (assert-signal state signal x descr)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-true">
+                    <h3 id="assert-true">
+                        assert-true
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State), Bool, &amp;a] State)
+                </p>
+                <pre class="args">
+                    (assert-true state x descr)
+                </pre>
+                <p class="doc">
+                    Assert that x is true.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#print-test-results">
+                    <h3 id="print-test-results">
+                        print-test-results
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State)] State)
+                </p>
+                <pre class="args">
+                    (print-test-results state)
+                </pre>
+                <p class="doc">
+                    Print test results.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#reset">
+                    <h3 id="reset">
+                        reset
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [State] State)
+                </p>
+                <pre class="args">
+                    (reset state)
+                </pre>
+                <p class="doc">
+                    Reset test state.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/V2.html
+++ b/docs/core/V2.html
@@ -1,1 +1,376 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Vector2.V2</h1><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V2)] V2)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">instantiate</div><p class="sig">(λ [Double, Double] V2)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V2)] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-x" class="anchor"><h3 id="set-x">set-x</h3></a><div class="description">instantiate</div><p class="sig">(λ [V2, Double] V2)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-x!" class="anchor"><h3 id="set-x!">set-x!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V2), Double] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-y" class="anchor"><h3 id="set-y">set-y</h3></a><div class="description">instantiate</div><p class="sig">(λ [V2, Double] V2)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-y!" class="anchor"><h3 id="set-y!">set-y!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V2), Double] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V2)] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-x" class="anchor"><h3 id="update-x">update-x</h3></a><div class="description">instantiate</div><p class="sig">(λ [V2, (λ [Double] Double)] V2)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-y" class="anchor"><h3 id="update-y">update-y</h3></a><div class="description">instantiate</div><p class="sig">(λ [V2, (λ [Double] Double)] V2)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#x" class="anchor"><h3 id="x">x</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V2)] &amp;Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#y" class="anchor"><h3 id="y">y</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V2)] &amp;Double)</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Vector2.V2
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] V2)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] V2)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x">
+                    <h3 id="set-x">
+                        set-x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V2, Double] V2)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x!">
+                    <h3 id="set-x!">
+                        set-x!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), Double] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y">
+                    <h3 id="set-y">
+                        set-y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V2, Double] V2)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y!">
+                    <h3 id="set-y!">
+                        set-y!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), Double] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-x">
+                    <h3 id="update-x">
+                        update-x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V2, (λ [Double] Double)] V2)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-y">
+                    <h3 id="update-y">
+                        update-y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V2, (λ [Double] Double)] V2)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#x">
+                    <h3 id="x">
+                        x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] &amp;Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#y">
+                    <h3 id="y">
+                        y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] &amp;Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/V3.html
+++ b/docs/core/V3.html
@@ -1,1 +1,452 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Vector3.V3</h1><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3)] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">instantiate</div><p class="sig">(λ [Double, Double, Double] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3)] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-x" class="anchor"><h3 id="set-x">set-x</h3></a><div class="description">instantiate</div><p class="sig">(λ [V3, Double] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-x!" class="anchor"><h3 id="set-x!">set-x!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3), Double] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-y" class="anchor"><h3 id="set-y">set-y</h3></a><div class="description">instantiate</div><p class="sig">(λ [V3, Double] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-y!" class="anchor"><h3 id="set-y!">set-y!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3), Double] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-z" class="anchor"><h3 id="set-z">set-z</h3></a><div class="description">instantiate</div><p class="sig">(λ [V3, Double] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-z!" class="anchor"><h3 id="set-z!">set-z!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3), Double] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3)] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-x" class="anchor"><h3 id="update-x">update-x</h3></a><div class="description">instantiate</div><p class="sig">(λ [V3, (λ [Double] Double)] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-y" class="anchor"><h3 id="update-y">update-y</h3></a><div class="description">instantiate</div><p class="sig">(λ [V3, (λ [Double] Double)] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-z" class="anchor"><h3 id="update-z">update-z</h3></a><div class="description">instantiate</div><p class="sig">(λ [V3, (λ [Double] Double)] V3)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#x" class="anchor"><h3 id="x">x</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3)] &amp;Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#y" class="anchor"><h3 id="y">y</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3)] &amp;Double)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#z" class="anchor"><h3 id="z">z</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref V3)] &amp;Double)</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Vector3.V3
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [Double, Double, Double] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x">
+                    <h3 id="set-x">
+                        set-x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V3, Double] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x!">
+                    <h3 id="set-x!">
+                        set-x!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), Double] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y">
+                    <h3 id="set-y">
+                        set-y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V3, Double] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y!">
+                    <h3 id="set-y!">
+                        set-y!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), Double] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-z">
+                    <h3 id="set-z">
+                        set-z
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V3, Double] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-z!">
+                    <h3 id="set-z!">
+                        set-z!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), Double] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-x">
+                    <h3 id="update-x">
+                        update-x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V3, (λ [Double] Double)] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-y">
+                    <h3 id="update-y">
+                        update-y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V3, (λ [Double] Double)] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-z">
+                    <h3 id="update-z">
+                        update-z
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [V3, (λ [Double] Double)] V3)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#x">
+                    <h3 id="x">
+                        x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] &amp;Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#y">
+                    <h3 id="y">
+                        y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] &amp;Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#z">
+                    <h3 id="z">
+                        z
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] &amp;Double)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/VN.html
+++ b/docs/core/VN.html
@@ -1,1 +1,376 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>VectorN.VN</h1><div class="binder"><a href="#copy" class="anchor"><h3 id="copy">copy</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref VN)] VN)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">instantiate</div><p class="sig">(λ [Int, (Array Double)] VN)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#n" class="anchor"><h3 id="n">n</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref VN)] &amp;Int)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#prn" class="anchor"><h3 id="prn">prn</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref VN)] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-n" class="anchor"><h3 id="set-n">set-n</h3></a><div class="description">instantiate</div><p class="sig">(λ [VN, Int] VN)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-n!" class="anchor"><h3 id="set-n!">set-n!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref VN), Int] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-v" class="anchor"><h3 id="set-v">set-v</h3></a><div class="description">instantiate</div><p class="sig">(λ [VN, (Array Double)] VN)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#set-v!" class="anchor"><h3 id="set-v!">set-v!</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref VN), (Array Double)] ())</p><span></span><p class="doc"></p></div><div class="binder"><a href="#str" class="anchor"><h3 id="str">str</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref VN)] String)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-n" class="anchor"><h3 id="update-n">update-n</h3></a><div class="description">instantiate</div><p class="sig">(λ [VN, (λ [Int] Int)] VN)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#update-v" class="anchor"><h3 id="update-v">update-v</h3></a><div class="description">instantiate</div><p class="sig">(λ [VN, (λ [(Array Double)] (Array Double))] VN)</p><span></span><p class="doc"></p></div><div class="binder"><a href="#v" class="anchor"><h3 id="v">v</h3></a><div class="description">instantiate</div><p class="sig">(λ [(Ref VN)] (Ref (Array Double)))</p><span></span><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                VectorN.VN
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] VN)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [Int, (Array Double)] VN)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#n">
+                    <h3 id="n">
+                        n
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] &amp;Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-n">
+                    <h3 id="set-n">
+                        set-n
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [VN, Int] VN)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-n!">
+                    <h3 id="set-n!">
+                        set-n!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), Int] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-v">
+                    <h3 id="set-v">
+                        set-v
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [VN, (Array Double)] VN)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-v!">
+                    <h3 id="set-v!">
+                        set-v!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Array Double)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-n">
+                    <h3 id="update-n">
+                        update-n
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [VN, (λ [Int] Int)] VN)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-v">
+                    <h3 id="update-v">
+                        update-v
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [VN, (λ [(Array Double)] (Array Double))] VN)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#v">
+                    <h3 id="v">
+                        v
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] (Ref (Array Double)))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -1,1 +1,680 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Vector2</h1><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [a, a] Bool)</p><pre class="args">(/= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Bool)</p><pre class="args">(= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#V2" class="anchor"><h3 id="V2">V2</h3></a><div class="description">module</div><p class="sig">Module</p><span></span><p class="doc"></p></div><div class="binder"><a href="#add" class="anchor"><h3 id="add">add</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] V2)</p><pre class="args">(add a b)</pre><p class="doc"></p></div><div class="binder"><a href="#angle-between" class="anchor"><h3 id="angle-between">angle-between</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Double)</p><pre class="args">(angle-between a b)</pre><p class="doc">Get the angle between to vectors a and b.</p></div><div class="binder"><a href="#anti-parallel?" class="anchor"><h3 id="anti-parallel?">anti-parallel?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Bool)</p><pre class="args">(anti-parallel? a b)</pre><p class="doc">Check whether the two vectors a and b are anti-parallel.</p></div><div class="binder"><a href="#approx" class="anchor"><h3 id="approx">approx</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Bool)</p><pre class="args">(approx a b)</pre><p class="doc">Check whether the vectors a and b are approximately equal.</p></div><div class="binder"><a href="#dist" class="anchor"><h3 id="dist">dist</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Double)</p><pre class="args">(dist a b)</pre><p class="doc">Get the distance between the vectors a and b.</p></div><div class="binder"><a href="#div" class="anchor"><h3 id="div">div</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), Double] V2)</p><pre class="args">(div a n)</pre><p class="doc"></p></div><div class="binder"><a href="#dot" class="anchor"><h3 id="dot">dot</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Double)</p><pre class="args">(dot x y)</pre><p class="doc">Get the dot product of the two vectors x and y.</p></div><div class="binder"><a href="#get-x" class="anchor"><h3 id="get-x">get-x</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2)] Double)</p><pre class="args">(get-x o)</pre><p class="doc"></p></div><div class="binder"><a href="#get-y" class="anchor"><h3 id="get-y">get-y</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2)] Double)</p><pre class="args">(get-y o)</pre><p class="doc"></p></div><div class="binder"><a href="#heading" class="anchor"><h3 id="heading">heading</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2)] Double)</p><pre class="args">(heading a)</pre><p class="doc">Get the heading of the vector a.</p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">defn</div><p class="sig">(λ [Double, Double] V2)</p><pre class="args">(init x y)</pre><p class="doc"></p></div><div class="binder"><a href="#lerp" class="anchor"><h3 id="lerp">lerp</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2), Double] V2)</p><pre class="args">(lerp a b amnt)</pre><p class="doc">Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).</p></div><div class="binder"><a href="#mag" class="anchor"><h3 id="mag">mag</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2)] Double)</p><pre class="args">(mag o)</pre><p class="doc">Get the magnitude of a vector.</p></div><div class="binder"><a href="#mag-sq" class="anchor"><h3 id="mag-sq">mag-sq</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2)] Double)</p><pre class="args">(mag-sq o)</pre><p class="doc">Get the squared magnitude of a vector.</p></div><div class="binder"><a href="#mul" class="anchor"><h3 id="mul">mul</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), Double] V2)</p><pre class="args">(mul a n)</pre><p class="doc"></p></div><div class="binder"><a href="#normalize" class="anchor"><h3 id="normalize">normalize</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2)] V2)</p><pre class="args">(normalize o)</pre><p class="doc">Normalize a vector.</p></div><div class="binder"><a href="#parallel?" class="anchor"><h3 id="parallel?">parallel?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Bool)</p><pre class="args">(parallel? a b)</pre><p class="doc">Check whether the two vectors a and b are parallel.</p></div><div class="binder"><a href="#perpendicular?" class="anchor"><h3 id="perpendicular?">perpendicular?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] Bool)</p><pre class="args">(perpendicular? a b)</pre><p class="doc">Check whether the two vectors a and b are perpendicular.</p></div><div class="binder"><a href="#random" class="anchor"><h3 id="random">random</h3></a><div class="description">defn</div><p class="sig">(λ [] V2)</p><pre class="args">(random)</pre><p class="doc"></p></div><div class="binder"><a href="#rotate" class="anchor"><h3 id="rotate">rotate</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), Double] V2)</p><pre class="args">(rotate a n)</pre><p class="doc">Rotate the vector a by the radians n.</p></div><div class="binder"><a href="#set-x" class="anchor"><h3 id="set-x">set-x</h3></a><div class="description">defn</div><p class="sig">(λ [V2, Double] V2)</p><pre class="args">(set-x o v)</pre><p class="doc"></p></div><div class="binder"><a href="#set-y" class="anchor"><h3 id="set-y">set-y</h3></a><div class="description">defn</div><p class="sig">(λ [V2, Double] V2)</p><pre class="args">(set-y o v)</pre><p class="doc"></p></div><div class="binder"><a href="#sub" class="anchor"><h3 id="sub">sub</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2), (Ref V2)] V2)</p><pre class="args">(sub a b)</pre><p class="doc"></p></div><div class="binder"><a href="#to-string" class="anchor"><h3 id="to-string">to-string</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V2)] String)</p><pre class="args">(to-string o)</pre><p class="doc"></p></div><div class="binder"><a href="#zero" class="anchor"><h3 id="zero">zero</h3></a><div class="description">defn</div><p class="sig">(λ [] V2)</p><pre class="args">(zero)</pre><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Vector2
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, a] Bool)
+                </p>
+                <pre class="args">
+                    (/= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Bool)
+                </p>
+                <pre class="args">
+                    (= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#V2">
+                    <h3 id="V2">
+                        V2
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    Module
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add">
+                    <h3 id="add">
+                        add
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] V2)
+                </p>
+                <pre class="args">
+                    (add a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#angle-between">
+                    <h3 id="angle-between">
+                        angle-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (angle-between a b)
+                </pre>
+                <p class="doc">
+                    Get the angle between to vectors a and b.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#anti-parallel?">
+                    <h3 id="anti-parallel?">
+                        anti-parallel?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Bool)
+                </p>
+                <pre class="args">
+                    (anti-parallel? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are anti-parallel.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#approx">
+                    <h3 id="approx">
+                        approx
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Bool)
+                </p>
+                <pre class="args">
+                    (approx a b)
+                </pre>
+                <p class="doc">
+                    Check whether the vectors a and b are approximately equal.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dist">
+                    <h3 id="dist">
+                        dist
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (dist a b)
+                </pre>
+                <p class="doc">
+                    Get the distance between the vectors a and b.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#div">
+                    <h3 id="div">
+                        div
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), Double] V2)
+                </p>
+                <pre class="args">
+                    (div a n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dot">
+                    <h3 id="dot">
+                        dot
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (dot x y)
+                </pre>
+                <p class="doc">
+                    Get the dot product of the two vectors x and y.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get-x">
+                    <h3 id="get-x">
+                        get-x
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (get-x o)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#get-y">
+                    <h3 id="get-y">
+                        get-y
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (get-y o)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#heading">
+                    <h3 id="heading">
+                        heading
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (heading a)
+                </pre>
+                <p class="doc">
+                    Get the heading of the vector a.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Double, Double] V2)
+                </p>
+                <pre class="args">
+                    (init x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#lerp">
+                    <h3 id="lerp">
+                        lerp
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2), Double] V2)
+                </p>
+                <pre class="args">
+                    (lerp a b amnt)
+                </pre>
+                <p class="doc">
+                    Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mag">
+                    <h3 id="mag">
+                        mag
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (mag o)
+                </pre>
+                <p class="doc">
+                    Get the magnitude of a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mag-sq">
+                    <h3 id="mag-sq">
+                        mag-sq
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] Double)
+                </p>
+                <pre class="args">
+                    (mag-sq o)
+                </pre>
+                <p class="doc">
+                    Get the squared magnitude of a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mul">
+                    <h3 id="mul">
+                        mul
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), Double] V2)
+                </p>
+                <pre class="args">
+                    (mul a n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#normalize">
+                    <h3 id="normalize">
+                        normalize
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] V2)
+                </p>
+                <pre class="args">
+                    (normalize o)
+                </pre>
+                <p class="doc">
+                    Normalize a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#parallel?">
+                    <h3 id="parallel?">
+                        parallel?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Bool)
+                </p>
+                <pre class="args">
+                    (parallel? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are parallel.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#perpendicular?">
+                    <h3 id="perpendicular?">
+                        perpendicular?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] Bool)
+                </p>
+                <pre class="args">
+                    (perpendicular? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are perpendicular.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] V2)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#rotate">
+                    <h3 id="rotate">
+                        rotate
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), Double] V2)
+                </p>
+                <pre class="args">
+                    (rotate a n)
+                </pre>
+                <p class="doc">
+                    Rotate the vector a by the radians n.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x">
+                    <h3 id="set-x">
+                        set-x
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [V2, Double] V2)
+                </p>
+                <pre class="args">
+                    (set-x o v)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y">
+                    <h3 id="set-y">
+                        set-y
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [V2, Double] V2)
+                </p>
+                <pre class="args">
+                    (set-y o v)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sub">
+                    <h3 id="sub">
+                        sub
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2), (Ref V2)] V2)
+                </p>
+                <pre class="args">
+                    (sub a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-string">
+                    <h3 id="to-string">
+                        to-string
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V2)] String)
+                </p>
+                <pre class="args">
+                    (to-string o)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero">
+                    <h3 id="zero">
+                        zero
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] V2)
+                </p>
+                <pre class="args">
+                    (zero)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -1,1 +1,547 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>Vector3</h1><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [a, a] Bool)</p><pre class="args">(/= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] Bool)</p><pre class="args">(= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#V3" class="anchor"><h3 id="V3">V3</h3></a><div class="description">module</div><p class="sig">Module</p><span></span><p class="doc"></p></div><div class="binder"><a href="#add" class="anchor"><h3 id="add">add</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] V3)</p><pre class="args">(add a b)</pre><p class="doc"></p></div><div class="binder"><a href="#angle-between" class="anchor"><h3 id="angle-between">angle-between</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] Double)</p><pre class="args">(angle-between a b)</pre><p class="doc">Get the angle between to vectors a and b.</p></div><div class="binder"><a href="#anti-parallel?" class="anchor"><h3 id="anti-parallel?">anti-parallel?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] Bool)</p><pre class="args">(anti-parallel? a b)</pre><p class="doc">Check whether the two vectors a and b are anti-parallel.</p></div><div class="binder"><a href="#cross" class="anchor"><h3 id="cross">cross</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] V3)</p><pre class="args">(cross x y)</pre><p class="doc">Compute the cross product of the two vectors x and y.</p></div><div class="binder"><a href="#div" class="anchor"><h3 id="div">div</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), Double] V3)</p><pre class="args">(div a n)</pre><p class="doc"></p></div><div class="binder"><a href="#dot" class="anchor"><h3 id="dot">dot</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] Double)</p><pre class="args">(dot x y)</pre><p class="doc">Get the dot product of the two vectors x and y.</p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">defn</div><p class="sig">(λ [Double, Double, Double] V3)</p><pre class="args">(init x y z)</pre><p class="doc"></p></div><div class="binder"><a href="#lerp" class="anchor"><h3 id="lerp">lerp</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3), Double] V3)</p><pre class="args">(lerp a b amnt)</pre><p class="doc">Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).</p></div><div class="binder"><a href="#mag" class="anchor"><h3 id="mag">mag</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3)] Double)</p><pre class="args">(mag o)</pre><p class="doc">Get the magnitude of a vector.</p></div><div class="binder"><a href="#mag-sq" class="anchor"><h3 id="mag-sq">mag-sq</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3)] Double)</p><pre class="args">(mag-sq o)</pre><p class="doc">Get the squared magnitude of a vector.</p></div><div class="binder"><a href="#mul" class="anchor"><h3 id="mul">mul</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), Double] V3)</p><pre class="args">(mul a n)</pre><p class="doc"></p></div><div class="binder"><a href="#normalize" class="anchor"><h3 id="normalize">normalize</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3)] V3)</p><pre class="args">(normalize o)</pre><p class="doc">Normalize a vector.</p></div><div class="binder"><a href="#parallel?" class="anchor"><h3 id="parallel?">parallel?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] Bool)</p><pre class="args">(parallel? a b)</pre><p class="doc">Check whether the two vectors a and b are parallel.</p></div><div class="binder"><a href="#perpendicular?" class="anchor"><h3 id="perpendicular?">perpendicular?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] Bool)</p><pre class="args">(perpendicular? a b)</pre><p class="doc">Check whether the two vectors a and b are perpendicular.</p></div><div class="binder"><a href="#random" class="anchor"><h3 id="random">random</h3></a><div class="description">defn</div><p class="sig">(λ [] V3)</p><pre class="args">(random)</pre><p class="doc"></p></div><div class="binder"><a href="#sub" class="anchor"><h3 id="sub">sub</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3), (Ref V3)] V3)</p><pre class="args">(sub a b)</pre><p class="doc"></p></div><div class="binder"><a href="#to-string" class="anchor"><h3 id="to-string">to-string</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref V3)] String)</p><pre class="args">(to-string o)</pre><p class="doc"></p></div><div class="binder"><a href="#zero" class="anchor"><h3 id="zero">zero</h3></a><div class="description">defn</div><p class="sig">(λ [] V3)</p><pre class="args">(zero)</pre><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                Vector3
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, a] Bool)
+                </p>
+                <pre class="args">
+                    (/= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] Bool)
+                </p>
+                <pre class="args">
+                    (= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#V3">
+                    <h3 id="V3">
+                        V3
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    Module
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add">
+                    <h3 id="add">
+                        add
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] V3)
+                </p>
+                <pre class="args">
+                    (add a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#angle-between">
+                    <h3 id="angle-between">
+                        angle-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] Double)
+                </p>
+                <pre class="args">
+                    (angle-between a b)
+                </pre>
+                <p class="doc">
+                    Get the angle between to vectors a and b.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#anti-parallel?">
+                    <h3 id="anti-parallel?">
+                        anti-parallel?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] Bool)
+                </p>
+                <pre class="args">
+                    (anti-parallel? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are anti-parallel.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#cross">
+                    <h3 id="cross">
+                        cross
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] V3)
+                </p>
+                <pre class="args">
+                    (cross x y)
+                </pre>
+                <p class="doc">
+                    Compute the cross product of the two vectors x and y.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#div">
+                    <h3 id="div">
+                        div
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), Double] V3)
+                </p>
+                <pre class="args">
+                    (div a n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dot">
+                    <h3 id="dot">
+                        dot
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] Double)
+                </p>
+                <pre class="args">
+                    (dot x y)
+                </pre>
+                <p class="doc">
+                    Get the dot product of the two vectors x and y.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Double, Double, Double] V3)
+                </p>
+                <pre class="args">
+                    (init x y z)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#lerp">
+                    <h3 id="lerp">
+                        lerp
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3), Double] V3)
+                </p>
+                <pre class="args">
+                    (lerp a b amnt)
+                </pre>
+                <p class="doc">
+                    Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mag">
+                    <h3 id="mag">
+                        mag
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] Double)
+                </p>
+                <pre class="args">
+                    (mag o)
+                </pre>
+                <p class="doc">
+                    Get the magnitude of a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mag-sq">
+                    <h3 id="mag-sq">
+                        mag-sq
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] Double)
+                </p>
+                <pre class="args">
+                    (mag-sq o)
+                </pre>
+                <p class="doc">
+                    Get the squared magnitude of a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mul">
+                    <h3 id="mul">
+                        mul
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), Double] V3)
+                </p>
+                <pre class="args">
+                    (mul a n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#normalize">
+                    <h3 id="normalize">
+                        normalize
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] V3)
+                </p>
+                <pre class="args">
+                    (normalize o)
+                </pre>
+                <p class="doc">
+                    Normalize a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#parallel?">
+                    <h3 id="parallel?">
+                        parallel?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] Bool)
+                </p>
+                <pre class="args">
+                    (parallel? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are parallel.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#perpendicular?">
+                    <h3 id="perpendicular?">
+                        perpendicular?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] Bool)
+                </p>
+                <pre class="args">
+                    (perpendicular? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are perpendicular.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] V3)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sub">
+                    <h3 id="sub">
+                        sub
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3), (Ref V3)] V3)
+                </p>
+                <pre class="args">
+                    (sub a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-string">
+                    <h3 id="to-string">
+                        to-string
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref V3)] String)
+                </p>
+                <pre class="args">
+                    (to-string o)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero">
+                    <h3 id="zero">
+                        zero
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] V3)
+                </p>
+                <pre class="args">
+                    (zero)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -1,1 +1,642 @@
-<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><div class="logo"><a href="http://github.com/carp-lang/Carp"><img src="logo.png"></a><div class="title">core</div><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1>VectorN</h1><div class="binder"><a href="#/=" class="anchor"><h3 id="/=">/=</h3></a><div class="description">defn</div><p class="sig">(λ [a, a] Bool)</p><pre class="args">(/= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#=" class="anchor"><h3 id="=">=</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] Bool)</p><pre class="args">(= a b)</pre><p class="doc"></p></div><div class="binder"><a href="#VN" class="anchor"><h3 id="VN">VN</h3></a><div class="description">module</div><p class="sig">Module</p><span></span><p class="doc"></p></div><div class="binder"><a href="#add" class="anchor"><h3 id="add">add</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] VN)</p><pre class="args">(add a b)</pre><p class="doc"></p></div><div class="binder"><a href="#add-" class="anchor"><h3 id="add-">add-</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;a, &amp;a] a)</p><pre class="args">(add- x y)</pre><p class="doc"></p></div><div class="binder"><a href="#angle-between" class="anchor"><h3 id="angle-between">angle-between</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] Double)</p><pre class="args">(angle-between a b)</pre><p class="doc">Get the angle between to vectors a and b.</p></div><div class="binder"><a href="#anti-parallel?" class="anchor"><h3 id="anti-parallel?">anti-parallel?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] Bool)</p><pre class="args">(anti-parallel? a b)</pre><p class="doc">Check whether the two vectors a and b are anti-parallel.</p></div><div class="binder"><a href="#dist" class="anchor"><h3 id="dist">dist</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] Double)</p><pre class="args">(dist a b)</pre><p class="doc">Get the distance between the vectors a and b.</p></div><div class="binder"><a href="#div" class="anchor"><h3 id="div">div</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), Double] VN)</p><pre class="args">(div a n)</pre><p class="doc"></p></div><div class="binder"><a href="#dot" class="anchor"><h3 id="dot">dot</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] Double)</p><pre class="args">(dot x y)</pre><p class="doc">Get the dot product of the two vectors x and y.</p></div><div class="binder"><a href="#init" class="anchor"><h3 id="init">init</h3></a><div class="description">defn</div><p class="sig">(λ [Int, (Array Double)] VN)</p><pre class="args">(init n v)</pre><p class="doc"></p></div><div class="binder"><a href="#lerp" class="anchor"><h3 id="lerp">lerp</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN), Double] VN)</p><pre class="args">(lerp a b amnt)</pre><p class="doc">Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).</p></div><div class="binder"><a href="#mag" class="anchor"><h3 id="mag">mag</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN)] Double)</p><pre class="args">(mag o)</pre><p class="doc">Get the magnitude of a vector.</p></div><div class="binder"><a href="#mag-sq" class="anchor"><h3 id="mag-sq">mag-sq</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN)] Double)</p><pre class="args">(mag-sq o)</pre><p class="doc">Get the squared magnitude of a vector.</p></div><div class="binder"><a href="#mul" class="anchor"><h3 id="mul">mul</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), Double] VN)</p><pre class="args">(mul a n)</pre><p class="doc"></p></div><div class="binder"><a href="#normalize" class="anchor"><h3 id="normalize">normalize</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN)] VN)</p><pre class="args">(normalize o)</pre><p class="doc">Normalize a vector.</p></div><div class="binder"><a href="#parallel?" class="anchor"><h3 id="parallel?">parallel?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] Bool)</p><pre class="args">(parallel? a b)</pre><p class="doc">Check whether the two vectors a and b are parallel.</p></div><div class="binder"><a href="#perpendicular?" class="anchor"><h3 id="perpendicular?">perpendicular?</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] Bool)</p><pre class="args">(perpendicular? a b)</pre><p class="doc">Check whether the two vectors a and b are perpendicular.</p></div><div class="binder"><a href="#random-sized" class="anchor"><h3 id="random-sized">random-sized</h3></a><div class="description">defn</div><p class="sig">(λ [Int] VN)</p><pre class="args">(random-sized n)</pre><p class="doc"></p></div><div class="binder"><a href="#square-" class="anchor"><h3 id="square-">square-</h3></a><div class="description">defn</div><p class="sig">(λ [&amp;a] a)</p><pre class="args">(square- n)</pre><p class="doc"></p></div><div class="binder"><a href="#sub" class="anchor"><h3 id="sub">sub</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN), (Ref VN)] VN)</p><pre class="args">(sub a b)</pre><p class="doc"></p></div><div class="binder"><a href="#to-string" class="anchor"><h3 id="to-string">to-string</h3></a><div class="description">defn</div><p class="sig">(λ [(Ref VN)] String)</p><pre class="args">(to-string o)</pre><p class="doc"></p></div><div class="binder"><a href="#unit-random" class="anchor"><h3 id="unit-random">unit-random</h3></a><div class="description">defn</div><p class="sig">(λ [] Double)</p><pre class="args">(unit-random)</pre><p class="doc"></p></div><div class="binder"><a href="#zero-sized" class="anchor"><h3 id="zero-sized">zero-sized</h3></a><div class="description">defn</div><p class="sig">(λ [Int] VN)</p><pre class="args">(zero-sized n)</pre><p class="doc"></p></div><div class="binder"><a href="#zip" class="anchor"><h3 id="zip">zip</h3></a><div class="description">defn</div><p class="sig">(λ [(λ [Double, Double] Double), (Ref VN), (Ref VN)] VN)</p><pre class="args">(zip f a b)</pre><p class="doc"></p></div><div class="binder"><a href="#zip-" class="anchor"><h3 id="zip-">zip-</h3></a><div class="description">defn</div><p class="sig">(λ [(λ [a, b] Double), (Ref (Array a)), (Ref (Array b))] VN)</p><pre class="args">(zip- f a b)</pre><p class="doc"></p></div></div></body></html>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <div class="logo">
+                <a href="http://github.com/carp-lang/Carp">
+                    <img src="logo.png">
+                </a>
+                <div class="title">
+                    core
+                </div>
+                <div class="index">
+                    <ul>
+                        <li>
+                            <a href="Dynamic.html">
+                                Dynamic
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Int.html">
+                                Int
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Long.html">
+                                Long
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bool.html">
+                                Bool
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Float.html">
+                                Float
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Double.html">
+                                Double
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector2.html">
+                                Vector2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V2.html">
+                                V2
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Vector3.html">
+                                Vector3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="V3.html">
+                                V3
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VectorN.html">
+                                VectorN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="VN.html">
+                                VN
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Geometry.html">
+                                Geometry
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Statistics.html">
+                                Statistics
+                            </a>
+                        </li>
+                        <li>
+                            <a href="String.html">
+                                String
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Char.html">
+                                Char
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Pattern.html">
+                                Pattern
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Array.html">
+                                Array
+                            </a>
+                        </li>
+                        <li>
+                            <a href="IO.html">
+                                IO
+                            </a>
+                        </li>
+                        <li>
+                            <a href="System.html">
+                                System
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Debug.html">
+                                Debug
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Test.html">
+                                Test
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Bench.html">
+                                Bench
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Map.html">
+                                Map
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <h1>
+                VectorN
+            </h1>
+            <div class="binder">
+                <a class="anchor" href="#/=">
+                    <h3 id="/=">
+                        /=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, a] Bool)
+                </p>
+                <pre class="args">
+                    (/= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#=">
+                    <h3 id="=">
+                        =
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] Bool)
+                </p>
+                <pre class="args">
+                    (= a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#VN">
+                    <h3 id="VN">
+                        VN
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    Module
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add">
+                    <h3 id="add">
+                        add
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] VN)
+                </p>
+                <pre class="args">
+                    (add a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add-">
+                    <h3 id="add-">
+                        add-
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;a, &amp;a] a)
+                </p>
+                <pre class="args">
+                    (add- x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#angle-between">
+                    <h3 id="angle-between">
+                        angle-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] Double)
+                </p>
+                <pre class="args">
+                    (angle-between a b)
+                </pre>
+                <p class="doc">
+                    Get the angle between to vectors a and b.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#anti-parallel?">
+                    <h3 id="anti-parallel?">
+                        anti-parallel?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] Bool)
+                </p>
+                <pre class="args">
+                    (anti-parallel? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are anti-parallel.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dist">
+                    <h3 id="dist">
+                        dist
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] Double)
+                </p>
+                <pre class="args">
+                    (dist a b)
+                </pre>
+                <p class="doc">
+                    Get the distance between the vectors a and b.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#div">
+                    <h3 id="div">
+                        div
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), Double] VN)
+                </p>
+                <pre class="args">
+                    (div a n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dot">
+                    <h3 id="dot">
+                        dot
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] Double)
+                </p>
+                <pre class="args">
+                    (dot x y)
+                </pre>
+                <p class="doc">
+                    Get the dot product of the two vectors x and y.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int, (Array Double)] VN)
+                </p>
+                <pre class="args">
+                    (init n v)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#lerp">
+                    <h3 id="lerp">
+                        lerp
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN), Double] VN)
+                </p>
+                <pre class="args">
+                    (lerp a b amnt)
+                </pre>
+                <p class="doc">
+                    Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mag">
+                    <h3 id="mag">
+                        mag
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] Double)
+                </p>
+                <pre class="args">
+                    (mag o)
+                </pre>
+                <p class="doc">
+                    Get the magnitude of a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mag-sq">
+                    <h3 id="mag-sq">
+                        mag-sq
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] Double)
+                </p>
+                <pre class="args">
+                    (mag-sq o)
+                </pre>
+                <p class="doc">
+                    Get the squared magnitude of a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mul">
+                    <h3 id="mul">
+                        mul
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), Double] VN)
+                </p>
+                <pre class="args">
+                    (mul a n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#normalize">
+                    <h3 id="normalize">
+                        normalize
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] VN)
+                </p>
+                <pre class="args">
+                    (normalize o)
+                </pre>
+                <p class="doc">
+                    Normalize a vector.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#parallel?">
+                    <h3 id="parallel?">
+                        parallel?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] Bool)
+                </p>
+                <pre class="args">
+                    (parallel? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are parallel.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#perpendicular?">
+                    <h3 id="perpendicular?">
+                        perpendicular?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] Bool)
+                </p>
+                <pre class="args">
+                    (perpendicular? a b)
+                </pre>
+                <p class="doc">
+                    Check whether the two vectors a and b are perpendicular.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-sized">
+                    <h3 id="random-sized">
+                        random-sized
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int] VN)
+                </p>
+                <pre class="args">
+                    (random-sized n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#square-">
+                    <h3 id="square-">
+                        square-
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;a] a)
+                </p>
+                <pre class="args">
+                    (square- n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sub">
+                    <h3 id="sub">
+                        sub
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN), (Ref VN)] VN)
+                </p>
+                <pre class="args">
+                    (sub a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-string">
+                    <h3 id="to-string">
+                        to-string
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref VN)] String)
+                </p>
+                <pre class="args">
+                    (to-string o)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#unit-random">
+                    <h3 id="unit-random">
+                        unit-random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Double)
+                </p>
+                <pre class="args">
+                    (unit-random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zero-sized">
+                    <h3 id="zero-sized">
+                        zero-sized
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Int] VN)
+                </p>
+                <pre class="args">
+                    (zero-sized n)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zip">
+                    <h3 id="zip">
+                        zip
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(λ [Double, Double] Double), (Ref VN), (Ref VN)] VN)
+                </p>
+                <pre class="args">
+                    (zip f a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#zip-">
+                    <h3 id="zip-">
+                        zip-
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(λ [a, b] Double), (Ref (Array a)), (Ref (Array b))] VN)
+                </p>
+                <pre class="args">
+                    (zip- f a b)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/core/carp_style.css
+++ b/docs/core/carp_style.css
@@ -24,6 +24,7 @@ a {
   display: inline-block;
   margin-top: 0.3em;
   margin-bottom: 0.3em;
+  white-space: normal;
 }
 
 ul {

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -1,1 +1,145 @@
-<head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"><link href="carp_style.css" rel="stylesheet"></head><body><div class="content"><a href="http://github.com/carp-lang/Carp"><div class="logo"><img src="logo.png"><div class="index"><ul><li><a href="Dynamic.html">Dynamic</a></li><li><a href="Int.html">Int</a></li><li><a href="Long.html">Long</a></li><li><a href="Bool.html">Bool</a></li><li><a href="Float.html">Float</a></li><li><a href="Double.html">Double</a></li><li><a href="Vector2.html">Vector2</a></li><li><a href="V2.html">V2</a></li><li><a href="Vector3.html">Vector3</a></li><li><a href="V3.html">V3</a></li><li><a href="VectorN.html">VectorN</a></li><li><a href="VN.html">VN</a></li><li><a href="Geometry.html">Geometry</a></li><li><a href="Statistics.html">Statistics</a></li><li><a href="String.html">String</a></li><li><a href="Char.html">Char</a></li><li><a href="Pattern.html">Pattern</a></li><li><a href="Array.html">Array</a></li><li><a href="IO.html">IO</a></li><li><a href="System.html">System</a></li><li><a href="Debug.html">Debug</a></li><li><a href="Test.html">Test</a></li><li><a href="Bench.html">Bench</a></li><li><a href="Map.html">Map</a></li></ul></div></div><h1 class="huge">core</h1></a></div></body>
+<!DOCTYPE HTML>
+
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <link rel="stylesheet" href="carp_style.css">
+    </head>
+    <body>
+        <div class="content">
+            <a href="http://github.com/carp-lang/Carp">
+                <div class="logo">
+                    <img src="logo.png" alt="Logo">
+                    <div class="index">
+                        <ul>
+                            <li>
+                                <a href="Dynamic.html">
+                                    Dynamic
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Int.html">
+                                    Int
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Long.html">
+                                    Long
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Bool.html">
+                                    Bool
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Float.html">
+                                    Float
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Double.html">
+                                    Double
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Vector2.html">
+                                    Vector2
+                                </a>
+                            </li>
+                            <li>
+                                <a href="V2.html">
+                                    V2
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Vector3.html">
+                                    Vector3
+                                </a>
+                            </li>
+                            <li>
+                                <a href="V3.html">
+                                    V3
+                                </a>
+                            </li>
+                            <li>
+                                <a href="VectorN.html">
+                                    VectorN
+                                </a>
+                            </li>
+                            <li>
+                                <a href="VN.html">
+                                    VN
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Geometry.html">
+                                    Geometry
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Statistics.html">
+                                    Statistics
+                                </a>
+                            </li>
+                            <li>
+                                <a href="String.html">
+                                    String
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Char.html">
+                                    Char
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Pattern.html">
+                                    Pattern
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Array.html">
+                                    Array
+                                </a>
+                            </li>
+                            <li>
+                                <a href="IO.html">
+                                    IO
+                                </a>
+                            </li>
+                            <li>
+                                <a href="System.html">
+                                    System
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Debug.html">
+                                    Debug
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Test.html">
+                                    Test
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Bench.html">
+                                    Bench
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Map.html">
+                                    Map
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <h1 class="huge">
+                    core
+                </h1>
+            </a>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This PR replaces `lucid` by `blaze-html` to leverage its pretty printer. This leads to pretty HTML, which is a bit nicer to deal with. This is per request from @bjorn3 in #268.

It also means that this diff is super huge, sorry about that!

Cheers