### PR TITLE
Add tests for args

### DIFF
--- a/test/args.carp
+++ b/test/args.carp
@@ -1,3 +1,19 @@
+(load "Test.carp")
+(use Test)
+
+(defdynamic _make-exe-path [pth]
+  (String.join (array (Project.get-config "output-directory") pth)))
+
+(defmacro make-exe-path [pth]
+  (_make-exe-path pth))
+
 (defn main []
-  (for [i 0 (System.get-args-len)]
-    (IO.println (System.get-arg i))))
+  (with-test test
+    (assert-equal test
+                 1
+                 (System.get-args-len)
+                 "System.get-args-len works as expected")
+    (assert-equal test
+                  (make-exe-path "/Untitled")
+                  (System.get-arg 0)
+                  "System.get-arg works as expected")))


### PR DESCRIPTION
Thanks for the project!

This PR just adds a couple of tests for `args.carp`, it assumes they are run with:

`carp -x test/args.carp`

or through the provided script:

`./run_carp_tests.sh`
