### PR TITLE
Headerparser: Parse function-like macros and multiline macros

### DIFF
--- a/examples/parse_me.h
+++ b/examples/parse_me.h
@@ -31,3 +31,11 @@ GLFWAPI void glfwPollEvents(void);
 #define K_BLAH 12345
 #define K_BLAX 0x123
 #define K_GLAH 12345
+
+// C function-like macros
+
+#define X(a, b) a + b
+#define Y(a, b) {\\
+  foo(a, b);\\
+}
+#define Z(a, b) "hi"

--- a/headerparse/Main.hs
+++ b/headerparse/Main.hs
@@ -53,7 +53,7 @@ parseHeaderFile path src prefix kebab =
                     name <- Parsec.many1 identifierChar
                     argList <- Parsec.optionMaybe argList
                     Parsec.many spaceOrTab
-                    number <- Parsec.many1 identifierChar
+                    _ <- defineBody
                     Parsec.many spaceOrTab
                     -- OBS! Never kebab
                     case argList of
@@ -75,6 +75,17 @@ parseHeaderFile path src prefix kebab =
                     return args
                   genTypes 0 = []
                   genTypes n = (("a" ++ show n), 0) : genTypes (n - 1)
+
+        defineBody :: Parsec.Parsec String () ()
+        defineBody = do s <- Parsec.many (Parsec.noneOf "\\\n")
+                        ending <- Parsec.optionMaybe (Parsec.string "\\\\\n")
+                        case ending of
+                          Nothing ->
+                            do c <- Parsec.optionMaybe (Parsec.noneOf "\n")
+                               case c of
+                                 Just _  -> defineBody
+                                 Nothing -> return ()
+                          Just _ -> defineBody
 
         prefixedFunctionPrototype :: Parsec.Parsec String () [XObj]
         prefixedFunctionPrototype = do Parsec.many spaceOrTab

--- a/headerparse/Main.hs
+++ b/headerparse/Main.hs
@@ -11,6 +11,8 @@ import Util
 import Types
 import Obj
 
+import Debug.Trace
+
 data Args = Args { sourcePath :: String
                  , prefixToRemove :: String
                  , kebabCase :: Bool
@@ -49,13 +51,30 @@ parseHeaderFile path src prefix kebab =
                     Parsec.string "#define"
                     Parsec.many spaceOrTab
                     name <- Parsec.many1 identifierChar
+                    argList <- Parsec.optionMaybe argList
                     Parsec.many spaceOrTab
                     number <- Parsec.many1 identifierChar
                     Parsec.many spaceOrTab
-                    let tyXObj =
-                          --toTypeXObj ("a", 0)
-                          XObj (Sym (SymPath [] "a") Symbol) Nothing Nothing
-                    return (createRegisterForm name tyXObj prefix False) -- OBS! Never kebab
+                    -- OBS! Never kebab
+                    case argList of
+                      Nothing ->
+                        let tyXObj =
+                              XObj (Sym (SymPath [] "a") Symbol) Nothing Nothing
+                        in return (createRegisterForm name tyXObj prefix False)
+                      Just args ->
+                        let argsTy = genTypes (length args)
+                            tyXObj = toFnTypeXObj argsTy ("a", 0)
+                        in return (createRegisterForm name tyXObj prefix False)
+            where argList = do
+                    _ <- Parsec.char '('
+                    args <- Parsec.sepBy
+                              (Parsec.many spaceOrTab >>
+                               Parsec.many1 identifierChar)
+                              (Parsec.char ',')
+                    _ <- Parsec.char ')'
+                    return args
+                  genTypes 0 = []
+                  genTypes n = (("a" ++ show n), 0) : genTypes (n - 1)
 
         prefixedFunctionPrototype :: Parsec.Parsec String () [XObj]
         prefixedFunctionPrototype = do Parsec.many spaceOrTab


### PR DESCRIPTION
This PR extends the parts of the header parser that deal with macros. It allows for function-like macros (i.e. macros that take arguments), and multi-line macros.

“Test” cases are included in `examples/parse_me.h`.

Cheers