### PR TITLE
headerparse: remove unnecessary import of Debug.Trace

### DIFF
--- a/headerparse/Main.hs
+++ b/headerparse/Main.hs
@@ -11,8 +11,6 @@ import Util
 import Types
 import Obj
 
-import Debug.Trace
-
 data Args = Args { sourcePath :: String
                  , prefixToRemove :: String
                  , kebabCase :: Bool


### PR DESCRIPTION
This PR removes an unnecessary import of `Debug.Trace` that I introduced into `headerparse` (oops).

Cheers