### PR TITLE
Simplify map

### DIFF
--- a/bench/map.carp
+++ b/bench/map.carp
@@ -1,0 +1,103 @@
+(load "Bench.carp")
+(use-all Bench IO)
+
+(defn insert []
+  (let [m {}]
+    (for [i 0 100]
+      (set! m (Map.put &m &i &1)))))
+
+(defn insert-collisions []
+  (let [m (Map.create-with-len 1)]
+    (for [i 0 100]
+      (set! m (Map.put &m &1 &1)))))
+
+(def m (the (Map Int Int) {}))
+
+(defn single-insert []
+  (set! m (Map.put &m &1 &1)))
+
+(defn setup-big-map []
+  (for [i 0 10000]
+    (set! m (Map.put &m &i &1))))
+
+(defn retrieve []
+  (Map.get &m &10))
+
+(defn setup-big-map-collisions []
+  (do
+    (set! m (Map.create-with-len 1))
+    (setup-big-map)))
+
+(defn map-tests []
+  (do
+    (println "Testing single map insert:")
+    (bench single-insert)
+    (println "")
+    (println "Testing 100 map inserts:")
+    (bench insert)
+    (println "")
+    (println "Testing 100 map inserts with maximum collisions:")
+    (bench insert-collisions)
+    (println "")
+    (setup-big-map)
+    (println "Testing map retrieval:")
+    (bench retrieve)
+    (println "")
+    (setup-big-map-collisions)
+    (println "Testing map retrieval with maximum collisions:")
+    (bench retrieve)
+    (println "")))
+
+
+(defn insert-set []
+  (let [m (Set.create)]
+    (for [i 0 100]
+      (set! m (Set.put &m &i)))))
+
+(defn insert-set-collisions []
+  (let [m (Set.create-with-len 1)]
+    (for [i 0 100]
+      (set! m (Set.put &m &i)))))
+
+(def s (the (Set Int) (Set.create)))
+
+(defn single-insert-set []
+  (set! s (Set.put &s &1)))
+
+(defn setup-big-set []
+  (for [i 0 10000]
+    (set! s (Set.put &s &i))))
+
+(defn contains-set []
+  (Set.contains? &s &10))
+
+(defn setup-big-set-collisions []
+  (do
+    (set! s (Set.create-with-len 1))
+    (setup-big-set)))
+
+(defn set-tests []
+  (do
+    (println "Testing single set insert:")
+    (bench single-insert-set)
+    (println "")
+    (println "Testing 100 set inserts:")
+    (bench insert-set)
+    (println "")
+    (println "Testing 100 set inserts with maximum collisions:")
+    (bench insert-set-collisions)
+    (println "")
+    (setup-big-set)
+    (println "Testing set contains:")
+    (bench contains-set)
+    (println "")
+    (setup-big-set-collisions)
+    (println "Testing set contains with maximum collisions:")
+    (bench contains-set)
+    (println "")))
+
+(defn main []
+  (do
+    (map-tests)
+    (println "")
+    (set-tests)))

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -40,8 +40,7 @@
   (defn hash [k] (Long.to-int (to-bytes @k)))
 )
 
-(deftype (Entry a b) [key a value b])
-(deftype (Bucket a b) [entries (Array (Entry a b))])
+(deftype (Bucket a b) [entries (Array (Pair a b))])
 
 (defmodule Bucket
   (defn empty []
@@ -55,9 +54,9 @@
              l (Array.length (Bucket.entries b))
              es (entries b)]
       (for [i 0 l]
-        (when (= (Entry.key (Array.nth es i)) k)
+        (when (= (Pair.a (Array.nth es i)) k)
           (do
-            (set! e (Entry.value (Array.nth es i)))
+            (set! e (Pair.b (Array.nth es i)))
             (break))))
        @e))
 
@@ -66,17 +65,17 @@
              l (Array.length (Bucket.entries b))
              es (entries b)]
       (for [i 0 l]
-        (when (= (Entry.key (Array.nth es i)) k)
+        (when (= (Pair.a (Array.nth es i)) k)
           (do
             (set! e true)
             (break))))
        e))
 
   (defn remove [entries k]
-    (let-do [nentries (the (Array (Entry a b)) [])]
+    (let-do [nentries (the (Array (Pair a b)) [])]
       (for [i 0 (Array.length entries)]
         (let [e (Array.nth entries i)]
-          (unless (= (Entry.key e) k)
+          (unless (= (Pair.a e) k)
              (set! nentries (Array.push-back nentries @e)))))
       nentries))
 
@@ -106,7 +105,7 @@
           b (buckets m)]
       (set-buckets @m (Array.aset @b
                                   idx
-                                  (Bucket.grow (Array.nth b idx) (Entry.init @k @v))))))
+                                  (Bucket.grow (Array.nth b idx) (Pair.init @k @v))))))
 
   (doc get "Get the value for the key k from map m. If it isn’t found, a zero element is returned.")
   (defn get [m k]
@@ -145,7 +144,7 @@
             entries (Bucket.entries bucket)]
         (for [j 0 len]
           (let [e (Array.nth entries j)]
-            (f (Entry.key e) (Entry.value e)))))))
+            (f (Pair.a e) (Pair.b e)))))))
 
   (doc from-array "Create a map from the array a containing key-value pairs.")
   (defn from-array [a]
@@ -165,7 +164,7 @@
               entries (Bucket.entries bucket)]
           (for [j 0 len]
             (let [e (Array.nth entries j)]
-              (set! res (String.join @"" &[res @" " (prn @(Entry.key e)) @" " (prn @(Entry.value e))]))))))
+              (set! res (String.join @"" &[res @" " (prn @(Pair.a e)) @" " (prn @(Pair.b e))]))))))
       (String.append &res " }")))
 )
 
@@ -188,7 +187,7 @@
           b (buckets m)]
       (set-buckets @m (Array.aset @b
                                   idx
-                                  (Bucket.grow (Array.nth b idx) (Entry.init @k true))))))
+                                  (Bucket.grow (Array.nth b idx) (Pair.init @k true))))))
 
   (doc length "Get the length of set m.")
   (defn length [m]
@@ -223,7 +222,7 @@
             entries (Bucket.entries bucket)]
         (for [j 0 len]
           (let [e (Array.nth entries j)]
-            (f (Entry.key e)))))))
+            (f (Pair.a e)))))))
 
   (doc from-array "Create a set from the values in array a.")
   (defn from-array [a]
@@ -241,6 +240,6 @@
               entries (Bucket.entries bucket)]
           (for [j 0 len]
             (let [e (Array.nth entries j)]
-              (set! res (String.join @"" &[res @" " (prn @(Entry.key e))]))))))
+              (set! res (String.join @"" &[res @" " (prn @(Pair.a e))]))))))
       (String.append &res " }")))
 )

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -168,61 +168,95 @@
       (String.append &res " }")))
 )
 
-(deftype (Set a) [n-buckets Int buckets (Array (Bucket a Bool))])
+(deftype (SetBucket a) [entries (Array a)])
+
+(defmodule SetBucket
+  (defn empty []
+    (SetBucket.init []))
+
+  (defn grow [b e]
+    (set-entries @b (Array.push-back @(entries b) e)))
+
+  (defn contains? [b k]
+    (let-do [e false
+             es (entries b)
+             l (Array.length es)]
+      (for [i 0 l]
+        (when (= (Array.nth es i) k)
+          (do
+            (set! e true)
+            (break))))
+       e))
+
+  (defn remove [entries k]
+    (let-do [nentries []]
+      (for [i 0 (Array.length entries)]
+        (let [e (Array.nth entries i)]
+          (unless (= e k)
+             (set! nentries (Array.push-back nentries @e)))))
+      nentries))
+
+  (defn shrink [b k]
+    (if (contains? b k)
+      (set-entries @b (remove (entries b) k))
+      @b))
+)
+
+(deftype (Set a) [n-buckets Int buckets (Array (SetBucket a))])
 
 (defmodule Set
   (def dflt-len 256)
 
   (doc create "Create an empty hashset.")
   (defn create []
-    (init dflt-len (Array.repeat dflt-len Bucket.empty)))
+    (init dflt-len (Array.repeat dflt-len SetBucket.empty)))
 
   (doc create-with-len "Create an empty hashset with a given minimum size.")
   (defn create-with-len [len]
-    (init len (Array.repeat len Bucket.empty)))
+    (init len (Array.repeat len SetBucket.empty)))
 
-  (doc put "Put a a value v into set m, using the key k.")
+  (doc put "Put a a key kinto set m.")
   (defn put [m k]
     (let [idx (Int.mod (hash k) @(n-buckets m))
           b (buckets m)]
       (set-buckets @m (Array.aset @b
                                   idx
-                                  (Bucket.grow (Array.nth b idx) (Pair.init @k true))))))
+                                  (SetBucket.grow (Array.nth b idx) @k)))))
 
   (doc length "Get the length of set m.")
   (defn length [m]
     (let-do [c 0]
       (for [i 0 @(n-buckets m)]
-        (set! c (+ c (Array.length (Bucket.entries (Array.nth (buckets m) i))))))
+        (set! c (+ c (Array.length (SetBucket.entries (Array.nth (buckets m) i))))))
       c))
 
   (doc empty? "Check whether the set m is empty.")
   (defn empty? [m]
     (= (length m) 0))
 
-  (doc contains? "Check whether the set m contains a value associated with key k.")
+  (doc contains? "Check whether the set m contains the key k.")
   (defn contains? [m k]
     (let [idx (Int.mod (hash k) @(n-buckets m))]
-      (Bucket.contains? (Array.nth (buckets m) idx) k)))
+      (SetBucket.contains? (Array.nth (buckets m) idx) k)))
 
-  (doc remove "Remove the value associated with key k from set m.")
+  (doc remove "Remove the key k from set m.")
   (defn remove [m k]
     (let [idx (Int.mod (hash k) @(n-buckets &m))
           b (buckets &m)]
       (set-buckets m (Array.aset @b
                                  idx
-                                 (Bucket.shrink (Array.nth b idx) k)))))
+                                 (SetBucket.shrink (Array.nth b idx) k)))))
 
 
   (doc for-each "Execute the unary function f for each element in set m.")
   (defn for-each [m f]
     (for [i 0 @(n-buckets m)]
       (let [bucket (Array.nth (buckets m) i)
-            len (Array.length (Bucket.entries bucket))
-            entries (Bucket.entries bucket)]
+            len (Array.length (SetBucket.entries bucket))
+            entries (SetBucket.entries bucket)]
         (for [j 0 len]
           (let [e (Array.nth entries j)]
-            (f (Pair.a e)))))))
+            (f e))))))
 
   (doc from-array "Create a set from the values in array a.")
   (defn from-array [a]
@@ -236,10 +270,10 @@
     (let-do [res @"{"]
       (for [i 0 @(n-buckets m)]
         (let [bucket (Array.nth (buckets m) i)
-              len (Array.length (Bucket.entries bucket))
-              entries (Bucket.entries bucket)]
+              len (Array.length (SetBucket.entries bucket))
+              entries (SetBucket.entries bucket)]
           (for [j 0 len]
             (let [e (Array.nth entries j)]
-              (set! res (String.join @"" &[res @" " (prn @(Pair.a e))]))))))
+              (set! res (String.join @"" &[res @" " (prn e)]))))))
       (String.append &res " }")))
 )

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -91,11 +91,11 @@
   (hidden dflt-len)
   (def dflt-len 256)
 
-  (doc create "Create an empty hashmap.")
+  (doc create "Create an empty map.")
   (defn create []
     (init dflt-len (Array.repeat dflt-len Bucket.empty)))
 
-  (doc create-with-len "Create an empty hashmap with a given minimum size.")
+  (doc create-with-len "Create an empty map with a given number of buckets. High numbers reduce the possibility of hash collisions while increasing the memory footprint.")
   (defn create-with-len [len]
     (init len (Array.repeat len Bucket.empty)))
 
@@ -107,7 +107,7 @@
                                   idx
                                   (Bucket.grow (Array.nth b idx) (Pair.init @k @v))))))
 
-  (doc get "Get the value for the key k from map m. If it isn’t found, a zero element is returned.")
+  (doc get "Get the value for the key k from map m. If it isn’t found, a zero element for the value type is returned.")
   (defn get [m k]
     (let [idx (Int.mod (hash k) @(n-buckets m))]
       (Bucket.get (Array.nth (buckets m) idx) k)))
@@ -119,7 +119,7 @@
         (set! c (+ c (Array.length (Bucket.entries (Array.nth (buckets m) i))))))
       c))
 
-  (doc length "Check whether the map m is empty.")
+  (doc empty "Check whether the map m is empty.")
   (defn empty? [m]
     (= (length m) 0))
 
@@ -136,7 +136,7 @@
                                  idx
                                  (Bucket.shrink (Array.nth b idx) k)))))
 
-  (doc for-each "Execute the binary function f for all keys and value in map m.")
+  (doc for-each "Execute the binary function f for all keys and values in the map m.")
   (defn for-each [m f]
     (for [i 0 @(n-buckets m)]
       (let [bucket (Array.nth (buckets m) i)
@@ -205,53 +205,54 @@
 (deftype (Set a) [n-buckets Int buckets (Array (SetBucket a))])
 
 (defmodule Set
+  (hidden dflt-len)
   (def dflt-len 256)
 
-  (doc create "Create an empty hashset.")
+  (doc create "Create an empty set.")
   (defn create []
     (init dflt-len (Array.repeat dflt-len SetBucket.empty)))
 
-  (doc create-with-len "Create an empty hashset with a given minimum size.")
+  (doc create-with-len "Create an empty set with a given number of buckets. Higher numbers decrease the probability of hash collisions while increasing the memory footprint.")
   (defn create-with-len [len]
     (init len (Array.repeat len SetBucket.empty)))
 
-  (doc put "Put a a key kinto set m.")
-  (defn put [m k]
-    (let [idx (Int.mod (hash k) @(n-buckets m))
-          b (buckets m)]
-      (set-buckets @m (Array.aset @b
+  (doc put "Put a a key k into the set s.")
+  (defn put [s k]
+    (let [idx (Int.mod (hash k) @(n-buckets s))
+          b (buckets s)]
+      (set-buckets @s (Array.aset @b
                                   idx
                                   (SetBucket.grow (Array.nth b idx) @k)))))
 
-  (doc length "Get the length of set m.")
-  (defn length [m]
+  (doc length "Get the length of set s.")
+  (defn length [s]
     (let-do [c 0]
-      (for [i 0 @(n-buckets m)]
-        (set! c (+ c (Array.length (SetBucket.entries (Array.nth (buckets m) i))))))
+      (for [i 0 @(n-buckets s)]
+        (set! c (+ c (Array.length (SetBucket.entries (Array.nth (buckets s) i))))))
       c))
 
-  (doc empty? "Check whether the set m is empty.")
-  (defn empty? [m]
-    (= (length m) 0))
+  (doc empty? "Check whether the set s is empty.")
+  (defn empty? [s]
+    (= (length s) 0))
 
-  (doc contains? "Check whether the set m contains the key k.")
-  (defn contains? [m k]
-    (let [idx (Int.mod (hash k) @(n-buckets m))]
-      (SetBucket.contains? (Array.nth (buckets m) idx) k)))
+  (doc contains? "Check whether the set s contains the key k.")
+  (defn contains? [s k]
+    (let [idx (Int.mod (hash k) @(n-buckets s))]
+      (SetBucket.contains? (Array.nth (buckets s) idx) k)))
 
-  (doc remove "Remove the key k from set m.")
-  (defn remove [m k]
-    (let [idx (Int.mod (hash k) @(n-buckets &m))
-          b (buckets &m)]
-      (set-buckets m (Array.aset @b
+  (doc remove "Remove the key k from the set s.")
+  (defn remove [s k]
+    (let [idx (Int.mod (hash k) @(n-buckets &s))
+          b (buckets &s)]
+      (set-buckets s (Array.aset @b
                                  idx
                                  (SetBucket.shrink (Array.nth b idx) k)))))
 
 
-  (doc for-each "Execute the unary function f for each element in set m.")
-  (defn for-each [m f]
-    (for [i 0 @(n-buckets m)]
-      (let [bucket (Array.nth (buckets m) i)
+  (doc for-each "Execute the unary function f for each element in the set s.")
+  (defn for-each [s f]
+    (for [i 0 @(n-buckets s)]
+      (let [bucket (Array.nth (buckets s) i)
             len (Array.length (SetBucket.entries bucket))
             entries (SetBucket.entries bucket)]
         (for [j 0 len]
@@ -260,16 +261,16 @@
 
   (doc from-array "Create a set from the values in array a.")
   (defn from-array [a]
-    (let-do [m (create)]
+    (let-do [s (create)]
       (for [i 0 (Array.length a)]
         (let [e (Array.nth a i)]
-          (set! m (put &m e))))
-      m))
+          (set! s (put &s e))))
+      s))
 
-  (defn str [m]
+  (defn str [s]
     (let-do [res @"{"]
-      (for [i 0 @(n-buckets m)]
-        (let [bucket (Array.nth (buckets m) i)
+      (for [i 0 @(n-buckets s)]
+        (let [bucket (Array.nth (buckets s) i)
               len (Array.length (SetBucket.entries bucket))
               entries (SetBucket.entries bucket)]
           (for [j 0 len]

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -216,7 +216,7 @@
                     (create)
                 </pre>
                 <p class="doc">
-                    Create an empty hashmap.
+                    Create an empty map.
                 </p>
             </div>
             <div class="binder">
@@ -235,7 +235,7 @@
                     (create-with-len len)
                 </pre>
                 <p class="doc">
-                    Create an empty hashmap with a given minimum size.
+                    Create an empty map with a given number of buckets. High numbers reduce the possibility of hash collisions while increasing the memory footprint.
                 </p>
             </div>
             <div class="binder">
@@ -255,6 +255,25 @@
                 </span>
                 <p class="doc">
                     
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#empty">
+                    <h3 id="empty">
+                        empty
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    a
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Check whether the map m is empty.
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +311,7 @@
                     (for-each m f)
                 </pre>
                 <p class="doc">
-                    Execute the binary function f for all keys and value in map m.
+                    Execute the binary function f for all keys and values in the map m.
                 </p>
             </div>
             <div class="binder">
@@ -330,7 +349,7 @@
                     (get m k)
                 </pre>
                 <p class="doc">
-                    Get the value for the key k from map m. If it isn’t found, a zero element is returned.
+                    Get the value for the key k from map m. If it isn’t found, a zero element for the value type is returned.
                 </p>
             </div>
             <div class="binder">
@@ -368,7 +387,7 @@
                     (length m)
                 </pre>
                 <p class="doc">
-                    Check whether the map m is empty.
+                    Get the length of the map m.
                 </p>
             </div>
             <div class="binder">


### PR DESCRIPTION
This PR adds a few changes to map that make it simpler and more performant:

- remove the `Entry` type, as it is equivalent to `Pair`
- add a `SetBucket` type to avoid carrying around useless values in hashsets
- Fix a few docstrings
- Add benchmarks

Cheers