### PR TITLE
Fix discoloration on reset

### DIFF
--- a/src/ColorText.hs
+++ b/src/ColorText.hs
@@ -5,9 +5,9 @@ import Util
 data TextColor = Blue | Red | Yellow | Green | White
 
 strWithColor :: TextColor -> String -> String
-strWithColor color str = 
-    if useColors 
-    then "\x1b[" ++ col ++ "m" ++ str ++ "\x1b[37m"
+strWithColor color str =
+    if useColors
+    then "\x1b[" ++ col ++ "m" ++ str ++ "\x1b[0m"
     else str
   where useColors = platform /= Windows
         col = case color of


### PR DESCRIPTION
This PR fixes #283. The original reset in `strWithColors` was ANSI code `37`, which is `white`. It should’ve been `0`, which is `reset`.

Cheers