### PR TITLE
Print short-circuiting test results

### DIFF
--- a/test/short_circuiting.carp
+++ b/test/short_circuiting.carp
@@ -67,4 +67,5 @@
                   3
                   (vararg-or)
                   "'or*' works")
+    (print-test-results test)
     ))


### PR DESCRIPTION
When running the carp test suite, I noticed that the results were not being printed at the end of this test. I Implemented this change and the results printed upon re-running the tests.