### PR TITLE
Print results as part of test macro

### DIFF
--- a/core/Test.carp
+++ b/core/Test.carp
@@ -104,9 +104,7 @@
         (IO.color "red")
         (IO.print "\tFailed: ")
         (IO.println &(Int.str failed))
-        (IO.color "reset")
-        (State.copy state))))
-)
+        (IO.color "reset")))))
 
 (defdynamic with-test-internal [name forms]
   (if (= (length forms) 1)
@@ -119,7 +117,10 @@
   (list 'let [name '&(Test.State.init 0 0)]
     (cons-last
       (list 'Int.copy (list 'Test.State.failed name))
-      (cons 'do (with-test-internal name forms)))))
+      (cons-last
+        (list 'Test.print-test-results name)
+        (cons 'do (with-test-internal name forms))))
+    ))
 
 (defmacro deftest [name state-name :rest forms]
   (list 'defn name []

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -305,7 +305,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref State)] State)
+                    (λ [(Ref State)] ())
                 </p>
                 <pre class="args">
                     (print-test-results state)

--- a/test/array.carp
+++ b/test/array.carp
@@ -193,5 +193,4 @@
       (assert-equal test
                     &[1 2 3 4 5 6 7 8 9]
                     &(sorted &[9 2 1 3 7 8 6 5 4])
-                    "sorted works as expected")
-      (print-test-results test))))
+                    "sorted works as expected"))))

--- a/test/char.carp
+++ b/test/char.carp
@@ -37,6 +37,5 @@
                   9
                   (meaning &\9)
                   "meaning works as expected 9")
-    (print-test-results test)
   )
 )

--- a/test/control_flow.carp
+++ b/test/control_flow.carp
@@ -72,5 +72,4 @@
     (assert-equal test
                   5
                   (unless-test-false)
-                  "unless works as expected when false")
-    (print-test-results test)))
+                  "unless works as expected when false")))

--- a/test/double_math.carp
+++ b/test/double_math.carp
@@ -102,5 +102,4 @@
                   0l
                   (to-bytes 0.0)
                   "to-bytes works as expected II"
-    )
-    (print-test-results test)))
+    )))

--- a/test/float_math.carp
+++ b/test/float_math.carp
@@ -108,5 +108,4 @@
                   0
                   (to-bytes 0.0f)
                   "to-bytes works as expected II"
-    )
-    (print-test-results test)))
+    )))

--- a/test/format.carp
+++ b/test/format.carp
@@ -34,5 +34,4 @@
     (assert-equal test
                   "10 % 12.0 yay"
                   &(fmt "%d %% %.1f %s" 10 12.0 "yay")
-                  "fmt macro works")
-    (print-test-results test)))
+                  "fmt macro works")))

--- a/test/heap.carp
+++ b/test/heap.carp
@@ -165,7 +165,5 @@
                           &exp
                           &arr
                           "swap 4 works"))
-
-
-    (print-test-results test)))
+    ))
 

--- a/test/int_math.carp
+++ b/test/int_math.carp
@@ -59,5 +59,4 @@
     (assert-equal test
                   1
                   (/ 3 2)
-                  "integer division truncates as expected")
-    (print-test-results test)))
+                  "integer division truncates as expected")))

--- a/test/long_math.carp
+++ b/test/long_math.carp
@@ -55,5 +55,4 @@
     (assert-equal test
                   2l
                   (neg -2l)
-                  "neg works as expected II")
-    (print-test-results test)))
+                  "neg works as expected II")))

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -166,5 +166,4 @@
     (assert-equal test
                   "1 thing 2 things"
                   &(str* 1 " thing " 2 " things")
-                  "str* macro works as expected")
-    (print-test-results test)))
+                  "str* macro works as expected")))

--- a/test/map.carp
+++ b/test/map.carp
@@ -100,5 +100,4 @@
                   "{ @\"hi\" @\"bye\" }"
                   &(str &(Set.from-array &[@"hi" @"bye"]))
                   "stringification works"
-    )
-    (print-test-results test)))
+    )))

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -407,5 +407,4 @@
       (assert-no-leak test stringcopy-append-leak-test "StringCopy.append does not leak")
       (assert-no-leak test lambda-1 "lambda-1 does not leak")
       (assert-no-leak test lambda-2 "lambda-2 does not leak")
-      (assert-no-leak test lambda-3 "lambda-3 does not leak")
-      (print-test-results test))))
+      (assert-no-leak test lambda-3 "lambda-3 does not leak"))))

--- a/test/nested.carp
+++ b/test/nested.carp
@@ -32,5 +32,4 @@
     (assert-equal test
                   false
                   (f)
-                  "interfaces get resolved correctly")
-    (print-test-results test)))
+                  "interfaces get resolved correctly")))

--- a/test/pattern.carp
+++ b/test/pattern.carp
@@ -76,5 +76,4 @@
     (assert-equal test
                   "sub sub sub"
                   &(substitute #"(\d)-(\d)" "1-2 2-3 3-4" "sub" -1)
-                  "substitute works as expected if all should be replaces")
-    (print-test-results test)))
+                  "substitute works as expected if all should be replaces")))

--- a/test/random.carp
+++ b/test/random.carp
@@ -13,5 +13,4 @@
                0.536041
                (do (Random.seed 33333.0) (Random.random))
                "deterministic randomization with seed works as expected"
-               Double.approx)
-    (print-test-results test)))
+               Double.approx)))

--- a/test/safe_arithmetic.carp
+++ b/test/safe_arithmetic.carp
@@ -93,5 +93,4 @@
     (assert-equal test
                   true
                   (safe-mul 9000000000000000000l 2000000000000000000l &l)
-                  "safe-mul is true with overflow")
-    (print-test-results test)))
+                  "safe-mul is true with overflow")))

--- a/test/short_circuiting.carp
+++ b/test/short_circuiting.carp
@@ -67,5 +67,4 @@
                   3
                   (vararg-or)
                   "'or*' works")
-    (print-test-results test)
     ))

--- a/test/sort.carp
+++ b/test/sort.carp
@@ -96,6 +96,5 @@
                           &exp
                           &res
                           "Array.sort works with chars"))
-
-    (print-test-results test)))
+    ))
 

--- a/test/statistics.carp
+++ b/test/statistics.carp
@@ -98,5 +98,4 @@
     (assert-equal test
                   2.0
                   @(Summary.median &(summary &[1.0 2.0 3.0]))
-                  "summary works as expected")
-    (print-test-results test)))
+                  "summary works as expected")))

--- a/test/string.carp
+++ b/test/string.carp
@@ -287,6 +287,5 @@
                   5
                   (index-of-from "abcabc" \c 2)
                   "index-of-from works correctly IV")
-    (print-test-results test)
   )
 )

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -78,5 +78,4 @@
                   &(init 2.5 5.0)
                   &(lerp &(init 0.0 0.0) &(init 5.0 10.0) 0.5)
                   "lerp works")
-    (print-test-results test)
 ))

--- a/test/vector3.carp
+++ b/test/vector3.carp
@@ -67,5 +67,4 @@
                   &(init 2.5 5.0 0.75)
                   &(lerp &(init 0.0 0.0 0.5) &(init 5.0 10.0 2.0) 0.5)
                   "lerp works")
-    (print-test-results test)
 ))

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -69,5 +69,4 @@
                   &(init 1 [2.0])
                   &(lerp &(init 1 [0.0]) &(init 1 [5.0]) 0.4)
                   "lerp works")
-    (print-test-results test)
 ))


### PR DESCRIPTION
As discussed in #290, this change moves the printing of test results to the `with-test` macro. Additionally, I renamed the misspelled `test/safe_arithmetic` file.

Tested using the `run_carp_tests.sh` script and observing that the results are the same as before the change.