### PR TITLE
add Project.get-config

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -134,6 +134,34 @@ commandProjectConfig [xobj@(XObj (Str key) _ _), value] =
 commandProjectConfig [faultyKey, _] =
   do presentError ("First argument to 'Project.config' must be a string: " ++ pretty faultyKey) dynamicNil
 
+-- | Command for changing various project settings.
+commandProjectGetConfig :: CommandCallback
+commandProjectGetConfig [xobj@(XObj (Str key) _ _)] =
+  do ctx <- get
+     let proj = contextProj ctx
+         env = contextGlobalEnv ctx
+     case getVal proj of
+      Right val -> return $ Right $ XObj (Str val) (Just dummyInfo) (Just StringTy)
+      Left err -> return $ Left err
+  where getVal :: Project -> Either EvalError String
+        getVal proj = case key of
+          "cflag" -> Right $ show $ projectCFlags proj
+          "libflag" -> Right $ show $ projectLibFlags proj
+          "prompt" -> Right $ projectPrompt proj
+          "search-path" -> Right $ show $ projectCarpSearchPaths proj
+          "print-ast" -> Right $ show $ projectPrintTypedAST proj
+          "echo-c" -> Right $ show $ projectEchoC proj
+          "echo-compiler-cmd" -> Right $ show $ projectEchoCompilationCommand proj
+          "compiler" -> Right $ projectCompiler proj
+          "title" -> Right $ show $ projectTitle proj
+          "output-directory" -> Right $ projectOutDir proj
+          "docs-directory" -> Right $ projectDocsDir proj
+          _ ->
+            Left $ EvalError ("[CONFIG ERROR] Project.get-config can't understand the key '" ++
+                               key ++ "' at " ++ prettyInfoFromXObj xobj ++ ".")
+commandProjectGetConfig [faultyKey] =
+  do presentError ("First argument to 'Project.config' must be a string: " ++ pretty faultyKey) dynamicNil
+
 -- | Command for exiting the REPL/compiler
 commandQuit :: CommandCallback
 commandQuit args =

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -141,21 +141,20 @@ commandProjectGetConfig [xobj@(XObj (Str key) _ _)] =
      let proj = contextProj ctx
          env = contextGlobalEnv ctx
      case getVal proj of
-      Right val -> return $ Right $ XObj (Str val) (Just dummyInfo) (Just StringTy)
+      Right val -> return $ Right $ XObj val (Just dummyInfo) (Just StringTy)
       Left err -> return $ Left err
-  where getVal :: Project -> Either EvalError String
-        getVal proj = case key of
-          "cflag" -> Right $ show $ projectCFlags proj
-          "libflag" -> Right $ show $ projectLibFlags proj
-          "prompt" -> Right $ projectPrompt proj
-          "search-path" -> Right $ show $ projectCarpSearchPaths proj
-          "print-ast" -> Right $ show $ projectPrintTypedAST proj
-          "echo-c" -> Right $ show $ projectEchoC proj
-          "echo-compiler-cmd" -> Right $ show $ projectEchoCompilationCommand proj
-          "compiler" -> Right $ projectCompiler proj
-          "title" -> Right $ show $ projectTitle proj
-          "output-directory" -> Right $ projectOutDir proj
-          "docs-directory" -> Right $ projectDocsDir proj
+  where getVal proj = case key of
+          "cflag" -> Right $ Str $ show $ projectCFlags proj
+          "libflag" -> Right $ Str $ show $ projectLibFlags proj
+          "prompt" -> Right $ Str $ projectPrompt proj
+          "search-path" -> Right $ Str $ show $ projectCarpSearchPaths proj
+          "print-ast" -> Right $ Bol $ projectPrintTypedAST proj
+          "echo-c" -> Right $ Bol $ projectEchoC proj
+          "echo-compiler-cmd" -> Right $ Bol $ projectEchoCompilationCommand proj
+          "compiler" -> Right $ Str $ projectCompiler proj
+          "title" -> Right $ Str $ projectTitle proj
+          "output-directory" -> Right $ Str $ projectOutDir proj
+          "docs-directory" -> Right $ Str $ projectDocsDir proj
           _ ->
             Left $ EvalError ("[CONFIG ERROR] Project.get-config can't understand the key '" ++
                                key ++ "' at " ++ prettyInfoFromXObj xobj ++ ".")

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -256,6 +256,7 @@ dynamicProjectModule = Env { envBindings = bindings
                            , envMode = ExternalEnv
                            , envFunctionNestingLevel = 0 }
   where bindings = Map.fromList [ addCommand "config" 2 commandProjectConfig
+                                , addCommand "get-config" 1 commandProjectGetConfig
                                 ]
 
 -- | A hack-ish function for converting any enum to an int.

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -28,6 +28,9 @@
 (defmacro test-> [a b] (> a b))
 (defmacro test-= [a b] (= a b))
 
+(defdynamic gc- [key] (Project.get-config key))
+(defmacro gc [key] (gc- key))
+
 (defn main []
   (with-test test
     (assert-true test
@@ -167,4 +170,12 @@
                   "1 thing 2 things"
                   &(str* 1 " thing " 2 " things")
                   "str* macro works as expected")
+    (assert-equal test
+                  false
+                  (gc "echo-c")
+                  "Project.get-config works as expected I")
+    (assert-equal test
+                  "Untitled"
+                  (gc "title")
+                  "Project.get-config works as expected II")
     (print-test-results test)))


### PR DESCRIPTION
This PR adds `Project.get-config`, the getter alternative to `Project.config`. This is there to simplify use cases like in #270 where you might want to fing out values like `output-directory` from within the program.

Test cases are included.

Cheers

PS: I noticed that a few properties of `Project` are missing in `Project.config`. WIll add those in a separate PR.