### PR TITLE
Fix mode resolution for multisymbols

### DIFF
--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -393,6 +393,9 @@ typeFromPath env p =
     Nothing -> error ("Couldn't find " ++ show p ++ " in env:\n" ++ prettyEnvironmentChain env)
 
 -- | Get the mode of a symbol at a given path.
+-- |
+-- | TODO: this duplicates a bunch of functionality from  Qualify.hs, namely
+-- | parts of doesNotBelongToAnInterface.
 modeFromPath :: Env -> SymPath -> SymbolMode
 modeFromPath env p =
   case lookupInEnv p env of

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -405,8 +405,10 @@ modeFromPath env p =
         ExternalEnv ->
           LookupGlobal CarpLand (definitionMode found)
         RecursionEnv -> LookupRecursive
-        -- TODO: how to find out whether we need to capture or not
-        _ -> LookupLocal Capture
+        _ ->  LookupLocal
+                (if envFunctionNestingLevel e < envFunctionNestingLevel env
+                            then Capture
+                            else NoCapture)
     Nothing -> error ("Couldn't find " ++ show p ++ " in env:\n" ++ prettyEnvironmentChain env)
 
 -- | Given a definition (def, defn, template, external) and

--- a/test/fixture_foo.h
+++ b/test/fixture_foo.h
@@ -1,0 +1,3 @@
+int fooInit() {
+  return 1;
+}

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -1,0 +1,20 @@
+(local-include "../test/fixture_foo.h")
+(load "Test.carp")
+(load "Vector.carp")
+
+; this is a test-only module to test module resolution (see #288)
+(defmodule Foo
+  (register init (Fn [] Int) "fooInit")
+)
+
+(use-all Test Vector2 Foo)
+
+(defn main []
+  (with-test test
+    (assert-equal test
+                   1
+                   (init)
+                   "test that the right module gets resolved"
+    )
+  )
+)


### PR DESCRIPTION
This PR fixes mode resolution for multisymbols during concretization, by which I mean it fixes #288.

A test case is included. It’s in a file called `text/regression.carp`, in which I intend to test for any regressions for fixes like this one.

Cheers