### PR TITLE
Proposal: make and and or macros

### DIFF
--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -1,3 +1,5 @@
+(load "Macros.carp")
+
 ;; The 'copy' and 'str' interfaces are defined internally:
 ;;(definterface copy (λ [&a] a))
 ;;(definterface str (λ [a] String))

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -242,6 +242,12 @@
 (defmacro case [name :rest forms]
   (case-internal name forms))
 
+(defmacro and [x y]
+  (list 'if x y false))
+
+(defmacro or [x y]
+  (list 'if x true y))
+
 (defdynamic build-vararg [func forms]
   (if (= (length forms) 0)
     (macro-error "vararg macro needs at least one argument")

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -166,20 +166,6 @@ concretizeXObj allowAmbiguityRoot typeEnv rootEnv visitedDefinitions root =
          return $ do okVisitedValue <- visitedValue
                      return [theExpr, typeXObj, okVisitedValue]
 
-    visitList allowAmbig env (XObj (Lst [andExpr@(XObj And _ _), expr1, expr2]) _ _) =
-      do visitedExpr1 <- visit allowAmbig env expr1
-         visitedExpr2 <- visit allowAmbig env expr2
-         return $ do okVisitedExpr1 <- visitedExpr1
-                     okVisitedExpr2 <- visitedExpr2
-                     return [andExpr, okVisitedExpr1, okVisitedExpr2]
-
-    visitList allowAmbig env (XObj (Lst [orExpr@(XObj Or _ _), expr1, expr2]) _ _) =
-      do visitedExpr1 <- visit allowAmbig env expr1
-         visitedExpr2 <- visit allowAmbig env expr2
-         return $ do okVisitedExpr1 <- visitedExpr1
-                     okVisitedExpr2 <- visitedExpr2
-                     return [orExpr, okVisitedExpr1, okVisitedExpr2]
-
     visitList allowAmbig env (XObj (Lst (func : args)) _ _) =
       do concretizeTypeOfXObj typeEnv func
          mapM_ (concretizeTypeOfXObj typeEnv) args

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -96,8 +96,6 @@ toC toCMode root = emitterSrc (execState (visit startingIndent root) (EmitterSta
             Def -> error (show (DontVisitObj Def))
             Let -> error (show (DontVisitObj Let))
             If -> error (show (DontVisitObj If))
-            And -> error (show (DontVisitObj And))
-            Or -> error (show (DontVisitObj Or))
             Break -> error (show (DontVisitObj Break))
             While -> error (show (DontVisitObj While))
             Do -> error (show (DontVisitObj Do))
@@ -268,34 +266,6 @@ toC toCMode root = emitterSrc (execState (visit startingIndent root) (EmitterSta
                        appendToSrc (addIndent indent' ++ ifRetVar ++ " = " ++ falseVar ++ ";\n")
                      appendToSrc (addIndent indent ++ "}\n")
                      return ifRetVar
-
-            -- And
-            [XObj And _ _, expr1, expr2] ->
-              let indent' = indent + indentAmount
-                  retVar = freshVar i
-              in  do appendToSrc (addIndent indent ++ "bool " ++ retVar ++ " = false;\n")
-                     expr1Var <- visit indent expr1
-                     appendToSrc (addIndent indent ++ "if(" ++ expr1Var ++ ") {\n")
-                     expr2Var <- visit indent' expr2
-                     appendToSrc (addIndent indent' ++ retVar ++ " = " ++ expr2Var ++ ";\n")
-                     appendToSrc (addIndent indent ++ "} else {\n")
-                     appendToSrc (addIndent indent' ++ retVar ++ " = false;\n")
-                     appendToSrc (addIndent indent ++ "}\n")
-                     return retVar
-
-            -- Or
-            [XObj Or _ _, expr1, expr2] ->
-              let indent' = indent + indentAmount
-                  retVar = freshVar i
-              in  do appendToSrc (addIndent indent ++ "bool " ++ retVar ++ " = false;\n")
-                     expr1Var <- visit indent expr1
-                     appendToSrc (addIndent indent ++ "if(" ++ expr1Var ++ ") {\n")
-                     appendToSrc (addIndent indent' ++ retVar ++ " = true;\n")
-                     appendToSrc (addIndent indent ++ "} else {\n")
-                     expr2Var <- visit indent' expr2
-                     appendToSrc (addIndent indent' ++ retVar ++ " = " ++ expr2Var ++ ";\n")
-                     appendToSrc (addIndent indent ++ "}\n")
-                     return retVar
 
             -- While
             [XObj While _ _, expr, body] ->

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -113,7 +113,7 @@ eval env xobj =
                          Right (XObj (Arr okEvaledArray) i t)
 
         -- 'and' and 'or' are defined here because they are expected to short circuit
-        [XObj And _ _, a, b] ->
+        [XObj (Sym (SymPath [] "mand") _) _ _, a, b] ->
           do evaledA <- eval env a
              evaledB <- eval env b
              return $ do okA <- evaledA
@@ -130,7 +130,7 @@ eval env xobj =
                            _ ->
                              Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okA))
 
-        [XObj Or _ _, a, b] ->
+        [XObj (Sym (SymPath [] "mor") _) _ _, a, b] ->
           do evaledA <- eval env a
              evaledB <- eval env b
              return $ do okA <- evaledA

--- a/src/GenerateConstraints.hs
+++ b/src/GenerateConstraints.hs
@@ -126,36 +126,6 @@ genConstraints root = fmap sort (gen root)
                                 let theTheConstraint = Constraint xobjType valueType xobj value OrdThe
                                 return (theTheConstraint : insideValueConstraints)
 
-                           -- And
-                           [XObj And _ _, expr1, expr2] ->
-                             do insideExpr1 <- gen expr1
-                                insideExpr2 <- gen expr2
-                                expr1Type <- toEither (ty expr1) (DefMissingType expr1)
-                                expr2Type <- toEither (ty expr2) (DefMissingType expr2)
-                                xobjType <- toEither (ty xobj) (DefMissingType xobj)
-                                let must1 = XObj (Sym (SymPath [] "Expression in 'and'") Symbol) (info expr1) (Just BoolTy)
-                                    must2 = XObj (Sym (SymPath [] "Expression in 'and'") Symbol) (info expr2) (Just BoolTy)
-                                    mustReturnBool = XObj (Sym (SymPath [] "Return value of 'and'") Symbol) (info xobj) (Just BoolTy)
-                                    andConstraint1 = Constraint expr1Type BoolTy expr1 must1          OrdAnd
-                                    andConstraint2 = Constraint expr2Type BoolTy expr2 must2          OrdAnd
-                                    retConstraint  = Constraint xobjType  BoolTy xobj  mustReturnBool OrdAnd
-                                return ([andConstraint1, andConstraint2, retConstraint] ++ insideExpr1 ++ insideExpr2)
-
-                           -- Or
-                           [XObj Or _ _, expr1, expr2] ->
-                             do insideExpr1 <- gen expr1
-                                insideExpr2 <- gen expr2
-                                expr1Type <- toEither (ty expr1) (DefMissingType expr1)
-                                expr2Type <- toEither (ty expr2) (DefMissingType expr2)
-                                xobjType <- toEither (ty xobj) (DefMissingType xobj)
-                                let must1 = XObj (Sym (SymPath [] "Expression in 'or'") Symbol) (info expr1) (Just BoolTy)
-                                    must2 = XObj (Sym (SymPath [] "Expression in 'or'") Symbol) (info expr2) (Just BoolTy)
-                                    mustReturnBool = XObj (Sym (SymPath [] "Return value of 'or'") Symbol) (info xobj) (Just BoolTy)
-                                    orConstraint1 = Constraint expr1Type BoolTy expr1 must1          OrdOr
-                                    orConstraint2 = Constraint expr2Type BoolTy expr2 must2          OrdOr
-                                    retConstraint  = Constraint xobjType  BoolTy xobj  mustReturnBool OrdOr
-                                return ([orConstraint1, orConstraint2, retConstraint] ++ insideExpr1 ++ insideExpr2)
-
                            -- Ref
                            [XObj Ref _ _, value] ->
                              gen value

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -80,8 +80,6 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
                        e@(Fn _ _)         -> return (Left (InvalidObj e xobj))
                        Let                -> return (Left (InvalidObj Let xobj))
                        If                 -> return (Left (InvalidObj If xobj))
-                       And                -> return (Left (InvalidObj And xobj))
-                       Or                 -> return (Left (InvalidObj Or xobj))
                        While              -> return (Left (InvalidObj While xobj))
                        Do                 -> return (Left (InvalidObj Do xobj))
                        (Mod _)            -> return (Left (InvalidObj If xobj))
@@ -285,22 +283,6 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
              return $ do okValue <- visitedValue
                          let Just valueTy = ty okValue
                          return (XObj (Lst [refExpr, okValue]) i (Just (RefTy valueTy)))
-
-        -- And
-        [andExpr@(XObj And _ _), expr1, expr2] ->
-          do visitedExpr1 <- visit env expr1
-             visitedExpr2 <- visit env expr2
-             return $ do okExpr1 <- visitedExpr1
-                         okExpr2 <- visitedExpr2
-                         return (XObj (Lst [andExpr, okExpr1, okExpr2]) i (Just BoolTy))
-
-        -- Or
-        [orExpr@(XObj Or _ _), expr1, expr2] ->
-          do visitedExpr1 <- visit env expr1
-             visitedExpr2 <- visit env expr2
-             return $ do okExpr1 <- visitedExpr1
-                         okExpr2 <- visitedExpr2
-                         return (XObj (Lst [orExpr, okExpr1, okExpr2]) i (Just BoolTy))
 
         -- Function application
         func : args ->

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -63,8 +63,6 @@ data Obj = Sym SymPath SymbolMode
          | While
          | Break
          | If
-         | And
-         | Or
          | Mod Env
          | Typ Ty
          | With
@@ -267,8 +265,6 @@ pretty = visit 0
             Def -> "def"
             Fn _ captures -> "fn" -- ++ " <" ++ joinWithComma (map getName (Set.toList captures)) ++ ">"
             If -> "if"
-            And -> "and"
-            Or -> "or"
             While -> "while"
             Do -> "do"
             Let -> "let"

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -224,8 +224,6 @@ symbol = do i <- createInfo
               "let" -> return (XObj Let i Nothing)
               "break" -> return (XObj Break i Nothing)
               "if" -> return (XObj If i Nothing)
-              "and" -> return (XObj And i Nothing)
-              "or" -> return (XObj Or i Nothing)
               "true" -> return (XObj (Bol True) i Nothing)
               "false" -> return (XObj (Bol False) i Nothing)
               "address" -> return (XObj Address i Nothing)

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -21,8 +21,8 @@
     1 true
     false))
 
-(defmacro test-and [a b] (and a b))
-(defmacro test-or [a b] (or a b))
+(defmacro test-and [a b] (mand a b))
+(defmacro test-or [a b] (mor a b))
 (defmacro test-not [a] (not a))
 (defmacro test-< [a b] (< a b))
 (defmacro test-> [a b] (> a b))


### PR DESCRIPTION
This PR removes the special case of `or` and `and` in the compiler and instead makes them macros. The code generated is more or less equivalent.

An annoying side-effect of this is that `and` and `or` within `Eval.hs` have to be renamed. At the moment I renamed them to `mand` and `mor`, but that’s not particularly great naming. I’m open for any suggestions!

Cheers