### PR TITLE
Use closures in core

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -57,7 +57,7 @@
 
   (doc minimum "Sum an array (elements must support + and zero).")
   (defn sum [xs]
-    (Array.reduce add-ref (zero) xs))
+    (Array.reduce (fn [x y] (+ @x @y)) (zero) xs))
 
   (doc subarray "Get subarray from start-index to end-index.")
   (defn subarray [xs start-index end-index]

--- a/core/Filepath.carp
+++ b/core/Filepath.carp
@@ -2,16 +2,11 @@
 
   (use Array)
 
-  (private append-slash)
-  (hidden append-slash)
-  (defn append-slash [s]
-    (str* s "/"))
-
   (doc dir-from-path "Removes the file-name part of a path to a file.")
   (defn dir-from-path [path]
     (let [segments (split-by path &[\/])
           n (dec (length &segments))
           without-last (prefix-array &segments n)]
-      (concat &(copy-map append-slash &without-last))))
+      (concat &(copy-map (fn [s] (str* s "/")) &without-last))))
 
   )

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -268,15 +268,10 @@
   (defn div [a n]
     (zip- / (VN.v a) &(Array.replicate @(VN.n a) &n)))
 
-  (defn square- [n]
-    (* @n @n))
-
-  (defn add- [x y]
-    (+ @x @y))
-
   (doc mag-sq "Get the squared magnitude of a vector.")
   (defn mag-sq [o]
-    (Array.reduce add- 0.0 &(Array.copy-map square- (VN.v o))))
+    (Array.reduce (fn [x y] (+ @x @y)) 0.0
+                  &(Array.copy-map (fn [x] (* @x @x)) (VN.v o))))
 
   (doc mag "Get the magnitude of a vector.")
   (defn mag [o]
@@ -296,7 +291,7 @@
 
   (doc dot "Get the dot product of the two vectors x and y.")
   (defn dot [x y]
-    (Array.reduce add- 0.0 (VN.v &(zip * x y))))
+    (Array.reduce (fn [x y] (+ @x @y)) 0.0 (VN.v &(zip * x y))))
 
   (doc angle-between "Get the angle between to vectors a and b.")
   (defn angle-between [a b]

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -220,25 +220,6 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#add-">
-                    <h3 id="add-">
-                        add-
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [&amp;a, &amp;a] a)
-                </p>
-                <pre class="args">
-                    (add- x y)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
                 <a class="anchor" href="#angle-between">
                     <h3 id="angle-between">
                         angle-between
@@ -499,25 +480,6 @@
                 </p>
                 <pre class="args">
                     (random-sized n)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#square-">
-                    <h3 id="square-">
-                        square-
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [&amp;a] a)
-                </p>
-                <pre class="args">
-                    (square- n)
                 </pre>
                 <p class="doc">
                     

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -165,7 +165,6 @@ mangle = replaceChars (Map.fromList [('+', "_PLUS_")
                                     ,('>', "_GT_")
                                     ,('?', "_QMARK_")
                                     ,('!', "_BANG_")
-                                    ,('.', "_")
                                     ,('=', "_EQ_")])
 
 -- | From two types, one with type variables and one without (e.g. (Fn ["t0"] "t1") and (Fn [Int] Bool))

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -147,7 +147,8 @@ instance Show SymPath where
     else joinWithPeriod modulePath ++ "." ++ symName
 
 pathToC :: SymPath -> String
-pathToC (SymPath modulePath name) = concatMap ((++ "_") . mangle) modulePath ++ mangle name
+pathToC (SymPath modulePath name) =
+  concatMap ((++ "_") . mangle) modulePath ++ mangle name
 
 -- | Add qualifying strings to beginning of a path.
 consPath :: [String] -> SymPath -> SymPath
@@ -164,6 +165,7 @@ mangle = replaceChars (Map.fromList [('+', "_PLUS_")
                                     ,('>', "_GT_")
                                     ,('?', "_QMARK_")
                                     ,('!', "_BANG_")
+                                    ,('.', "_")
                                     ,('=', "_EQ_")])
 
 -- | From two types, one with type variables and one without (e.g. (Fn ["t0"] "t1") and (Fn [Int] Bool))


### PR DESCRIPTION
This PR changes the core/stdlib to use closures instead of helper functions for `map` et al.

This uncovered a bug in emitting closures: there was a stray `.` in the name that was passed into the emitter (e.g. `_Lambda_VectorN.mag-sq_17`). This is probably due to `Emit.hs:188`, where we mangle any old name as if it was a single name. The simple fix for this was to add a new mangle rule that substitutes `.` by `_`. This is maybe a little hacky, but it works and is unintrusive. Maybe someone else has a better suggestion?

Cheers