### PR TITLE
Add Char.upper-case and Char.lower-case

### DIFF
--- a/core/Char.carp
+++ b/core/Char.carp
@@ -25,6 +25,14 @@
 
   (defn /= [a b]
     (not (= (the Char a) b)))
+
+  (doc lower-case "Tests whether a character is lower case.")
+  (defn lower-case [c]
+    (and (<= \a c) (<= c \z)))
+
+  (doc upper-case "Tests whether a character is upper case.")
+  (defn upper-case [c]
+    (and (<= \A c) (<= c \Z)))
 )
 
 (defmodule CharRef

--- a/core/Char.carp
+++ b/core/Char.carp
@@ -26,12 +26,12 @@
   (defn /= [a b]
     (not (= (the Char a) b)))
 
-  (doc lower-case "Tests whether a character is lower case.")
-  (defn lower-case [c]
+  (doc lower-case? "Tests whether a character is lower case.")
+  (defn lower-case? [c]
     (and (<= \a c) (<= c \z)))
 
-  (doc upper-case "Tests whether a character is upper case.")
-  (defn upper-case [c]
+  (doc upper-case? "Tests whether a character is upper case.")
+  (defn upper-case? [c]
     (and (<= \A c) (<= c \Z)))
 )
 

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -296,6 +296,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#lower-case">
+                    <h3 id="lower-case">
+                        lower-case
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char] Bool)
+                </p>
+                <pre class="args">
+                    (lower-case c)
+                </pre>
+                <p class="doc">
+                    Tests whether a character is lower case.
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#meaning">
                     <h3 id="meaning">
                         meaning
@@ -407,6 +426,25 @@
                 </span>
                 <p class="doc">
                     
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#upper-case">
+                    <h3 id="upper-case">
+                        upper-case
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char] Bool)
+                </p>
+                <pre class="args">
+                    (upper-case c)
+                </pre>
+                <p class="doc">
+                    Tests whether a character is upper case.
                 </p>
             </div>
         </div>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -296,9 +296,9 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#lower-case">
-                    <h3 id="lower-case">
-                        lower-case
+                <a class="anchor" href="#lower-case?">
+                    <h3 id="lower-case?">
+                        lower-case?
                     </h3>
                 </a>
                 <div class="description">
@@ -308,7 +308,7 @@
                     (λ [Char] Bool)
                 </p>
                 <pre class="args">
-                    (lower-case c)
+                    (lower-case? c)
                 </pre>
                 <p class="doc">
                     Tests whether a character is lower case.
@@ -429,9 +429,9 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#upper-case">
-                    <h3 id="upper-case">
-                        upper-case
+                <a class="anchor" href="#upper-case?">
+                    <h3 id="upper-case?">
+                        upper-case?
                     </h3>
                 </a>
                 <div class="description">
@@ -441,7 +441,7 @@
                     (λ [Char] Bool)
                 </p>
                 <pre class="args">
-                    (upper-case c)
+                    (upper-case? c)
                 </pre>
                 <p class="doc">
                     Tests whether a character is upper case.

--- a/test/char.carp
+++ b/test/char.carp
@@ -38,22 +38,22 @@
                   (meaning &\9)
                   "meaning works as expected 9")
     (assert-true  test
-                  (upper-case \A)
-                  "upper-case works as expected I")
+                  (upper-case? \A)
+                  "upper-case? works as expected I")
     (assert-false test
-                  (upper-case \a)
-                  "upper-case works as expected II")
+                  (upper-case? \a)
+                  "upper-case? works as expected II")
     (assert-false test
-                  (upper-case \#)
-                  "upper-case works as expected III")
+                  (upper-case? \#)
+                  "upper-case? works as expected III")
     (assert-true  test
-                  (lower-case \a)
-                  "lower-case works as expected I")
+                  (lower-case? \a)
+                  "lower-case? works as expected I")
     (assert-false test
-                  (lower-case \A)
-                  "lower-case works as expected II")
+                  (lower-case? \A)
+                  "lower-case? works as expected II")
     (assert-false test
-                  (lower-case \#)
-                  "lower-case works as expected III")
+                  (lower-case? \#)
+                  "lower-case? works as expected III")
   )
 )

--- a/test/char.carp
+++ b/test/char.carp
@@ -37,5 +37,23 @@
                   9
                   (meaning &\9)
                   "meaning works as expected 9")
+    (assert-true  test
+                  (upper-case \A)
+                  "upper-case works as expected I")
+    (assert-false test
+                  (upper-case \a)
+                  "upper-case works as expected II")
+    (assert-false test
+                  (upper-case \#)
+                  "upper-case works as expected III")
+    (assert-true  test
+                  (lower-case \a)
+                  "lower-case works as expected I")
+    (assert-false test
+                  (lower-case \A)
+                  "lower-case works as expected II")
+    (assert-false test
+                  (lower-case \#)
+                  "lower-case works as expected III")
   )
 )


### PR DESCRIPTION
This PR adds the functions `Char.upper-case` and `Char.lower-case` to test whether a character is upper or lower case. It will only return `true` for characters that are actually alphabetical, which means that e.g. `!` is neither upper nor lower case.

Test cases are included.

Cheers