### PR TITLE
Add headerparse to lines_of_code.sh

### DIFF
--- a/lines_of_code.sh
+++ b/lines_of_code.sh
@@ -1,1 +1,1 @@
-cloc app bench core examples src test --force-lang=Lisp,carp
+cloc app bench core examples headerparse src test --force-lang=Lisp,carp


### PR DESCRIPTION
This PR adds the `headerparse` directory to the script `lines_of_code.sh`.

Cheers