### PR TITLE
Better random

### DIFF
--- a/core/Random.carp
+++ b/core/Random.carp
@@ -13,8 +13,12 @@
   (hidden s)
   (private s)
 
-  (doc seed "seed resets the seed of the random number generator to `new-seed`.")
-  (defn seed [new-seed]
+  (doc seed "seed resets the seed of the random number generator.")
+  (defn seed []
+    (set! s (Double.from-long (System.nanotime))))
+
+  (doc seed-from "seed-from resets the seed of the random number generator to `new-seed`.")
+  (defn seed-from [new-seed]
     (set! s new-seed))
 
   (doc random "random returns a float from 0 to 1.")

--- a/core/System.carp
+++ b/core/System.carp
@@ -5,6 +5,8 @@
   (register free (Fn [t] ()))
   (doc time "Gets the current system time as an integer.")
   (register time (Fn [] Int))
+  (doc nanotime "Gets the current system time in nanoseconds as a long.")
+  (register nanotime (Fn [] Long))
   (doc sleep-seconds "Sleeps for a specified number of seconds.")
   (register sleep-seconds (Fn [Int] ()))
   (doc sleep-seconds "Sleeps for a specified number of microseconds.")

--- a/core/carp_system.h
+++ b/core/carp_system.h
@@ -24,6 +24,13 @@ void System_sleep_MINUS_micros(int t) {
 }
 #endif
 
+
+double System_nanotime() {
+  struct timespec tv;
+  clock_gettime(CLOCK_REALTIME, &tv);
+  return 1000000000 * tv.tv_sec + tv.tv_nsec;
+}
+
 void System_system(String *command) {
     system(*command);
 }

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -163,6 +163,63 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#SEEK-CUR">
+                    <h3 id="SEEK-CUR">
+                        SEEK-CUR
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#SEEK-END">
+                    <h3 id="SEEK-END">
+                        SEEK-END
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#SEEK-SET">
+                    <h3 id="SEEK-SET">
+                        SEEK-SET
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    Int
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#color">
                     <h3 id="color">
                         color
@@ -239,6 +296,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#fflush">
+                    <h3 id="fflush">
+                        fflush
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr FILE)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    flushes a file pointer (i.e. commits every write).
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#fgetc">
                     <h3 id="fgetc">
                         fgetc
@@ -274,6 +350,63 @@
                 </span>
                 <p class="doc">
                     opens a file by name using a mode (one or multiple of [r]ead, [w]rite, and [a]ppend), returns a file pointer.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#fread">
+                    <h3 id="fread">
+                        fread
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [a, Int, Int, (Ptr FILE)] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    reads from a file pointer into a pointer.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#fseek">
+                    <h3 id="fseek">
+                        fseek
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr FILE), Int, Int] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    sets the position indicator of a file.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ftell">
+                    <h3 id="ftell">
+                        ftell
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr FILE)] Int)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    gets the position indicator of a file.
                 </p>
             </div>
             <div class="binder">
@@ -407,6 +540,44 @@
                 </span>
                 <p class="doc">
                     returns the contents of a file passed as argument as a string.
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#rewind">
+                    <h3 id="rewind">
+                        rewind
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr FILE)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    rewinds a file pointer (i.e. puts input and output stream to beginning).
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#unlink">
+                    <h3 id="unlink">
+                        unlink
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [String] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    unlinks a file (i.e. deletes it).
                 </p>
             </div>
         </div>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -258,6 +258,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#nanotime">
+                    <h3 id="nanotime">
+                        nanotime
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [] Long)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    Gets the current system time in nanoseconds as a long.
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#signal">
                     <h3 id="signal">
                         signal

--- a/examples/basics.carp
+++ b/examples/basics.carp
@@ -154,7 +154,7 @@
   (Float.random-between 10.0f 20.0f))
 
 (defn print-random-floats []
-  (do (Random.seed 0.2)
+  (do (Random.seed-from 0.2)
       (let [rands (Array.repeat 10 random-float)]
         (println (ref (Array.str &rands))))))
 
@@ -201,7 +201,7 @@
 (defn main []
   ; here we always use the same seed for determinism, for simple random
   ; numbers that change you can for instance use (System.time)
-  (do (Random.seed 0.1)
+  (do (Random.seed-from 0.1)
       (Things.call)
       (use-doubles)
       (println (ref (str (fib 10))))

--- a/examples/guessing.carp
+++ b/examples/guessing.carp
@@ -39,7 +39,7 @@
 
 (defn main []
   (do (println "Seeding random number generator...\n")
-      (Random.seed (Double.from-int (System.time)))
+      (Random.seed-from (Double.from-int (System.time)))
       (start-new-game!)
       (while guessing
         (let [user-input (get-line)

--- a/examples/updating.carp
+++ b/examples/updating.carp
@@ -35,7 +35,7 @@
   (do
     ; here we always use the same seed for determinism, for simple random
     ; numbers that change you can for instance use (System.time)
-    (Random.seed 0.1)
+    (Random.seed-from 0.1)
     (let [monsters (Array.copy-map Monster.init-random &[@"Pegasus" @"Dragon" @"Devil"])]
       (do
         (println (ref (Array.str &monsters)))

--- a/test/random.carp
+++ b/test/random.carp
@@ -11,6 +11,6 @@
                Double.approx)
     (assert-op test
                0.536041
-               (do (Random.seed 33333.0) (Random.random))
+               (do (Random.seed-from 33333.0) (Random.random))
                "deterministic randomization with seed works as expected"
                Double.approx)))


### PR DESCRIPTION
This PR changes the API of `Random.seed` to not take an argument, and instead use a good default (`System.nanotime`, another function that is new). If you really want to do seed yourself, use `Random.seed-from`, which is equivalent to the old version of `Random.seed`.

Cheers