### PR TITLE
Compiler: only use colored errors on ttys

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -55,6 +55,7 @@ library
                      , blaze-html
                      , blaze-markup
                      , text
+                     , unix
 
   default-language:    Haskell2010
 

--- a/src/ColorText.hs
+++ b/src/ColorText.hs
@@ -1,5 +1,8 @@
 module ColorText where
 
+import System.Posix.Terminal (queryTerminal)
+import System.Posix.IO (stdOutput)
+
 import Util
 
 data TextColor = Blue | Red | Yellow | Green | White
@@ -18,7 +21,10 @@ strWithColor color str =
                 White -> "37" -- TODO: Use 0 instead?
 
 putStrWithColor :: TextColor -> String -> IO ()
-putStrWithColor color str = putStr (strWithColor color str)
+putStrWithColor color str =
+  do
+    istty <- queryTerminal stdOutput
+    putStr $ if istty then strWithColor color str else str
 
 putStrLnWithColor :: TextColor -> String -> IO ()
 putStrLnWithColor color str = putStrWithColor color (str ++ "\n")


### PR DESCRIPTION
This PR adds a check for output coloring that restricts colors to TTY devices (i.e. terminals). This prevents files from being clobeered with ANSI escape codes.

One downside of this is that it depends on the `unix` package, which is kind of a bummer, but seems to be the only way.

Cheers