### PR TITLE
emit: fix emitting slash character

### DIFF
--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -90,6 +90,7 @@ toC toCMode root = emitterSrc (execState (visit startingIndent root) (EmitterSta
             Chr c -> return $ case c of
                                 '\t' -> "'\\t'"
                                 '\n' -> "'\\n'"
+                                '\\' -> "'\\\\'"
                                 x -> ['\'', x, '\'']
             Sym _ _ -> visitSymbol indent xobj
             Defn -> error (show (DontVisitObj Defn))


### PR DESCRIPTION
This PR fixes the compiler/emitter for slash characters. Previously it emitted `'\'`, which is wrong. it should be `'\\'` to appease the compiler!

Cheers