### PR TITLE
Add suport for markdown in docstrings

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -56,6 +56,7 @@ library
                      , blaze-markup
                      , text
                      , unix
+                     , cmark
 
   default-language:    Haskell2010
 

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -178,7 +178,8 @@
                     (= a b)
                 </pre>
                 <p class="doc">
-                    Compare two arrays.
+                    <p>Compare two arrays.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +274,8 @@
                     (aupdate a i f)
                 </pre>
                 <p class="doc">
-                    Transmute the element at index i of array a using function f.
+                    <p>Transmute the element at index i of array a using function f.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +294,8 @@
                     (aupdate! a i f)
                 </pre>
                 <p class="doc">
-                    Transmute the element at index i of array a using function f in place.
+                    <p>Transmute the element at index i of array a using function f in place.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -311,7 +314,8 @@
                     (concat xs)
                 </pre>
                 <p class="doc">
-                    Returns a new Array which is the concatenation of the provided `xs`.
+                    <p>Returns a new Array which is the concatenation of the provided <code>xs</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -349,7 +353,8 @@
                     (copy-map f a)
                 </pre>
                 <p class="doc">
-                    Map over array a using function f (copies the array).
+                    <p>Map over array a using function f (copies the array).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -387,7 +392,8 @@
                     (element-count a e)
                 </pre>
                 <p class="doc">
-                    Count occurrences of element e in an array.
+                    <p>Count occurrences of element e in an array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -425,7 +431,8 @@
                     (enumerated xs)
                 </pre>
                 <p class="doc">
-                    Create a new array of Pair:s where the first position is the index and the second position is the element from the original array.
+                    <p>Create a new array of Pair:s where the first position is the index and the second position is the element from the original array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +470,8 @@
                     (first a)
                 </pre>
                 <p class="doc">
-                    Take the first element of an array.
+                    <p>Take the first element of an array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -482,7 +490,8 @@
                     (index-of a e)
                 </pre>
                 <p class="doc">
-                    Get the index of element e in an array.
+                    <p>Get the index of element e in an array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -501,7 +510,8 @@
                     (last a)
                 </pre>
                 <p class="doc">
-                    Take the last element of an array.
+                    <p>Take the last element of an array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -539,7 +549,8 @@
                     (maximum xs)
                 </pre>
                 <p class="doc">
-                    Get the maximum in an array (elements must support &lt;).
+                    <p>Get the maximum in an array (elements must support &lt;).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -558,7 +569,8 @@
                     (minimum xs)
                 </pre>
                 <p class="doc">
-                    Sum an array (elements must support + and zero).
+                    <p>Sum an array (elements must support + and zero).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -634,7 +646,8 @@
                     (prefix-array xs end-index)
                 </pre>
                 <p class="doc">
-                    Get prefix-array to end-index.
+                    <p>Get prefix-array to end-index.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -710,7 +723,8 @@
                     (range start end step)
                 </pre>
                 <p class="doc">
-                    Create an array from start to end with step between them (the elements must support &lt;, &lt;=, and &gt;=).
+                    <p>Create an array from start to end with step between them (the elements must support &lt;, &lt;=, and &gt;=).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -748,7 +762,8 @@
                     (reduce f x xs)
                 </pre>
                 <p class="doc">
-                    Reduce an array, using the function f.
+                    <p>Reduce an array, using the function f.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -767,7 +782,8 @@
                     (repeat n f)
                 </pre>
                 <p class="doc">
-                    Repeat function f n times and store the results in an array.
+                    <p>Repeat function f n times and store the results in an array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -786,7 +802,8 @@
                     (repeat-indexed n f)
                 </pre>
                 <p class="doc">
-                    Repeat function f n times and store the results in an array (will be supplied with the index).
+                    <p>Repeat function f n times and store the results in an array (will be supplied with the index).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -805,7 +822,8 @@
                     (replicate n e)
                 </pre>
                 <p class="doc">
-                    Repeat element e n times and store the results in an array.
+                    <p>Repeat element e n times and store the results in an array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -824,7 +842,8 @@
                     (reverse a)
                 </pre>
                 <p class="doc">
-                    Reverse an array.
+                    <p>Reverse an array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -843,7 +862,8 @@
                     (sort arr)
                 </pre>
                 <p class="doc">
-                    Perform an in-place heapsort of a given owned array.
+                    <p>Perform an in-place heapsort of a given owned array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -862,7 +882,8 @@
                     (sort! arr)
                 </pre>
                 <p class="doc">
-                    Perform an in-place heapsort of a given array.
+                    <p>Perform an in-place heapsort of a given array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -881,7 +902,8 @@
                     (sorted arr)
                 </pre>
                 <p class="doc">
-                    Perform a heapsort in a new copy of given array.
+                    <p>Perform a heapsort in a new copy of given array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -919,7 +941,8 @@
                     (subarray xs start-index end-index)
                 </pre>
                 <p class="doc">
-                    Get subarray from start-index to end-index.
+                    <p>Get subarray from start-index to end-index.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -938,7 +961,8 @@
                     (suffix-array xs start-index)
                 </pre>
                 <p class="doc">
-                    Get subarray from start-index.
+                    <p>Get subarray from start-index.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -976,7 +1000,8 @@
                     (sum-length xs)
                 </pre>
                 <p class="doc">
-                    Returns the sum of lengths from an Array of Arrays.
+                    <p>Returns the sum of lengths from an Array of Arrays.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -995,7 +1020,8 @@
                     (swap a i j)
                 </pre>
                 <p class="doc">
-                    Swap indices i and j of array a.
+                    <p>Swap indices i and j of array a.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1014,7 +1040,8 @@
                     (swap! a i j)
                 </pre>
                 <p class="doc">
-                    Swap indices i and j of array a in place.
+                    <p>Swap indices i and j of array a in place.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1033,7 +1060,8 @@
                     (zero)
                 </pre>
                 <p class="doc">
-                    Returns the empty array.
+                    <p>Returns the empty array.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1052,7 +1080,8 @@
                     (zip f a b)
                 </pre>
                 <p class="doc">
-                    Map over two arrays using a function that takes two arguments. Produces a new array with the length of the shorter input.
+                    <p>Map over two arrays using a function that takes two arguments. Produces a new array with the length of the shorter input.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -159,7 +159,8 @@
                     (bench f)
                 </pre>
                 <p class="doc">
-                    Benchmark function f and print the results.
+                    <p>Benchmark function f and print the results.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -178,7 +179,8 @@
                     (set-min-runs! n)
                 </pre>
                 <p class="doc">
-                    Set the minimum number of runs. If your functions takes a large amount of time, experimenting with this might make sense.
+                    <p>Set the minimum number of runs. If your functions takes a large amount of time, experimenting with this might make sense.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -311,7 +311,8 @@
                     (lower-case? c)
                 </pre>
                 <p class="doc">
-                    Tests whether a character is lower case.
+                    <p>Tests whether a character is lower case.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -330,7 +331,8 @@
                     (meaning char-ref)
                 </pre>
                 <p class="doc">
-                    Convert a numerical char into the appropriate number.
+                    <p>Convert a numerical char into the appropriate number.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +446,8 @@
                     (upper-case? c)
                 </pre>
                 <p class="doc">
-                    Tests whether a character is upper case.
+                    <p>Tests whether a character is upper case.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -159,7 +159,8 @@
                     (assert-balanced form)
                 </pre>
                 <p class="doc">
-                    Raises an error if the memory balance (numberr of alloc:s - number of free:s) isn&#39;t 0. Requires compiling with --log-memory.
+                    <p>Raises an error if the memory balance (numberr of alloc:s - number of free:s) isn't 0. Requires compiling with --log-memory.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -178,7 +179,8 @@
                     
                 </span>
                 <p class="doc">
-                    Leak some memory. Useful for testing tools that detect leaks.
+                    <p>Leak some memory. Useful for testing tools that detect leaks.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -235,7 +237,8 @@
                     (memory-logged form)
                 </pre>
                 <p class="doc">
-                    Log all calls to memory allocation within te form. Requires compiling with --log-memory.
+                    <p>Log all calls to memory allocation within te form. Requires compiling with --log-memory.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +276,8 @@
                     (sanitize-addresses)
                 </pre>
                 <p class="doc">
-                    Instruct the compiler to sanitize addresses.
+                    <p>Instruct the compiler to sanitize addresses.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +296,8 @@
                     (trace x)
                 </pre>
                 <p class="doc">
-                    Print the value of an expression to stdout, then return its value.
+                    <p>Print the value of an expression to stdout, then return its value.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -368,7 +368,8 @@
                     (approx x y)
                 </pre>
                 <p class="doc">
-                    checks whether x and y are approximately (i.e. margin of error of 0.00001) equal
+                    <p>checks whether x and y are approximately (i.e. margin of error of 0.00001) equal</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -368,7 +368,8 @@
                     (approx x y)
                 </pre>
                 <p class="doc">
-                    checks whether x and y are approximately (i.e. margin of error of 0.00001) equal
+                    <p>checks whether x and y are approximately (i.e. margin of error of 0.00001) equal</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -159,7 +159,8 @@
                     (degree-to-radians n)
                 </pre>
                 <p class="doc">
-                    Converts degrees expressed as a double into radians.
+                    <p>Converts degrees expressed as a double into radians.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -178,7 +179,8 @@
                     (radians-to-degree n)
                 </pre>
                 <p class="doc">
-                    Converts radians expressed as a double into degree.
+                    <p>Converts radians expressed as a double into degree.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -159,7 +159,8 @@
                     
                 </span>
                 <p class="doc">
-                    the End-Of-File character as a literal.
+                    <p>the End-Of-File character as a literal.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -235,7 +236,8 @@
                     (color cname)
                 </pre>
                 <p class="doc">
-                    Sets the output color using ANSI.
+                    <p>Sets the output color using ANSI.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -254,7 +256,8 @@
                     (colorize cname s)
                 </pre>
                 <p class="doc">
-                    Wraps a string in ANSI coloration and prints it.
+                    <p>Wraps a string in ANSI coloration and prints it.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +276,8 @@
                     
                 </span>
                 <p class="doc">
-                    exit the current program with a return code.
+                    <p>exit the current program with a return code.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +296,8 @@
                     
                 </span>
                 <p class="doc">
-                    closes a file pointer.
+                    <p>closes a file pointer.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -330,7 +335,8 @@
                     
                 </span>
                 <p class="doc">
-                    gets a character from a file pointer.
+                    <p>gets a character from a file pointer.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -349,7 +355,8 @@
                     
                 </span>
                 <p class="doc">
-                    opens a file by name using a mode (one or multiple of [r]ead, [w]rite, and [a]ppend), returns a file pointer.
+                    <p>opens a file by name using a mode (one or multiple of [r]ead, [w]rite, and [a]ppend), returns a file pointer.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -425,7 +432,8 @@
                     
                 </span>
                 <p class="doc">
-                    writes to a file pointer.
+                    <p>writes to a file pointer.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +452,8 @@
                     
                 </span>
                 <p class="doc">
-                    gets a character from stdin.
+                    <p>gets a character from stdin.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +472,8 @@
                     
                 </span>
                 <p class="doc">
-                    gets a line from stdin.
+                    <p>gets a line from stdin.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -482,7 +492,8 @@
                     
                 </span>
                 <p class="doc">
-                    prints a string ref to stdout, does not append a newline.
+                    <p>prints a string ref to stdout, does not append a newline.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -501,7 +512,8 @@
                     
                 </span>
                 <p class="doc">
-                    prints a string ref to stdout, appends a newline.
+                    <p>prints a string ref to stdout, appends a newline.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -520,7 +532,8 @@
                     (read-&gt;EOF filename)
                 </pre>
                 <p class="doc">
-                    reads a file given by name until the End-Of-File character is reached.
+                    <p>reads a file given by name until the End-Of-File character is reached.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -539,7 +552,8 @@
                     
                 </span>
                 <p class="doc">
-                    returns the contents of a file passed as argument as a string.
+                    <p>returns the contents of a file passed as argument as a string.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -349,7 +349,8 @@
                     
                 </span>
                 <p class="doc">
-                    The absolute value (removes the negative sign) of an Int.
+                    <p>The absolute value (removes the negative sign) of an Int.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -710,7 +711,8 @@
                     (pow x y)
                 </pre>
                 <p class="doc">
-                    Raise x to the power of y.
+                    <p>Raise x to the power of y.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -767,7 +769,8 @@
                     
                 </span>
                 <p class="doc">
-                    Performs an addition and checks whether it overflowed.
+                    <p>Performs an addition and checks whether it overflowed.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -786,7 +789,8 @@
                     
                 </span>
                 <p class="doc">
-                    Performs an multiplication and checks whether it overflowed.
+                    <p>Performs an multiplication and checks whether it overflowed.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -805,7 +809,8 @@
                     
                 </span>
                 <p class="doc">
-                    Performs an substraction and checks whether it overflowed.
+                    <p>Performs an substraction and checks whether it overflowed.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -178,7 +178,8 @@
                     (contains? m k)
                 </pre>
                 <p class="doc">
-                    Check whether the map m contains the key k.
+                    <p>Check whether the map m contains the key k.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -216,7 +217,8 @@
                     (create)
                 </pre>
                 <p class="doc">
-                    Create an empty map.
+                    <p>Create an empty map.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -235,7 +237,8 @@
                     (create-with-len len)
                 </pre>
                 <p class="doc">
-                    Create an empty map with a given number of buckets. High numbers reduce the possibility of hash collisions while increasing the memory footprint.
+                    <p>Create an empty map with a given number of buckets. High numbers reduce the possibility of hash collisions while increasing the memory footprint.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +276,8 @@
                     
                 </span>
                 <p class="doc">
-                    Check whether the map m is empty.
+                    <p>Check whether the map m is empty.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -311,7 +315,8 @@
                     (for-each m f)
                 </pre>
                 <p class="doc">
-                    Execute the binary function f for all keys and values in the map m.
+                    <p>Execute the binary function f for all keys and values in the map m.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -330,7 +335,8 @@
                     (from-array a)
                 </pre>
                 <p class="doc">
-                    Create a map from the array a containing key-value pairs.
+                    <p>Create a map from the array a containing key-value pairs.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -349,7 +355,8 @@
                     (get m k)
                 </pre>
                 <p class="doc">
-                    Get the value for the key k from map m. If it isn’t found, a zero element for the value type is returned.
+                    <p>Get the value for the key k from map m. If it isn’t found, a zero element for the value type is returned.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -387,7 +394,8 @@
                     (length m)
                 </pre>
                 <p class="doc">
-                    Get the length of the map m.
+                    <p>Get the length of the map m.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +452,8 @@
                     (put m k v)
                 </pre>
                 <p class="doc">
-                    Put a a value v into map m, using the key k.
+                    <p>Put a a value v into map m, using the key k.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +472,8 @@
                     (remove m k)
                 </pre>
                 <p class="doc">
-                    Remove the value under the key k from the map m.
+                    <p>Remove the value under the key k from the map m.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -197,7 +197,8 @@
                     
                 </span>
                 <p class="doc">
-                    Finds the index of a pattern in a string. Returns -1 otherwise.
+                    <p>Finds the index of a pattern in a string. Returns -1 otherwise.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -216,7 +217,8 @@
                     (from-chars chars)
                 </pre>
                 <p class="doc">
-                    Creates a pattern that matches a group of characters from a list of those characters.
+                    <p>Creates a pattern that matches a group of characters from a list of those characters.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -235,7 +237,8 @@
                     
                 </span>
                 <p class="doc">
-                    Finds all matches of a pattern in a string as a nested array. Returns [] otherwise.
+                    <p>Finds all matches of a pattern in a string as a nested array. Returns [] otherwise.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +276,8 @@
                     
                 </span>
                 <p class="doc">
-                    Finds the match groups of the first match of a pattern in a string. Returns [] otherwise.
+                    <p>Finds the match groups of the first match of a pattern in a string. Returns [] otherwise.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +296,8 @@
                     
                 </span>
                 <p class="doc">
-                    Finds the first match of a pattern in a string. Returns [] otherwise.
+                    <p>Finds the first match of a pattern in a string. Returns [] otherwise.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -311,7 +316,8 @@
                     (matches? pat s)
                 </pre>
                 <p class="doc">
-                    Checks whether a pattern matches a string.
+                    <p>Checks whether a pattern matches a string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -368,7 +374,8 @@
                     
                 </span>
                 <p class="doc">
-                    Finds all matches of a pattern in a string and replaces it by another n times (-1 for all occurrences).
+                    <p>Finds all matches of a pattern in a string and replaces it by another n times (-1 for all occurrences).</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -178,7 +178,8 @@
                     (grouped-median data interval)
                 </pre>
                 <p class="doc">
-                    Compute the grouped median of the samples data.
+                    <p>Compute the grouped median of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -197,7 +198,8 @@
                     (high-median data)
                 </pre>
                 <p class="doc">
-                    Compute the high median of the samples data.
+                    <p>Compute the high median of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -216,7 +218,8 @@
                     (iqr data)
                 </pre>
                 <p class="doc">
-                    Compute the interquartile range.
+                    <p>Compute the interquartile range.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -235,7 +238,8 @@
                     (low-median data)
                 </pre>
                 <p class="doc">
-                    Compute the low median of the samples data.
+                    <p>Compute the low median of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -254,7 +258,8 @@
                     (mean data)
                 </pre>
                 <p class="doc">
-                    Compute the mean of the samples data.
+                    <p>Compute the mean of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +278,8 @@
                     (median data)
                 </pre>
                 <p class="doc">
-                    Compute the median of the samples data.
+                    <p>Compute the median of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +298,8 @@
                     (pstdev data)
                 </pre>
                 <p class="doc">
-                    Compute the population standard deviation of the samples data.
+                    <p>Compute the population standard deviation of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -311,7 +318,8 @@
                     
                 </span>
                 <p class="doc">
-                    Compute the standard deviation of the samples data as a percentile.
+                    <p>Compute the standard deviation of the samples data as a percentile.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -330,7 +338,8 @@
                     (pvariance data)
                 </pre>
                 <p class="doc">
-                    Compute the population variance of the samples data.
+                    <p>Compute the population variance of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -349,7 +358,8 @@
                     (quartiles data)
                 </pre>
                 <p class="doc">
-                    Compute the quartiles of the samples data.
+                    <p>Compute the quartiles of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -368,7 +378,8 @@
                     (stdev data)
                 </pre>
                 <p class="doc">
-                    Compute the standard deviation of the samples data.
+                    <p>Compute the standard deviation of the samples data.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -406,7 +417,8 @@
                     (summary samples)
                 </pre>
                 <p class="doc">
-                    Compute a variety of statistical values from a list of samples.
+                    <p>Compute a variety of statistical values from a list of samples.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -425,7 +437,8 @@
                     (variance data)
                 </pre>
                 <p class="doc">
-                    Compute the variance of the samples data.
+                    <p>Compute the variance of the samples data.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -254,7 +254,8 @@
                     (alpha? s)
                 </pre>
                 <p class="doc">
-                    Check if a string contains only alpha characters (a-Z).
+                    <p>Check if a string contains only alpha characters (a-Z).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +274,8 @@
                     (alphanum? s)
                 </pre>
                 <p class="doc">
-                    Checks whether a string is alphanumerical.
+                    <p>Checks whether a string is alphanumerical.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -349,7 +351,8 @@
                     (chomp s)
                 </pre>
                 <p class="doc">
-                    Trims newline from the end of a string.
+                    <p>Trims newline from the end of a string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -368,7 +371,8 @@
                     (collapse-whitespace s)
                 </pre>
                 <p class="doc">
-                    Collapse groups of whitespace into single spaces.
+                    <p>Collapse groups of whitespace into single spaces.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -387,7 +391,8 @@
                     (concat strings)
                 </pre>
                 <p class="doc">
-                    Returns a new string which is the concatenation of the provided `strings`.
+                    <p>Returns a new string which is the concatenation of the provided <code>strings</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -406,7 +411,8 @@
                     (count-char s c)
                 </pre>
                 <p class="doc">
-                    Returns the number of occurrences of `c` in the string `s`.
+                    <p>Returns the number of occurrences of <code>c</code> in the string <code>s</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +450,8 @@
                     (empty? s)
                 </pre>
                 <p class="doc">
-                    Check if the string is the empty string.
+                    <p>Check if the string is the empty string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +470,8 @@
                     (ends-with? s sub)
                 </pre>
                 <p class="doc">
-                    Check if the string `s` ends with the string `sub`.
+                    <p>Check if the string <code>s</code> ends with the string <code>sub</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -539,7 +547,8 @@
                     (head s)
                 </pre>
                 <p class="doc">
-                    Returns the character at start of string.
+                    <p>Returns the character at start of string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -558,7 +567,8 @@
                     (hex? s)
                 </pre>
                 <p class="doc">
-                    Checks whether a string is hexadecimal.
+                    <p>Checks whether a string is hexadecimal.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -577,7 +587,8 @@
                     (in? s sub)
                 </pre>
                 <p class="doc">
-                    Checks whether a string contains another string.
+                    <p>Checks whether a string contains another string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -634,7 +645,8 @@
                     (join sep strings)
                 </pre>
                 <p class="doc">
-                    Returns a new string which is the concatenation of the provided `strings` separated by string `sep`.
+                    <p>Returns a new string which is the concatenation of the provided <code>strings</code> separated by string <code>sep</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -653,7 +665,8 @@
                     (join-with-char sep strings)
                 </pre>
                 <p class="doc">
-                    Returns a new string which is the concatenation of the provided `strings` separated by char `sep`.
+                    <p>Returns a new string which is the concatenation of the provided <code>strings</code> separated by char <code>sep</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -691,7 +704,8 @@
                     (lines s)
                 </pre>
                 <p class="doc">
-                    Split a string into lines.
+                    <p>Split a string into lines.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -710,7 +724,8 @@
                     (lower? s)
                 </pre>
                 <p class="doc">
-                    Checks whether a string is all lowercase.
+                    <p>Checks whether a string is all lowercase.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -729,7 +744,8 @@
                     (num? s)
                 </pre>
                 <p class="doc">
-                    Checks whether a string is numerical.
+                    <p>Checks whether a string is numerical.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -748,7 +764,8 @@
                     (pad-left len pad s)
                 </pre>
                 <p class="doc">
-                    Pads the left of a string with len bytes using the padding pad.
+                    <p>Pads the left of a string with len bytes using the padding pad.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -767,7 +784,8 @@
                     (pad-right len pad s)
                 </pre>
                 <p class="doc">
-                    Pads the right of a string with len bytes using the padding pad.
+                    <p>Pads the right of a string with len bytes using the padding pad.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -786,7 +804,8 @@
                     (prefix-string s a)
                 </pre>
                 <p class="doc">
-                    Return the first `a` characters of the string `s`.
+                    <p>Return the first <code>a</code> characters of the string <code>s</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -862,7 +881,8 @@
                     (repeat n inpt)
                 </pre>
                 <p class="doc">
-                    Returns a new string which is `inpt` repeated `n` times.
+                    <p>Returns a new string which is <code>inpt</code> repeated <code>n</code> times.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -881,7 +901,8 @@
                     (reverse s)
                 </pre>
                 <p class="doc">
-                    Produce a new string which is `s` reversed.
+                    <p>Produce a new string which is <code>s</code> reversed.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -900,7 +921,8 @@
                     (split-by _s separators)
                 </pre>
                 <p class="doc">
-                    Split a string by separators.
+                    <p>Split a string by separators.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -919,7 +941,8 @@
                     (starts-with? s sub)
                 </pre>
                 <p class="doc">
-                    Check if the string `s` begins with the string `sub`.
+                    <p>Check if the string <code>s</code> begins with the string <code>sub</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1014,7 +1037,8 @@
                     (suffix-string s b)
                 </pre>
                 <p class="doc">
-                    Return the last `b` characters of the string `s`.
+                    <p>Return the last <code>b</code> characters of the string <code>s</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1033,7 +1057,8 @@
                     (sum-length strings)
                 </pre>
                 <p class="doc">
-                    Returns the sum of lengths from an array of Strings.
+                    <p>Returns the sum of lengths from an array of Strings.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1071,7 +1096,8 @@
                     (trim s)
                 </pre>
                 <p class="doc">
-                    Trims whitespace from both sides of a string.
+                    <p>Trims whitespace from both sides of a string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1090,7 +1116,8 @@
                     (trim-left s)
                 </pre>
                 <p class="doc">
-                    Trims whitespace from the left of a string.
+                    <p>Trims whitespace from the left of a string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1109,7 +1136,8 @@
                     (trim-right s)
                 </pre>
                 <p class="doc">
-                    Trims whitespace from the right of a string.
+                    <p>Trims whitespace from the right of a string.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1128,7 +1156,8 @@
                     (upper? s)
                 </pre>
                 <p class="doc">
-                    Checks whether a string is all uppercase.
+                    <p>Checks whether a string is all uppercase.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1147,7 +1176,8 @@
                     (words s)
                 </pre>
                 <p class="doc">
-                    Split a string into words.
+                    <p>Split a string into words.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -1166,7 +1196,8 @@
                     (zero)
                 </pre>
                 <p class="doc">
-                    The empty string.
+                    <p>The empty string.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -197,7 +197,8 @@
                     
                 </span>
                 <p class="doc">
-                    Frees an object. Should not be called except in direst circumstances.
+                    <p>Frees an object. Should not be called except in direst circumstances.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -216,7 +217,8 @@
                     
                 </span>
                 <p class="doc">
-                    Gets the number of command line arguments.
+                    <p>Gets the number of command line arguments.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +446,8 @@
                     
                 </span>
                 <p class="doc">
-                    Sleeps for a specified number of microseconds.
+                    <p>Sleeps for a specified number of microseconds.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +466,8 @@
                     
                 </span>
                 <p class="doc">
-                    Performs a system command.
+                    <p>Performs a system command.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -482,7 +486,8 @@
                     
                 </span>
                 <p class="doc">
-                    Gets the current system time as an integer.
+                    <p>Gets the current system time as an integer.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -178,7 +178,8 @@
                     (assert-equal state x y descr)
                 </pre>
                 <p class="doc">
-                    Assert that x and y are equal. Equality needs to be implemented for their type.
+                    <p>Assert that x and y are equal. Equality needs to be implemented for their type.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -197,7 +198,8 @@
                     (assert-exit state exit-code f descr)
                 </pre>
                 <p class="doc">
-                    Assert that function f aborts with OS signal signal.
+                    <p>Assert that function f aborts with OS signal signal.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -216,7 +218,8 @@
                     (assert-false state x descr)
                 </pre>
                 <p class="doc">
-                    Assert that x is false.
+                    <p>Assert that x is false.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -235,7 +238,8 @@
                     (assert-not-equal state x y descr)
                 </pre>
                 <p class="doc">
-                    Assert that x and y are not equal. Equality needs to be implemented for their type.
+                    <p>Assert that x and y are not equal. Equality needs to be implemented for their type.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -254,7 +258,8 @@
                     (assert-op state x y descr op)
                 </pre>
                 <p class="doc">
-                    Assert that op returns true when given x and y.
+                    <p>Assert that op returns true when given x and y.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +297,8 @@
                     (assert-true state x descr)
                 </pre>
                 <p class="doc">
-                    Assert that x is true.
+                    <p>Assert that x is true.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -311,7 +317,8 @@
                     (print-test-results state)
                 </pre>
                 <p class="doc">
-                    Print test results.
+                    <p>Print test results.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -330,7 +337,8 @@
                     (reset state)
                 </pre>
                 <p class="doc">
-                    Reset test state.
+                    <p>Reset test state.</p>
+
                 </p>
             </div>
         </div>

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -235,7 +235,8 @@
                     (angle-between a b)
                 </pre>
                 <p class="doc">
-                    Get the angle between to vectors a and b.
+                    <p>Get the angle between to vectors a and b.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -254,7 +255,8 @@
                     (anti-parallel? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are anti-parallel.
+                    <p>Check whether the two vectors a and b are anti-parallel.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +275,8 @@
                     (approx a b)
                 </pre>
                 <p class="doc">
-                    Check whether the vectors a and b are approximately equal.
+                    <p>Check whether the vectors <code>a</code> and <code>b</code> are approximately equal.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -292,7 +295,8 @@
                     (dist a b)
                 </pre>
                 <p class="doc">
-                    Get the distance between the vectors a and b.
+                    <p>Get the distance between the vectors a and b.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -330,7 +334,8 @@
                     (dot x y)
                 </pre>
                 <p class="doc">
-                    Get the dot product of the two vectors x and y.
+                    <p>Get the dot product of the two vectors x and y.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -387,7 +392,8 @@
                     (heading a)
                 </pre>
                 <p class="doc">
-                    Get the heading of the vector a.
+                    <p>Get the heading of the vector a.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -425,7 +431,8 @@
                     (lerp a b amnt)
                 </pre>
                 <p class="doc">
-                    Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).
+                    <p>Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +451,8 @@
                     (mag o)
                 </pre>
                 <p class="doc">
-                    Get the magnitude of a vector.
+                    <p>Get the magnitude of a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +471,8 @@
                     (mag-sq o)
                 </pre>
                 <p class="doc">
-                    Get the squared magnitude of a vector.
+                    <p>Get the squared magnitude of a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -501,7 +510,8 @@
                     (normalize o)
                 </pre>
                 <p class="doc">
-                    Normalize a vector.
+                    <p>Normalize a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -520,7 +530,8 @@
                     (parallel? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are parallel.
+                    <p>Check whether the two vectors a and b are parallel.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -539,7 +550,8 @@
                     (perpendicular? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are perpendicular.
+                    <p>Check whether the two vectors a and b are perpendicular.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -577,7 +589,8 @@
                     (rotate a n)
                 </pre>
                 <p class="doc">
-                    Rotate the vector a by the radians n.
+                    <p>Rotate the vector a by the radians n.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -235,7 +235,8 @@
                     (angle-between a b)
                 </pre>
                 <p class="doc">
-                    Get the angle between to vectors a and b.
+                    <p>Get the angle between to vectors a and b.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -254,7 +255,8 @@
                     (anti-parallel? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are anti-parallel.
+                    <p>Check whether the two vectors a and b are anti-parallel.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +275,8 @@
                     (cross x y)
                 </pre>
                 <p class="doc">
-                    Compute the cross product of the two vectors x and y.
+                    <p>Compute the cross product of the two vectors x and y.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -311,7 +314,8 @@
                     (dot x y)
                 </pre>
                 <p class="doc">
-                    Get the dot product of the two vectors x and y.
+                    <p>Get the dot product of the two vectors x and y.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -349,7 +353,8 @@
                     (lerp a b amnt)
                 </pre>
                 <p class="doc">
-                    Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).
+                    <p>Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -368,7 +373,8 @@
                     (mag o)
                 </pre>
                 <p class="doc">
-                    Get the magnitude of a vector.
+                    <p>Get the magnitude of a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -387,7 +393,8 @@
                     (mag-sq o)
                 </pre>
                 <p class="doc">
-                    Get the squared magnitude of a vector.
+                    <p>Get the squared magnitude of a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -425,7 +432,8 @@
                     (normalize o)
                 </pre>
                 <p class="doc">
-                    Normalize a vector.
+                    <p>Normalize a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +452,8 @@
                     (parallel? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are parallel.
+                    <p>Check whether the two vectors a and b are parallel.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +472,8 @@
                     (perpendicular? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are perpendicular.
+                    <p>Check whether the two vectors a and b are perpendicular.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -235,7 +235,8 @@
                     (angle-between a b)
                 </pre>
                 <p class="doc">
-                    Get the angle between to vectors a and b.
+                    <p>Get the angle between to vectors a and b.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -254,7 +255,8 @@
                     (anti-parallel? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are anti-parallel.
+                    <p>Check whether the two vectors a and b are anti-parallel.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -273,7 +275,8 @@
                     (dist a b)
                 </pre>
                 <p class="doc">
-                    Get the distance between the vectors a and b.
+                    <p>Get the distance between the vectors a and b.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -311,7 +314,8 @@
                     (dot x y)
                 </pre>
                 <p class="doc">
-                    Get the dot product of the two vectors x and y.
+                    <p>Get the dot product of the two vectors x and y.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -349,7 +353,8 @@
                     (lerp a b amnt)
                 </pre>
                 <p class="doc">
-                    Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).
+                    <p>Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -368,7 +373,8 @@
                     (mag o)
                 </pre>
                 <p class="doc">
-                    Get the magnitude of a vector.
+                    <p>Get the magnitude of a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -387,7 +393,8 @@
                     (mag-sq o)
                 </pre>
                 <p class="doc">
-                    Get the squared magnitude of a vector.
+                    <p>Get the squared magnitude of a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -425,7 +432,8 @@
                     (normalize o)
                 </pre>
                 <p class="doc">
-                    Normalize a vector.
+                    <p>Normalize a vector.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -444,7 +452,8 @@
                     (parallel? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are parallel.
+                    <p>Check whether the two vectors a and b are parallel.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -463,7 +472,8 @@
                     (perpendicular? a b)
                 </pre>
                 <p class="doc">
-                    Check whether the two vectors a and b are perpendicular.
+                    <p>Check whether the two vectors a and b are perpendicular.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -2,6 +2,7 @@
 
 module RenderDocs where
 
+import CMark
 import Text.Blaze.Html5 as H
 import Text.Blaze.Html5.Attributes as A
 import Text.Blaze.Html.Renderer.Pretty (renderHtml)
@@ -100,6 +101,7 @@ binderToHtml (Binder meta xobj) =
                     Just (XObj (Str s) _ _) -> s
                     Just found -> pretty found
                     Nothing -> ""
+      htmlDoc = commonmarkToHtml [optSafe] $ Text.pack docString
   in  do H.div ! A.class_ "binder" $
            do H.a ! A.class_ "anchor" ! A.href (stringValue ("#" ++ name)) $
                 do H.h3 ! A.id (stringValue name) $ (toHtml name)
@@ -108,5 +110,5 @@ binderToHtml (Binder meta xobj) =
               case maybeNameAndArgs of
                 Just nameAndArgs -> H.pre ! A.class_ "args" $ toHtml nameAndArgs
                 Nothing -> H.span $ toHtml (""::String)
-              H.p ! A.class_ "doc" $ (toHtml docString)
+              H.p ! A.class_ "doc" $ (preEscapedToHtml htmlDoc)
               --p_ (toHtml (description))


### PR DESCRIPTION
This PR adds support for Markdown (more specifically, CommonMark) to docstrings in Carp. This should simplify generating rich, good documentation.

This is a proposal and should be treated as such. If people have strong feeling for or against this, I’d like to hear it and why!

Cheers