### PR TITLE
Add performance-oriented patches

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -5,7 +5,7 @@
     (let [total x]
       (do
         (for [i 0 (length xs)]
-          (set! total (f &total (nth xs i))))
+          (set! total (f total (nth xs i))))
         total)))
 
   (doc first "Take the first element of an array.")
@@ -57,7 +57,7 @@
 
   (doc minimum "Sum an array (elements must support + and zero).")
   (defn sum [xs]
-    (Array.reduce (fn [x y] (+ @x @y)) (zero) xs))
+    (Array.reduce (fn [x y] (+ x @y)) (zero) xs))
 
   (doc subarray "Get subarray from start-index to end-index.")
   (defn subarray [xs start-index end-index]

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -99,13 +99,19 @@
   (defn create-with-len [len]
     (init len (Array.repeat len Bucket.empty)))
 
+  (doc put! "Put a a value v into map m, using the key k. Takes ownership.")
+  (defn put! [m k v]
+    (let [idx (Int.mod (hash k) @(n-buckets &m))]
+      (update-buckets m (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (Bucket.grow n (Pair.init @k @v))))))))
+
   (doc put "Put a a value v into map m, using the key k.")
   (defn put [m k v]
-    (let [idx (Int.mod (hash k) @(n-buckets m))
-          b (buckets m)]
-      (set-buckets @m (Array.aset @b
-                                  idx
-                                  (Bucket.grow (Array.nth b idx) (Pair.init @k @v))))))
+    (let [idx (Int.mod (hash k) @(n-buckets m))]
+      (update-buckets @m (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (Bucket.grow n (Pair.init @k @v))))))))
 
   (doc get "Get the value for the key k from map m. If it isn’t found, a zero element for the value type is returned.")
   (defn get [m k]
@@ -128,13 +134,19 @@
     (let [idx (Int.mod (hash k) @(n-buckets m))]
       (Bucket.contains? (Array.nth (buckets m) idx) k)))
 
+  (doc remove! "Remove the value under the key k from the map m. Takes ownership.")
+  (defn remove! [m k]
+    (let [idx (Int.mod (hash k) @(n-buckets &m))]
+      (update-buckets m (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (Bucket.shrink n k)))))))
+
   (doc remove "Remove the value under the key k from the map m.")
   (defn remove [m k]
-    (let [idx (Int.mod (hash k) @(n-buckets &m))
-          b (buckets &m)]
-      (set-buckets m (Array.aset @b
-                                 idx
-                                 (Bucket.shrink (Array.nth b idx) k)))))
+    (let [idx (Int.mod (hash k) @(n-buckets m))]
+      (update-buckets @m (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (Bucket.shrink n k)))))))
 
   (doc for-each "Execute the binary function f for all keys and values in the map m.")
   (defn for-each [m f]
@@ -216,13 +228,19 @@
   (defn create-with-len [len]
     (init len (Array.repeat len SetBucket.empty)))
 
+  (doc put! "Put a a key k into the set s. Takes ownership")
+  (defn put! [s k]
+    (let [idx (Int.mod (hash k) @(n-buckets &s))]
+      (update-buckets s (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (SetBucket.grow n @k)))))))
+
   (doc put "Put a a key k into the set s.")
   (defn put [s k]
-    (let [idx (Int.mod (hash k) @(n-buckets s))
-          b (buckets s)]
-      (set-buckets @s (Array.aset @b
-                                  idx
-                                  (SetBucket.grow (Array.nth b idx) @k)))))
+    (let [idx (Int.mod (hash k) @(n-buckets s))]
+      (update-buckets @s (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (SetBucket.grow n @k)))))))
 
   (doc length "Get the length of set s.")
   (defn length [s]
@@ -240,14 +258,19 @@
     (let [idx (Int.mod (hash k) @(n-buckets s))]
       (SetBucket.contains? (Array.nth (buckets s) idx) k)))
 
+  (doc remove! "Remove the key k from the set s. Takes ownership")
+  (defn remove! [s k]
+    (let [idx (Int.mod (hash k) @(n-buckets &s))]
+      (update-buckets s (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (SetBucket.shrink n k)))))))
+
   (doc remove "Remove the key k from the set s.")
   (defn remove [s k]
-    (let [idx (Int.mod (hash k) @(n-buckets &s))
-          b (buckets &s)]
-      (set-buckets s (Array.aset @b
-                                 idx
-                                 (SetBucket.shrink (Array.nth b idx) k)))))
-
+    (let [idx (Int.mod (hash k) @(n-buckets s))]
+      (update-buckets @s (fn [b]
+        (let [n (Array.nth &b idx)]
+          (Array.aset b idx (SetBucket.shrink n k)))))))
 
   (doc for-each "Execute the unary function f for each element in the set s.")
   (defn for-each [s f]
@@ -264,7 +287,7 @@
     (let-do [s (create)]
       (for [i 0 (Array.length a)]
         (let [e (Array.nth a i)]
-          (set! s (put &s e))))
+          (set! s (put! s e))))
       s))
 
   (defn str [s]

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -99,17 +99,10 @@
   (defn create-with-len [len]
     (init len (Array.repeat len Bucket.empty)))
 
-  (doc put! "Put a a value v into map m, using the key k. Takes ownership.")
-  (defn put! [m k v]
-    (let [idx (Int.mod (hash k) @(n-buckets &m))]
-      (update-buckets m (fn [b]
-        (let [n (Array.nth &b idx)]
-          (Array.aset b idx (Bucket.grow n (Pair.init @k @v))))))))
-
   (doc put "Put a a value v into map m, using the key k.")
   (defn put [m k v]
-    (let [idx (Int.mod (hash k) @(n-buckets m))]
-      (update-buckets @m (fn [b]
+    (let [idx (Int.mod (hash k) @(n-buckets &m))]
+      (update-buckets m (fn [b]
         (let [n (Array.nth &b idx)]
           (Array.aset b idx (Bucket.grow n (Pair.init @k @v))))))))
 
@@ -134,17 +127,10 @@
     (let [idx (Int.mod (hash k) @(n-buckets m))]
       (Bucket.contains? (Array.nth (buckets m) idx) k)))
 
-  (doc remove! "Remove the value under the key k from the map m. Takes ownership.")
-  (defn remove! [m k]
-    (let [idx (Int.mod (hash k) @(n-buckets &m))]
-      (update-buckets m (fn [b]
-        (let [n (Array.nth &b idx)]
-          (Array.aset b idx (Bucket.shrink n k)))))))
-
   (doc remove "Remove the value under the key k from the map m.")
   (defn remove [m k]
-    (let [idx (Int.mod (hash k) @(n-buckets m))]
-      (update-buckets @m (fn [b]
+    (let [idx (Int.mod (hash k) @(n-buckets &m))]
+      (update-buckets m (fn [b]
         (let [n (Array.nth &b idx)]
           (Array.aset b idx (Bucket.shrink n k)))))))
 
@@ -165,7 +151,7 @@
         (let [e (Array.nth a i)
               k (Pair.a e)
               v (Pair.b e)]
-          (set! m (put &m k v))))
+          (set! m (put m k v))))
       m))
 
   (defn str [m]
@@ -228,17 +214,10 @@
   (defn create-with-len [len]
     (init len (Array.repeat len SetBucket.empty)))
 
-  (doc put! "Put a a key k into the set s. Takes ownership")
-  (defn put! [s k]
-    (let [idx (Int.mod (hash k) @(n-buckets &s))]
-      (update-buckets s (fn [b]
-        (let [n (Array.nth &b idx)]
-          (Array.aset b idx (SetBucket.grow n @k)))))))
-
   (doc put "Put a a key k into the set s.")
   (defn put [s k]
-    (let [idx (Int.mod (hash k) @(n-buckets s))]
-      (update-buckets @s (fn [b]
+    (let [idx (Int.mod (hash k) @(n-buckets &s))]
+      (update-buckets s (fn [b]
         (let [n (Array.nth &b idx)]
           (Array.aset b idx (SetBucket.grow n @k)))))))
 
@@ -258,17 +237,10 @@
     (let [idx (Int.mod (hash k) @(n-buckets s))]
       (SetBucket.contains? (Array.nth (buckets s) idx) k)))
 
-  (doc remove! "Remove the key k from the set s. Takes ownership")
-  (defn remove! [s k]
-    (let [idx (Int.mod (hash k) @(n-buckets &s))]
-      (update-buckets s (fn [b]
-        (let [n (Array.nth &b idx)]
-          (Array.aset b idx (SetBucket.shrink n k)))))))
-
   (doc remove "Remove the key k from the set s.")
   (defn remove [s k]
-    (let [idx (Int.mod (hash k) @(n-buckets s))]
-      (update-buckets @s (fn [b]
+    (let [idx (Int.mod (hash k) @(n-buckets &s))]
+      (update-buckets s (fn [b]
         (let [n (Array.nth &b idx)]
           (Array.aset b idx (SetBucket.shrink n k)))))))
 
@@ -287,7 +259,7 @@
     (let-do [s (create)]
       (for [i 0 (Array.length a)]
         (let [e (Array.nth a i)]
-          (set! s (put! s e))))
+          (set! s (put s e))))
       s))
 
   (defn str [s]

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -270,7 +270,7 @@
 
   (doc mag-sq "Get the squared magnitude of a vector.")
   (defn mag-sq [o]
-    (Array.reduce (fn [x y] (+ @x @y)) 0.0
+    (Array.reduce (fn [x y] (+ x @y)) 0.0
                   &(Array.copy-map (fn [x] (* @x @x)) (VN.v o))))
 
   (doc mag "Get the magnitude of a vector.")
@@ -291,7 +291,7 @@
 
   (doc dot "Get the dot product of the two vectors x and y.")
   (defn dot [x y]
-    (Array.reduce (fn [x y] (+ @x @y)) 0.0 (VN.v &(zip * x y))))
+    (Array.reduce (fn [x y] (+ x @y)) 0.0 (VN.v &(zip * x y))))
 
   (doc angle-between "Get the angle between to vectors a and b.")
   (defn angle-between [a b]

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -756,7 +756,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [&amp;a, &amp;b] a), a, (Ref (Array b))] a)
+                    (λ [(λ [a, &amp;b] a), a, (Ref (Array b))] a)
                 </p>
                 <pre class="args">
                     (reduce f x xs)

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -446,33 +446,13 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b)), &amp;a, &amp;b] (Map a b))
+                    (λ [(Map a b), &amp;a, &amp;b] (Map a b))
                 </p>
                 <pre class="args">
                     (put m k v)
                 </pre>
                 <p class="doc">
                     <p>Put a a value v into map m, using the key k.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#put!">
-                    <h3 id="put!">
-                        put!
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Map a b), &amp;a, &amp;b] (Map a b))
-                </p>
-                <pre class="args">
-                    (put! m k v)
-                </pre>
-                <p class="doc">
-                    <p>Put a a value v into map m, using the key k. Takes ownership.</p>
 
                 </p>
             </div>
@@ -486,33 +466,13 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b)), &amp;a] (Map a b))
+                    (λ [(Map a b), &amp;a] (Map a b))
                 </p>
                 <pre class="args">
                     (remove m k)
                 </pre>
                 <p class="doc">
                     <p>Remove the value under the key k from the map m.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#remove!">
-                    <h3 id="remove!">
-                        remove!
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Map a b), &amp;a] (Map a b))
-                </p>
-                <pre class="args">
-                    (remove! m k)
-                </pre>
-                <p class="doc">
-                    <p>Remove the value under the key k from the map m. Takes ownership.</p>
 
                 </p>
             </div>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -457,6 +457,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#put!">
+                    <h3 id="put!">
+                        put!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Map a b), &amp;a, &amp;b] (Map a b))
+                </p>
+                <pre class="args">
+                    (put! m k v)
+                </pre>
+                <p class="doc">
+                    <p>Put a a value v into map m, using the key k. Takes ownership.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#remove">
                     <h3 id="remove">
                         remove
@@ -466,13 +486,33 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), &amp;a] (Map a b))
+                    (λ [(Ref (Map a b)), &amp;a] (Map a b))
                 </p>
                 <pre class="args">
                     (remove m k)
                 </pre>
                 <p class="doc">
                     <p>Remove the value under the key k from the map m.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#remove!">
+                    <h3 id="remove!">
+                        remove!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Map a b), &amp;a] (Map a b))
+                </p>
+                <pre class="args">
+                    (remove! m k)
+                </pre>
+                <p class="doc">
+                    <p>Remove the value under the key k from the map m. Takes ownership.</p>
 
                 </p>
             </div>

--- a/examples/basics.carp
+++ b/examples/basics.carp
@@ -112,15 +112,15 @@
 (defn even? [x]
   (= (Int.mod @x 2) 0))
 
-(defn add-with-refs [x y]
-  (Int.+ @x @y))
+(defn add-with-ref [x y]
+  (Int.+ x @y))
 
 (defn square-reffed [x]
   (Int.* @x @x))
 
 (defn map-filter-reduce-stuff []
   (let [stuff [3 5 8 9 10]
-        after (reduce add-with-refs 0 &(copy-map square-reffed &(filter even? stuff)))]
+        after (reduce add-with-ref 0 &(copy-map square-reffed &(filter even? stuff)))]
     (do
       (print "ANSWER: ")
       (println (refstr after)))))

--- a/examples/bugs.carp
+++ b/examples/bugs.carp
@@ -62,7 +62,7 @@
 ;; Closures do not generate type definitions, issue #299
 ;; (defmodule Example
 ;;   (defn parallel [resistances]
-;;     (Array.reduce (fn [x y] (+ @x (/ 1.0 @y))) 0.0 resistances))
+;;     (Array.reduce (fn [x y] (+ x (/ 1.0 @y))) 0.0 resistances))
 ;;   )
 
 (deftype Hi [])

--- a/examples/map.carp
+++ b/examples/map.carp
@@ -6,7 +6,7 @@
                @"Charlie" 23
                @"Dave" 56
                @"Emily" 42}
-        ages2 (Map.put &ages1 "Dave" &57)]
+        ages2 (Map.put ages1 "Dave" &57)]
     (do
       (println* "Charlie is " (Map.get &ages2 "Charlie") " years old.")
       (println* "Dave is " (Map.get &ages2 "Dave") " years old.")
@@ -14,7 +14,7 @@
 
 (defn start-with-empty []
   (let [a {}
-        b (Map.put &a "aha" &123)]
+        b (Map.put a "aha" &123)]
     (println* (Map.get &b "aha"))))
 
 (defn checking []

--- a/test/map.carp
+++ b/test/map.carp
@@ -42,8 +42,13 @@
     )
     (assert-equal test
                   true
-                  (Map.empty? &(Map.remove (Map.put &(Map.create) "1" "2") "1"))
+                  (Map.empty? &(Map.remove &(Map.put! (Map.create) "1" "2") "1"))
                   "remove works"
+    )
+    (assert-equal test
+                  true
+                  (Map.empty? &(Map.remove! (Map.put! (Map.create) "1" "2") "1"))
+                  "remove! works"
     )
     (assert-equal test
                   2
@@ -93,8 +98,13 @@
     )
     (assert-equal test
                   true
-                  (Set.empty? &(Set.remove (Set.put &(Set.create) "1") "1"))
+                  (Set.empty? &(Set.remove &(Set.put! (Set.create) "1") "1"))
                   "remove works"
+    )
+    (assert-equal test
+                  true
+                  (Set.empty? &(Set.remove! (Set.put! (Set.create) "1") "1"))
+                  "remove! works"
     )
     (assert-equal test
                   "{ @\"hi\" @\"bye\" }"

--- a/test/map.carp
+++ b/test/map.carp
@@ -7,12 +7,12 @@
   (with-test test
     (assert-equal test
                   "2"
-                  &(Map.get &(Map.put &(Map.create) "1" "2") "1")
+                  &(Map.get &(Map.put (Map.create) "1" "2") "1")
                   "basic put and get works"
     )
     (assert-equal test
                   1
-                  (Map.length &(Map.put &(Map.create) "1" "2"))
+                  (Map.length &(Map.put (Map.create) "1" "2"))
                   "length works"
     )
     (assert-equal test
@@ -27,7 +27,7 @@
     )
     (assert-equal test
                   true
-                  (Map.contains? &(Map.put &(Map.create) "1" "2") "1")
+                  (Map.contains? &(Map.put (Map.create) "1" "2") "1")
                   "contains? works"
     )
     (assert-equal test
@@ -37,18 +37,13 @@
     )
     (assert-equal test
                   false
-                  (Map.empty? &(Map.put &(Map.create) "1" "2"))
+                  (Map.empty? &(Map.put (Map.create) "1" "2"))
                   "empty? works"
     )
     (assert-equal test
                   true
-                  (Map.empty? &(Map.remove &(Map.put! (Map.create) "1" "2") "1"))
+                  (Map.empty? &(Map.remove (Map.put (Map.create) "1" "2") "1"))
                   "remove works"
-    )
-    (assert-equal test
-                  true
-                  (Map.empty? &(Map.remove! (Map.put! (Map.create) "1" "2") "1"))
-                  "remove! works"
     )
     (assert-equal test
                   2
@@ -68,7 +63,7 @@
     )
     (assert-equal test
                   1
-                  (Set.length &(Set.put &(Set.create) "1"))
+                  (Set.length &(Set.put (Set.create) "1"))
                   "length works"
     )
     (assert-equal test
@@ -83,7 +78,7 @@
     )
     (assert-equal test
                   true
-                  (Set.contains? &(Set.put &(Set.create) "1") "1")
+                  (Set.contains? &(Set.put (Set.create) "1") "1")
                   "contains? works"
     )
     (assert-equal test
@@ -93,18 +88,13 @@
     )
     (assert-equal test
                   false
-                  (Set.empty? &(Set.put &(Set.create) "1"))
+                  (Set.empty? &(Set.put (Set.create) "1"))
                   "empty? works"
     )
     (assert-equal test
                   true
-                  (Set.empty? &(Set.remove &(Set.put! (Set.create) "1") "1"))
+                  (Set.empty? &(Set.remove (Set.put (Set.create) "1") "1"))
                   "remove works"
-    )
-    (assert-equal test
-                  true
-                  (Set.empty? &(Set.remove! (Set.put! (Set.create) "1") "1"))
-                  "remove! works"
     )
     (assert-equal test
                   "{ @\"hi\" @\"bye\" }"

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -192,7 +192,7 @@
         (assert (= &[@"q" @"b" @"c"] &xs)))))
 
 (defn append-ref [a b]
-  (StringCopy.append @a @b))
+  (StringCopy.append a @b))
 
 (defn array-reduce []
   (let [xs [@"a" @"b" @"c"]


### PR DESCRIPTION
This PR adds `Map.put!`, `Map.remove!`, `Set.put!`, and `Set.remove!`. They avoid copying the map/set, but also take ownership over the data.

It also changes the type signature of `Array.reduce` to take ownership of the accumulator to reduce the need for copying there as well.

Test are included, examples are fixed.

Cheers