### PR TITLE
Add Pattern.find-all

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -3,6 +3,8 @@
 (defmodule Pattern
   (doc find "Finds the index of a pattern in a string. Returns -1 otherwise.")
   (register find (Fn [&Pattern &String] Int))
+  (doc find-all "Finds all indices of a pattern in a string. Returns [] otherwise.")
+  (register find-all (Fn [&Pattern &String] (Array Int)))
   (doc match "Finds the match groups of the first match of a pattern in a string. Returns [] otherwise.")
   (register match (Fn [&Pattern &String] (Array String)))
   (doc match-str "Finds the first match of a pattern in a string. Returns [] otherwise.")
@@ -77,17 +79,20 @@
     (Pattern.substitute #"\s+" s " " -1))
 
   (doc split-by "Split a string by separators.")
-  (defn split-by [_s separators]
-    (let-do [s @_s
-             result (the (Array String) [])
-             pat (Pattern.from-chars separators)
-             idx (Pattern.find &pat &s)]
-      (while (Int./= idx -1)
-        (do
-          (set! result (Array.push-back result (prefix-string &s idx)))
-          (set! s (suffix-string &s (+ idx 1)))
-          (set! idx (Pattern.find &pat &s))))
-      (Array.push-back result s)))
+  (defn split-by [s separators]
+    (let-do [pat (Pattern.from-chars separators)
+             idx (Pattern.find-all &pat s)
+             lidx (Array.length &idx)
+             result (Array.allocate (Int.inc lidx))]
+      (Array.aset-uninitialized! &result 0
+        (substring s 0 (if (> lidx 0) @(Array.nth &idx 0) (length s))))
+      (for [i 0 (Int.dec (Array.length &idx))]
+        (Array.aset-uninitialized! &result (Int.inc i)
+          (substring s (Int.inc @(Array.nth &idx i)) @(Array.nth &idx (Int.inc i)))))
+      (when (> lidx 0)
+        (Array.aset-uninitialized! &result lidx
+          (suffix-string s (Int.inc @(Array.nth &idx (Int.dec lidx))))))
+      result))
 
   (doc words "Split a string into words.")
   (defn words [s]

--- a/core/String.carp
+++ b/core/String.carp
@@ -69,11 +69,11 @@
 
   (doc prefix-string "Return the first `a` characters of the string `s`.")
   (defn prefix-string [s a]
-    (from-chars &(Array.prefix-array &(chars s) a)))
+    (from-chars &(Array.subarray &(chars s) 0 a)))
 
   (doc suffix-string "Return the last `b` characters of the string `s`.")
   (defn suffix-string [s b]
-    (from-chars &(Array.suffix-array &(chars s) b)))
+    (from-chars &(Array.subarray &(chars s) b (length s))))
 
   (doc starts-with? "Check if the string `s` begins with the string `sub`.")
   (defn starts-with? [s sub]

--- a/test/pattern.carp
+++ b/test/pattern.carp
@@ -33,6 +33,14 @@
                   (find #"\d" "   ")
                   "find works as expected if not found")
     (assert-equal test
+                  &[3 6]
+                  &(find-all #"\d\d" "   12 67")
+                  "find-all works as expected")
+    (assert-equal test
+                  &[]
+                  &(find-all #"\d\d" "   ")
+                  "find-all works as expected if not found")
+    (assert-equal test
                   &[@"12"]
                   &(match #"(\d+)" "   12")
                   "match works as expected")


### PR DESCRIPTION
This PR adds `Pattern.find-all`, which behaves similarly to `Pattern.find`, but instead of only finding the index of the first occurrence, it will return an array of all occurrences within the provided source string. It also updates to `String.lines` to use this algorithm, which speeds up `String.split-by` by almost an order of magnitude because it reduces the number of Array allocations to one.

Of note is that this introduces the function `Pattern_internal_update_int_array`, which is extremely similar to what `Array_push_back__int` would generate (but with C in-place updates).

Test cases are included!

Cheers