### PR TITLE
Error if load gets handed the wrong type

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -1056,6 +1056,8 @@ commandLoad [xobj@(XObj (Str path) _ _)] =
                   Left _ ->  commandLoad [XObj (Str mainToLoad) Nothing Nothing]
             ExitFailure _ -> do
                 return $ invalidPathWith ctx path stderr1
+commandLoad [x] =
+  return $ Left (EvalError ("Invalid args to 'load' command: " ++ pretty x))
 
 
 -- | Load several files in order.
@@ -1095,8 +1097,6 @@ commandExpand [xobj] =
        Right expanded ->
          liftIO $ do putStrLnWithColor Yellow (pretty expanded)
                      return dynamicNil
-commandExpand args =
-  return (Left (EvalError ("Invalid args to 'expand' command: " ++ joinWithComma (map pretty args))))
 
 -- | This function will show the resulting C code from an expression.
 -- | i.e. (Int.+ 2 3) => "_0 = 2 + 3"
@@ -1115,8 +1115,6 @@ commandC [xobj] =
              do liftIO (printC annXObj)
                 liftIO (mapM printC annDeps)
                 return dynamicNil
-commandC args =
-  return (Left (EvalError ("Invalid args to 'c': " ++ joinWithComma (map pretty args))))
 
 -- | Helper function for commandC
 printC :: XObj -> IO ()


### PR DESCRIPTION
This PR introduces an error case to `load` that gives a good error message if it is handed the wrong type. The compiler used to die before that.

I also took the liberty to remove a bunch of dead branches that checked the arity of commands (they are dead, because the arity is already checked before by the closure generated by `addCommand`).

Cheers