### PR TITLE
Fixed SDL import capitalization in Life example

### DIFF
--- a/examples/life.carp
+++ b/examples/life.carp
@@ -4,8 +4,8 @@
 (use Double)
 (use Array)
 
-(load "core/sdl.carp")
-(load "core/sdl_image.carp")
+(load "core/SDL.carp")
+(load "core/SDL_image.carp")
 (use SDL)
 (use SDLApp)
 (use SDL.Event)


### PR DESCRIPTION
Found a typo in the game of life example causing it to not compile under Linux (due to case sensitivity). 