### PR TITLE
Remove stdbool dependency

### DIFF
--- a/core/carp_bool.h
+++ b/core/carp_bool.h
@@ -1,4 +1,4 @@
-#include <stdbool.h>
+#include "carp_stdbool.h"
 
 // Bool
 bool Bool_copy(bool* b) {

--- a/core/carp_char.h
+++ b/core/carp_char.h
@@ -1,4 +1,4 @@
-#include <stdbool.h>
+#include "carp_stdbool.h"
 
 bool Char__EQ_(char a, char b) {
   return a == b;

--- a/core/carp_double.h
+++ b/core/carp_double.h
@@ -1,6 +1,6 @@
 #include <limits.h>
 #include <math.h>
-#include <stdbool.h>
+#include "carp_stdbool.h"
 
 double Double__PLUS_(double x, double y) { return x + y; }
 double Double__MINUS_(double x, double y) { return x - y; }

--- a/core/carp_float.h
+++ b/core/carp_float.h
@@ -1,6 +1,6 @@
 #include <limits.h>
 #include <math.h>
-#include <stdbool.h>
+#include "carp_stdbool.h"
 
 float Float__PLUS_(float x, float y) { return x + y; }
 float Float__MINUS_(float x, float y) { return x - y; }

--- a/core/carp_int.h
+++ b/core/carp_int.h
@@ -1,5 +1,5 @@
 #include <math.h>
-#include <stdbool.h>
+#include "carp_stdbool.h"
 
 int Int__PLUS_(int x, int y)   { return x + y; }
 int Int__MINUS_(int x, int y)  { return x - y; }

--- a/core/carp_long.h
+++ b/core/carp_long.h
@@ -1,5 +1,5 @@
 #include <math.h>
-#include <stdbool.h>
+#include "carp_stdbool.h"
 
 long Long__PLUS_(long x, long y)   { return x + y; }
 long Long__MINUS_(long x, long y)  { return x - y; }

--- a/core/carp_memory.h
+++ b/core/carp_memory.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <stdbool.h>
+#include "carp_stdbool.h"
 #include <stdlib.h>
 
 #ifdef LOG_MEMORY

--- a/core/carp_safe_int.h
+++ b/core/carp_safe_int.h
@@ -1,5 +1,5 @@
 #include <math.h>
-#include <stdbool.h>
+#include "carp_stdbool.h"
 
 bool Int_safe_MINUS_add(int x, int y, int* res) { return __builtin_sadd_overflow(x, y, res); }
 bool Int_safe_MINUS_sub(int x, int y, int* res) { return __builtin_ssub_overflow(x, y, res); }

--- a/core/carp_stdbool.h
+++ b/core/carp_stdbool.h
@@ -1,0 +1,6 @@
+// we inline stdbool to not rely on c99 too much
+
+#define bool _Bool
+#define true 1
+#define false 0
+#define __bool_true_false_are_defined 1

--- a/core/core.h
+++ b/core/core.h
@@ -2,7 +2,7 @@
 #define PRELUDE_H
 
 #include <assert.h>
-#include <stdbool.h>
+#include "carp_stdbool.h"
 #include <stddef.h>
 #include <sys/wait.h>
 #include <signal.h>


### PR DESCRIPTION
This PR adds our own version of `stdbool.h` to remove the C99 dependency. This should solve #332.

Cheers