### PR TITLE
Map.to-array and Set.to-array functions, equality for non-ref Pairs

### DIFF
--- a/core/Map.carp
+++ b/core/Map.carp
@@ -225,6 +225,12 @@
           (set! m (put m k v))))
       m))
 
+  (doc to-array "Convert Map to Array of Pairs")
+  (defn to-array [m]
+    (kv-reduce (fn [arr k v] (Array.push-back arr (Pair.init-from-refs k v)))
+               []
+               m))
+
   (defn str [m]
     (let [res (kv-reduce (fn [s k v]
                            (String.join @"" &[s @" " (prn @k) @" " (prn @v)]))
@@ -342,6 +348,10 @@
             (let [e (Array.nth entries j)]
               (set! init (f init e))))))
       init))
+
+  (doc to-array "Convert Set to Array of elements")
+  (defn to-array [s]
+    (reduce (fn [arr elt] (Array.push-back arr @elt)) [] s))
 
   (defn str [set]
     (let [res (reduce (fn [s e] (String.join @"" &[s @" " (prn e)]))

--- a/core/Tuples.carp
+++ b/core/Tuples.carp
@@ -5,7 +5,18 @@
     (Pair.init @r1 @r2))
 
   (defn = [p1 p2]
+    (and (= (Pair.a &p1) (Pair.a &p2))
+         (= (Pair.b &p1) (Pair.b &p2))))
+
+  (defn /= [p1 p2]
+    (not (Pair.= p1 p2)))
+
+  )
+
+(defmodule PairRef
+  (defn = [p1 p2]
     (and (= (Pair.a p1) (Pair.a p2))
          (= (Pair.b p1) (Pair.b p2))))
 
-  )
+  (defn /= [p1 p2]
+    (not (PairRef.= p1 p2))))

--- a/test/map.carp
+++ b/test/map.carp
@@ -101,6 +101,17 @@
                 "stringification works II"
   )
   (assert-equal test
+                &[(Pair.init 1 2)]
+                &(Map.to-array &(Map.put (Map.create) &1 &2))
+                "Map.to-array works 1"
+  )
+  (assert-equal test
+                2
+                (Array.length &(Map.to-array &(Map.from-array &[(Pair.init 1 2)
+                                                                (Pair.init 3 4)])))
+                "Map.to-array works 2"
+  )
+  (assert-equal test
                 "{ 1 12 3 34 }"
                 &(str &(Map.endo-map (fn [k v] (+ @v (* 10 @k)))
                                      {1 2 3 4}))
@@ -122,6 +133,11 @@
                 &[1 1 2]
                 &(Map.vals &{1 1 2 1 3 2})
                 "vals works"
+  )
+  (assert-equal test
+                1
+                (Set.length &(Set.put (Set.create) "1"))
+                "length works"
   )
   (assert-equal test
                 2
@@ -179,4 +195,14 @@
                 "{ @\"hi\" @\"bye\" }"
                 &(str &(Set.from-array &[@"hi" @"bye"]))
                 "stringification works"
+  )
+  (assert-equal test
+                &[1]
+                &(Set.to-array &(Set.put (Set.create) &1))
+                "Set.to-array works 1"
+  )
+  (assert-equal test
+                2
+                (Array.length &(Set.to-array &(Set.from-array &[1 2])))
+                "Set.to-array works 2"
   ))


### PR DESCRIPTION
Some additions I think would fit the standard library.

Had to add the Pair equality to be able to write the tests for to-array :)