### PR TITLE
lua license: fix referenced file

### DIFF
--- a/LUA_LICENSE
+++ b/LUA_LICENSE
@@ -1,4 +1,4 @@
-The pattern matching code in src/carp_regex.h comes from Lua and is licensed
+The pattern matching code in core/carp_pattern.h comes from Lua and is licensed
 under the terms of the MIT license below.
 
 Copyright © 1994–2017 Lua.org, PUC-Rio.


### PR DESCRIPTION
This PR fixes #370 by changing the referred file from `src/carp_regex.h` to `core/carp_pattern.h`. The file was renamed early on, and the directory path was just wrong!

Cheers