### PR TITLE
core: refactor the vector module; generic types and use module system

### DIFF
--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -1,62 +1,44 @@
+(deftype (Vector2 a) [x a, y a])
+
 (defmodule Vector2
-  (deftype V2 [x Double, y Double])
-
-  (defn init [x y]
-    (V2.init x y))
-
-  (defn get-x [o]
-    @(V2.x o))
-
-  (defn get-y [o]
-    @(V2.y o))
-
-  (defn set-x [o v]
-    (V2.set-x o v))
-
-  (defn set-y [o v]
-    (V2.set-y o v))
-
-  (defn to-string [o]
-    (str* @"Vector2(" (str @(V2.x o)) @", " (str @(V2.y o)) @")"))
-
   (defn zero []
-    (V2.init 0.0 0.0))
+    (init 0.0 0.0))
 
   (defn random []
-    (V2.init (random-between 0.0 1.0) (random-between 0.0 1.0)))
+    (init (random-between 0.0 1.0) (random-between 0.0 1.0)))
 
   (defn add [a b]
-    (V2.init (+ @(V2.x a) @(V2.x b))
-             (+ @(V2.y a) @(V2.y b))))
+    (init (+ @(x a) @(x b))
+          (+ @(y a) @(y b))))
 
   (defn sub [a b]
-    (V2.init (- @(V2.x a) @(V2.x b))
-             (- @(V2.y a) @(V2.y b))))
+    (init (- @(x a) @(x b))
+          (- @(y a) @(y b))))
 
   (defn mul [a n]
-    (V2.init (* @(V2.x a) n)
-             (* @(V2.y a) n)))
+    (init (* @(x a) n)
+          (* @(y a) n)))
 
   (defn div [a n]
-    (V2.init (/ @(V2.x a) n)
-             (/ @(V2.y a) n)))
+    (init (/ @(x a) n)
+          (/ @(y a) n)))
 
   (defn = [a b]
-    (and (Double.= @(V2.x a) @(V2.x b))
-         (Double.= @(V2.y a) @(V2.y b))))
+    (and (Double.= @(x a) @(x b))
+         (Double.= @(y a) @(y b))))
 
   (defn /= [a b]
     (not (= a b)))
 
   (doc approx "Check whether the vectors a and b are approximately equal.")
   (defn approx [a b]
-    (and (Double.approx @(V2.x a) @(V2.x b))
-         (Double.approx @(V2.y a) @(V2.y b))))
+    (and (Double.approx @(x a) @(x b))
+         (Double.approx @(y a) @(y b))))
 
   (doc mag-sq "Get the squared magnitude of a vector.")
   (defn mag-sq [o]
-    (let [x @(V2.x o)
-          y @(V2.y o)]
+    (let [x @(x o)
+          y @(y o)]
       (+ (* x x) (* y y))))
 
   (doc mag "Get the magnitude of a vector.")
@@ -67,7 +49,7 @@
   (defn normalize [o]
     (let [m (mag o)]
       (if (= m 0.0)
-        (V2.copy o)
+        @o
         (div o m))))
 
   (doc dist "Get the distance between the vectors a and b.")
@@ -77,18 +59,18 @@
 
   (doc heading "Get the heading of the vector a.")
   (defn heading [a]
-    (Double.atan2 @(V2.y a) @(V2.x a)))
+    (Double.atan2 @(y a) @(x a)))
 
   (doc rotate "Rotate the vector a by the radians n.")
   (defn rotate [a n]
     (let [h (+ (heading a) n)
           m (mag a)]
-      (V2.init (* (Double.cos h) m) (* (Double.sin h) m))))
+      (init (* (Double.cos h) m) (* (Double.sin h) m))))
 
   (doc dot "Get the dot product of the two vectors x and y.")
-  (defn dot [x y]
-    (+ (* @(V2.x x) @(V2.x y))
-       (* @(V2.y x) @(V2.y y))))
+  (defn dot [a b]
+    (+ (* @(x a) @(x b))
+       (* @(y a) @(y b))))
 
   (doc angle-between "Get the angle between to vectors a and b.")
   (defn angle-between [a b]
@@ -109,59 +91,52 @@
 
   (doc lerp "Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).")
   (defn lerp [a b amnt]
-    (init (* (- @(V2.x b) @(V2.x a)) amnt)
-          (* (- @(V2.y b) @(V2.y a)) amnt)))
+    (init (* (- @(x b) @(x a)) amnt)
+          (* (- @(y b) @(y a)) amnt)))
 )
 
+(deftype (Vector3 a) [x a, y a, z a])
+
 (defmodule Vector3
-  (deftype V3 [x Double, y Double, z Double])
-
-  (defn init [x y z]
-    (V3.init x y z))
-
-  (defn to-string [o]
-    (str* @"Vector3(" (str @(V3.x o)) @", " (str @(V3.y o))
-          @", " (str @(V3.z o)) @")"))
-
   (defn zero []
-    (V3.init 0.0 0.0 0.0))
+    (init 0.0 0.0 0.0))
 
   (defn random []
-    (V3.init (random-between 0.0 1.0) (random-between 0.0 1.0) (random-between 0.0 1.0)))
+    (init (random-between 0.0 1.0) (random-between 0.0 1.0) (random-between 0.0 1.0)))
 
   (defn = [a b]
-    (and (Double.= @(V3.x a) @(V3.x b))
-         (and (Double.= @(V3.y a) @(V3.y b))
-              (Double.= @(V3.z a) @(V3.z b)))))
+    (and (Double.= @(x a) @(x b))
+         (and (Double.= @(y a) @(y b))
+              (Double.= @(z a) @(z b)))))
 
   (defn /= [a b]
     (not (= a b)))
 
   (defn add [a b]
-    (V3.init (+ @(V3.x a) @(V3.x b))
-             (+ @(V3.y a) @(V3.y b))
-             (+ @(V3.z a) @(V3.z b))))
+    (init (+ @(x a) @(x b))
+          (+ @(y a) @(y b))
+          (+ @(z a) @(z b))))
 
   (defn sub [a b]
-    (V3.init (- @(V3.x a) @(V3.x b))
-             (- @(V3.y a) @(V3.y b))
-             (- @(V3.z a) @(V3.z b))))
+    (init (- @(x a) @(x b))
+          (- @(y a) @(y b))
+          (- @(z a) @(z b))))
 
   (defn mul [a n]
-    (V3.init (* @(V3.x a) n)
-             (* @(V3.y a) n)
-             (* @(V3.z a) n)))
+    (init (* @(x a) n)
+          (* @(y a) n)
+          (* @(z a) n)))
 
   (defn div [a n]
-    (V3.init (/ @(V3.x a) n)
-             (/ @(V3.y a) n)
-             (/ @(V3.z a) n)))
+    (init (/ @(x a) n)
+          (/ @(y a) n)
+          (/ @(z a) n)))
 
   (doc mag-sq "Get the squared magnitude of a vector.")
   (defn mag-sq [o]
-    (let [x @(V3.x o)
-          y @(V3.y o)
-          z @(V3.z o)]
+    (let [x @(x o)
+          y @(y o)
+          z @(z o)]
       (+ (* x x) (+ (* y y) (* z z)))))
 
   (doc mag "Get the magnitude of a vector.")
@@ -172,24 +147,24 @@
   (defn normalize [o]
     (let [m (mag o)]
       (if (= m 0.0)
-        (V3.copy o)
+        @o
         (div o m))))
 
   (doc cross "Compute the cross product of the two vectors x and y.")
-  (defn cross [x y]
-    (V3.init
-      (- (* @(V3.y x) @(V3.z y))
-         (* @(V3.z x) @(V3.y y)))
-      (- (* @(V3.z x) @(V3.x y))
-         (* @(V3.x x) @(V3.z y)))
-      (- (* @(V3.x x) @(V3.y y))
-         (* @(V3.y x) @(V3.x y)))))
+  (defn cross [a b]
+    (init
+      (- (* @(y a) @(z b))
+         (* @(z a) @(y b)))
+      (- (* @(z a) @(x b))
+         (* @(x a) @(z b)))
+      (- (* @(x a) @(y b))
+         (* @(y a) @(x b)))))
 
   (doc dot "Get the dot product of the two vectors x and y.")
-  (defn dot [x y]
-    (+ (* @(V3.x x) @(V3.x y))
-       (+ (* @(V3.y x) @(V3.y y))
-          (* @(V3.z x) @(V3.z y)))))
+  (defn dot [a b]
+    (+ (* @(x a) @(x b))
+       (+ (* @(y a) @(y b))
+          (* @(z a) @(z b)))))
 
   (doc angle-between "Get the angle between to vectors a and b.")
   (defn angle-between [a b]
@@ -210,48 +185,44 @@
 
   (doc lerp "Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).")
   (defn lerp [a b amnt]
-    (init (* (- @(V3.x b) @(V3.x a)) amnt)
-          (* (- @(V3.y b) @(V3.y a)) amnt)
-          (* (- @(V3.z b) @(V3.z a)) amnt)))
+    (init (* (- @(x b) @(x a)) amnt)
+          (* (- @(y b) @(y a)) amnt)
+          (* (- @(z b) @(z a)) amnt)))
 )
 
+(deftype (VectorN a) [n Int, v (Array a)])
+
 (defmodule VectorN
-  (deftype VN [n Int, v (Array Double)])
-
-  (defn init [n v]
-    (VN.init n v))
-
   (defn zero-sized [n]
     (let [z 0.0]
-      (VN.init n (Array.replicate n &z))))
+      (init n (Array.replicate n &z))))
 
+  (private unit-random)
+  (hidden unit-random)
   (defn unit-random []
     (random-between 0.0 1.0))
 
   (defn random-sized [n]
-    (VN.init n (Array.repeat n &unit-random)))
-
-
-  (defn to-string [o]
-    (str* @"VectorN(dim=" (str @(VN.n o)) @", vals=" (str (VN.v o)) @")"))
+    (init n (Array.repeat n &unit-random)))
 
   (defn zip- [f a b]
-    (let [total []]
+    (let [total (Array.allocate (Array.length a))]
       (do
         (for [i 0 (Array.length a)]
-          (set! total (Array.push-back @&total (f @(Array.nth a i) @(Array.nth b i)))))
-        (VN.init (Array.length a) total))))
+          (Array.aset-uninitialized! &total i (f @(Array.nth a i)
+                                                 @(Array.nth b i))))
+        (init (Array.length a) total))))
 
   (defn zip [f a b]
-    (if (= @(VN.n a) @(VN.n b))
-      (zip- f (VN.v a) (VN.v b))
+    (if (= @(n a) @(n b))
+      (zip- f (v a) (v b))
       (do
         (IO.println "Error: vectors are of wrong dimensionality")
-        (VN.copy a))))
+        @a)))
 
   (defn = [a b]
-    (and (Int.= @(VN.n a) @(VN.n b))
-         (Array.= (VN.v a) (VN.v b))))
+    (and (Int.= @(n a) @(n b))
+         (Array.= (v a) (v b))))
 
   (defn /= [a b]
     (not (= a b)))
@@ -263,15 +234,15 @@
     (zip - a b))
 
   (defn mul [a n]
-    (zip- * (VN.v a) &(Array.replicate @(VN.n a) &n)))
+    (zip- * (v a) &(Array.replicate @(VectorN.n a) &n)))
 
   (defn div [a n]
-    (zip- / (VN.v a) &(Array.replicate @(VN.n a) &n)))
+    (zip- / (v a) &(Array.replicate @(VectorN.n a) &n)))
 
   (doc mag-sq "Get the squared magnitude of a vector.")
   (defn mag-sq [o]
     (Array.reduce &(fn [x y] (+ x @y)) 0.0
-                  &(Array.copy-map &(fn [x] (* @x @x)) (VN.v o))))
+                  &(Array.copy-map &(fn [x] (* @x @x)) (v o))))
 
   (doc mag "Get the magnitude of a vector.")
   (defn mag [o]
@@ -286,12 +257,12 @@
   (defn normalize [o]
     (let [m (mag o)]
       (if (= m 0.0)
-        (VN.copy o)
+        @o
         (div o m))))
 
   (doc dot "Get the dot product of the two vectors x and y.")
   (defn dot [x y]
-    (Array.reduce &(fn [x y] (+ x @y)) 0.0 (VN.v &(zip * x y))))
+    (Array.reduce &(fn [x y] (+ x @y)) 0.0 (v &(zip * x y))))
 
   (doc angle-between "Get the angle between to vectors a and b.")
   (defn angle-between [a b]
@@ -312,6 +283,6 @@
 
   (doc lerp "Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).")
   (defn lerp [a b amnt]
-    (init @(VN.n a) @(VN.v &(zip- * &(Array.replicate @(VN.n a) &amnt)
-                                   (VN.v &(zip - b a))))))
+    (init @(n a) @(v &(zip- * &(Array.replicate @(n a) &amnt)
+                              (v &(zip - b a))))))
 )

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>
@@ -172,30 +157,11 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Bool)
+                    (λ [(Ref (Vector2 Double)), (Ref (Vector2 Double))] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
                 </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#V2">
-                    <h3 id="V2">
-                        V2
-                    </h3>
-                </a>
-                <div class="description">
-                    module
-                </div>
-                <p class="sig">
-                    Module
-                </p>
-                <span>
-                    
-                </span>
                 <p class="doc">
                     
                 </p>
@@ -210,7 +176,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] V2)
+                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] (Vector2 a))
                 </p>
                 <pre class="args">
                     (add a b)
@@ -229,7 +195,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Double)
+                    (λ [(Ref (Vector2 Double)), (Ref (Vector2 Double))] Double)
                 </p>
                 <pre class="args">
                     (angle-between a b)
@@ -249,7 +215,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Bool)
+                    (λ [(Ref (Vector2 Double)), (Ref (Vector2 Double))] Bool)
                 </p>
                 <pre class="args">
                     (anti-parallel? a b)
@@ -269,7 +235,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Bool)
+                    (λ [(Ref (Vector2 Double)), (Ref (Vector2 Double))] Bool)
                 </p>
                 <pre class="args">
                     (approx a b)
@@ -277,6 +243,44 @@
                 <p class="doc">
                     <p>Check whether the vectors a and b are approximately equal.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector2 a))] (Vector2 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Vector2 a)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -289,7 +293,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Double)
+                    (λ [(Ref (Vector2 Double)), (Ref (Vector2 Double))] Double)
                 </p>
                 <pre class="args">
                     (dist a b)
@@ -309,7 +313,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), Double] V2)
+                    (λ [(Ref (Vector2 a)), a] (Vector2 a))
                 </p>
                 <pre class="args">
                     (div a n)
@@ -328,52 +332,14 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Double)
+                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] a)
                 </p>
                 <pre class="args">
-                    (dot x y)
+                    (dot a b)
                 </pre>
                 <p class="doc">
                     <p>Get the dot product of the two vectors x and y.</p>
 
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#get-x">
-                    <h3 id="get-x">
-                        get-x
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref V2)] Double)
-                </p>
-                <pre class="args">
-                    (get-x o)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#get-y">
-                    <h3 id="get-y">
-                        get-y
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref V2)] Double)
-                </p>
-                <pre class="args">
-                    (get-y o)
-                </pre>
-                <p class="doc">
-                    
                 </p>
             </div>
             <div class="binder">
@@ -386,7 +352,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2)] Double)
+                    (λ [(Ref (Vector2 Double))] Double)
                 </p>
                 <pre class="args">
                     (heading a)
@@ -403,14 +369,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] V2)
+                    (λ [a, a] (Vector2 a))
                 </p>
-                <pre class="args">
-                    (init x y)
-                </pre>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -425,7 +391,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2), Double] V2)
+                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a)), a] (Vector2 a))
                 </p>
                 <pre class="args">
                     (lerp a b amnt)
@@ -445,7 +411,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2)] Double)
+                    (λ [(Ref (Vector2 Double))] Double)
                 </p>
                 <pre class="args">
                     (mag o)
@@ -465,7 +431,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2)] Double)
+                    (λ [(Ref (Vector2 a))] a)
                 </p>
                 <pre class="args">
                     (mag-sq o)
@@ -485,7 +451,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), Double] V2)
+                    (λ [(Ref (Vector2 a)), a] (Vector2 a))
                 </p>
                 <pre class="args">
                     (mul a n)
@@ -504,7 +470,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2)] V2)
+                    (λ [(Ref (Vector2 Double))] (Vector2 Double))
                 </p>
                 <pre class="args">
                     (normalize o)
@@ -524,7 +490,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Bool)
+                    (λ [(Ref (Vector2 Double)), (Ref (Vector2 Double))] Bool)
                 </p>
                 <pre class="args">
                     (parallel? a b)
@@ -544,7 +510,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] Bool)
+                    (λ [(Ref (Vector2 Double)), (Ref (Vector2 Double))] Bool)
                 </p>
                 <pre class="args">
                     (perpendicular? a b)
@@ -552,6 +518,25 @@
                 <p class="doc">
                     <p>Check whether the two vectors a and b are perpendicular.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector2 a))] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -564,7 +549,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] V2)
+                    (λ [] (Vector2 Double))
                 </p>
                 <pre class="args">
                     (random)
@@ -583,7 +568,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), Double] V2)
+                    (λ [(Ref (Vector2 Double)), Double] (Vector2 Double))
                 </p>
                 <pre class="args">
                     (rotate a n)
@@ -600,14 +585,33 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (λ [V2, Double] V2)
+                    (λ [(Vector2 a), a] (Vector2 a))
                 </p>
-                <pre class="args">
-                    (set-x o v)
-                </pre>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x!">
+                    <h3 id="set-x!">
+                        set-x!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector2 a)), a] ())
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -619,14 +623,52 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (λ [V2, Double] V2)
+                    (λ [(Vector2 a), a] (Vector2 a))
                 </p>
-                <pre class="args">
-                    (set-y o v)
-                </pre>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y!">
+                    <h3 id="set-y!">
+                        set-y!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector2 a)), a] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector2 a))] String)
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -641,7 +683,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2), (Ref V2)] V2)
+                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] (Vector2 a))
                 </p>
                 <pre class="args">
                     (sub a b)
@@ -651,20 +693,77 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#to-string">
-                    <h3 id="to-string">
-                        to-string
+                <a class="anchor" href="#update-x">
+                    <h3 id="update-x">
+                        update-x
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref V2)] String)
+                    (λ [(Vector2 a), (Ref (λ [a] a))] (Vector2 a))
                 </p>
-                <pre class="args">
-                    (to-string o)
-                </pre>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-y">
+                    <h3 id="update-y">
+                        update-y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Vector2 a), (Ref (λ [a] a))] (Vector2 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#x">
+                    <h3 id="x">
+                        x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector2 a))] &amp;a)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#y">
+                    <h3 id="y">
+                        y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector2 a))] &amp;a)
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -679,7 +778,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] V2)
+                    (λ [] (Vector2 Double))
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>
@@ -172,30 +157,11 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] Bool)
+                    (λ [(Ref (Vector3 Double)), (Ref (Vector3 Double))] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
                 </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#V3">
-                    <h3 id="V3">
-                        V3
-                    </h3>
-                </a>
-                <div class="description">
-                    module
-                </div>
-                <p class="sig">
-                    Module
-                </p>
-                <span>
-                    
-                </span>
                 <p class="doc">
                     
                 </p>
@@ -210,7 +176,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] V3)
+                    (λ [(Ref (Vector3 a)), (Ref (Vector3 a))] (Vector3 a))
                 </p>
                 <pre class="args">
                     (add a b)
@@ -229,7 +195,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] Double)
+                    (λ [(Ref (Vector3 Double)), (Ref (Vector3 Double))] Double)
                 </p>
                 <pre class="args">
                     (angle-between a b)
@@ -249,7 +215,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] Bool)
+                    (λ [(Ref (Vector3 Double)), (Ref (Vector3 Double))] Bool)
                 </p>
                 <pre class="args">
                     (anti-parallel? a b)
@@ -257,6 +223,25 @@
                 <p class="doc">
                     <p>Check whether the two vectors a and b are anti-parallel.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a))] (Vector3 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -269,14 +254,33 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] V3)
+                    (λ [(Ref (Vector3 a)), (Ref (Vector3 a))] (Vector3 a))
                 </p>
                 <pre class="args">
-                    (cross x y)
+                    (cross a b)
                 </pre>
                 <p class="doc">
                     <p>Compute the cross product of the two vectors x and y.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Vector3 a)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -289,7 +293,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), Double] V3)
+                    (λ [(Ref (Vector3 a)), a] (Vector3 a))
                 </p>
                 <pre class="args">
                     (div a n)
@@ -308,10 +312,10 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] Double)
+                    (λ [(Ref (Vector3 a)), (Ref (Vector3 a))] a)
                 </p>
                 <pre class="args">
-                    (dot x y)
+                    (dot a b)
                 </pre>
                 <p class="doc">
                     <p>Get the dot product of the two vectors x and y.</p>
@@ -325,14 +329,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (λ [Double, Double, Double] V3)
+                    (λ [a, a, a] (Vector3 a))
                 </p>
-                <pre class="args">
-                    (init x y z)
-                </pre>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -347,7 +351,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3), Double] V3)
+                    (λ [(Ref (Vector3 a)), (Ref (Vector3 a)), a] (Vector3 a))
                 </p>
                 <pre class="args">
                     (lerp a b amnt)
@@ -367,7 +371,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3)] Double)
+                    (λ [(Ref (Vector3 Double))] Double)
                 </p>
                 <pre class="args">
                     (mag o)
@@ -387,7 +391,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3)] Double)
+                    (λ [(Ref (Vector3 a))] a)
                 </p>
                 <pre class="args">
                     (mag-sq o)
@@ -407,7 +411,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), Double] V3)
+                    (λ [(Ref (Vector3 a)), a] (Vector3 a))
                 </p>
                 <pre class="args">
                     (mul a n)
@@ -426,7 +430,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3)] V3)
+                    (λ [(Ref (Vector3 Double))] (Vector3 Double))
                 </p>
                 <pre class="args">
                     (normalize o)
@@ -446,7 +450,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] Bool)
+                    (λ [(Ref (Vector3 Double)), (Ref (Vector3 Double))] Bool)
                 </p>
                 <pre class="args">
                     (parallel? a b)
@@ -466,7 +470,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] Bool)
+                    (λ [(Ref (Vector3 Double)), (Ref (Vector3 Double))] Bool)
                 </p>
                 <pre class="args">
                     (perpendicular? a b)
@@ -474,6 +478,25 @@
                 <p class="doc">
                     <p>Check whether the two vectors a and b are perpendicular.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a))] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -486,11 +509,144 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] V3)
+                    (λ [] (Vector3 Double))
                 </p>
                 <pre class="args">
                     (random)
                 </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x">
+                    <h3 id="set-x">
+                        set-x
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Vector3 a), a] (Vector3 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-x!">
+                    <h3 id="set-x!">
+                        set-x!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a)), a] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y">
+                    <h3 id="set-y">
+                        set-y
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Vector3 a), a] (Vector3 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-y!">
+                    <h3 id="set-y!">
+                        set-y!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a)), a] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-z">
+                    <h3 id="set-z">
+                        set-z
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Vector3 a), a] (Vector3 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-z!">
+                    <h3 id="set-z!">
+                        set-z!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a)), a] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a))] String)
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -505,7 +661,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3), (Ref V3)] V3)
+                    (λ [(Ref (Vector3 a)), (Ref (Vector3 a))] (Vector3 a))
                 </p>
                 <pre class="args">
                     (sub a b)
@@ -515,20 +671,115 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#to-string">
-                    <h3 id="to-string">
-                        to-string
+                <a class="anchor" href="#update-x">
+                    <h3 id="update-x">
+                        update-x
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref V3)] String)
+                    (λ [(Vector3 a), (Ref (λ [a] a))] (Vector3 a))
                 </p>
-                <pre class="args">
-                    (to-string o)
-                </pre>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-y">
+                    <h3 id="update-y">
+                        update-y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Vector3 a), (Ref (λ [a] a))] (Vector3 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-z">
+                    <h3 id="update-z">
+                        update-z
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Vector3 a), (Ref (λ [a] a))] (Vector3 a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#x">
+                    <h3 id="x">
+                        x
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a))] &amp;a)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#y">
+                    <h3 id="y">
+                        y
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a))] &amp;a)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#z">
+                    <h3 id="z">
+                        z
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Vector3 a))] &amp;a)
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -543,7 +794,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] V3)
+                    (λ [] (Vector3 Double))
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -53,28 +53,13 @@
                             </a>
                         </li>
                         <li>
-                            <a href="V2.html">
-                                V2
-                            </a>
-                        </li>
-                        <li>
                             <a href="Vector3.html">
                                 Vector3
                             </a>
                         </li>
                         <li>
-                            <a href="V3.html">
-                                V3
-                            </a>
-                        </li>
-                        <li>
                             <a href="VectorN.html">
                                 VectorN
-                            </a>
-                        </li>
-                        <li>
-                            <a href="VN.html">
-                                VN
                             </a>
                         </li>
                         <li>
@@ -172,30 +157,11 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] Bool)
+                    (λ [(Ref (VectorN a)), (Ref (VectorN a))] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
                 </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#VN">
-                    <h3 id="VN">
-                        VN
-                    </h3>
-                </a>
-                <div class="description">
-                    module
-                </div>
-                <p class="sig">
-                    Module
-                </p>
-                <span>
-                    
-                </span>
                 <p class="doc">
                     
                 </p>
@@ -210,7 +176,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] VN)
+                    (λ [(Ref (VectorN a)), (Ref (VectorN a))] (VectorN a))
                 </p>
                 <pre class="args">
                     (add a b)
@@ -229,7 +195,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] Double)
+                    (λ [(Ref (VectorN Double)), (Ref (VectorN Double))] Double)
                 </p>
                 <pre class="args">
                     (angle-between a b)
@@ -249,7 +215,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] Bool)
+                    (λ [(Ref (VectorN Double)), (Ref (VectorN Double))] Bool)
                 </p>
                 <pre class="args">
                     (anti-parallel? a b)
@@ -257,6 +223,44 @@
                 <p class="doc">
                     <p>Check whether the two vectors a and b are anti-parallel.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (VectorN a))] (VectorN a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(VectorN a)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -269,7 +273,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] Double)
+                    (λ [(Ref (VectorN Double)), (Ref (VectorN Double))] Double)
                 </p>
                 <pre class="args">
                     (dist a b)
@@ -289,7 +293,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), Double] VN)
+                    (λ [(Ref (VectorN a)), a] (VectorN a))
                 </p>
                 <pre class="args">
                     (div a n)
@@ -308,7 +312,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] Double)
+                    (λ [(Ref (VectorN Double)), (Ref (VectorN Double))] Double)
                 </p>
                 <pre class="args">
                     (dot x y)
@@ -325,14 +329,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (λ [Int, (Array Double)] VN)
+                    (λ [Int, (Array a)] (VectorN a))
                 </p>
-                <pre class="args">
-                    (init n v)
-                </pre>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -347,7 +351,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN), Double] VN)
+                    (λ [(Ref (VectorN a)), (Ref (VectorN a)), a] (VectorN a))
                 </p>
                 <pre class="args">
                     (lerp a b amnt)
@@ -367,7 +371,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN)] Double)
+                    (λ [(Ref (VectorN Double))] Double)
                 </p>
                 <pre class="args">
                     (mag o)
@@ -387,7 +391,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN)] Double)
+                    (λ [(Ref (VectorN Double))] Double)
                 </p>
                 <pre class="args">
                     (mag-sq o)
@@ -407,11 +411,30 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), Double] VN)
+                    (λ [(Ref (VectorN a)), a] (VectorN a))
                 </p>
                 <pre class="args">
                     (mul a n)
                 </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#n">
+                    <h3 id="n">
+                        n
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (VectorN a))] &amp;Int)
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -426,7 +449,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN)] VN)
+                    (λ [(Ref (VectorN Double))] (VectorN Double))
                 </p>
                 <pre class="args">
                     (normalize o)
@@ -446,7 +469,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] Bool)
+                    (λ [(Ref (VectorN Double)), (Ref (VectorN Double))] Bool)
                 </p>
                 <pre class="args">
                     (parallel? a b)
@@ -466,7 +489,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] Bool)
+                    (λ [(Ref (VectorN Double)), (Ref (VectorN Double))] Bool)
                 </p>
                 <pre class="args">
                     (perpendicular? a b)
@@ -474,6 +497,25 @@
                 <p class="doc">
                     <p>Check whether the two vectors a and b are perpendicular.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (VectorN a))] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -486,11 +528,106 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] VN)
+                    (λ [Int] (VectorN Double))
                 </p>
                 <pre class="args">
                     (random-sized n)
                 </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-n">
+                    <h3 id="set-n">
+                        set-n
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(VectorN a), Int] (VectorN a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-n!">
+                    <h3 id="set-n!">
+                        set-n!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (VectorN a)), Int] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-v">
+                    <h3 id="set-v">
+                        set-v
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(VectorN a), (Array a)] (VectorN a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-v!">
+                    <h3 id="set-v!">
+                        set-v!
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (VectorN a)), (Array a)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (VectorN a))] String)
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -505,7 +642,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN), (Ref VN)] VN)
+                    (λ [(Ref (VectorN a)), (Ref (VectorN a))] (VectorN a))
                 </p>
                 <pre class="args">
                     (sub a b)
@@ -515,39 +652,58 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#to-string">
-                    <h3 id="to-string">
-                        to-string
+                <a class="anchor" href="#update-n">
+                    <h3 id="update-n">
+                        update-n
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref VN)] String)
+                    (λ [(VectorN a), (Ref (λ [Int] Int))] (VectorN a))
                 </p>
-                <pre class="args">
-                    (to-string o)
-                </pre>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#unit-random">
-                    <h3 id="unit-random">
-                        unit-random
+                <a class="anchor" href="#update-v">
+                    <h3 id="update-v">
+                        update-v
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    instantiate
                 </div>
                 <p class="sig">
-                    (λ [] Double)
+                    (λ [(VectorN a), (Ref (λ [(Array a)] (Array a)))] (VectorN a))
                 </p>
-                <pre class="args">
-                    (unit-random)
-                </pre>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#v">
+                    <h3 id="v">
+                        v
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (λ [(Ref (VectorN a))] (Ref (Array a)))
+                </p>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
@@ -562,7 +718,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] VN)
+                    (λ [Int] (VectorN Double))
                 </p>
                 <pre class="args">
                     (zero-sized n)
@@ -581,7 +737,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [Double, Double] Double), (Ref VN), (Ref VN)] VN)
+                    (λ [(λ [a, b] a), (Ref (VectorN a)), (Ref (VectorN b))] (VectorN a))
                 </p>
                 <pre class="args">
                     (zip f a b)
@@ -600,7 +756,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, b] Double), (Ref (Array a)), (Ref (Array b))] VN)
+                    (λ [(λ [a, b] c), (Ref (Array a)), (Ref (Array b))] (VectorN c))
                 </p>
                 <pre class="args">
                     (zip- f a b)

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -49,28 +49,13 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="V2.html">
-                                    V2
-                                </a>
-                            </li>
-                            <li>
                                 <a href="Vector3.html">
                                     Vector3
                                 </a>
                             </li>
                             <li>
-                                <a href="V3.html">
-                                    V3
-                                </a>
-                            </li>
-                            <li>
                                 <a href="VectorN.html">
                                     VectorN
-                                </a>
-                            </li>
-                            <li>
-                                <a href="VN.html">
-                                    VN
                                 </a>
                             </li>
                             <li>

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -15,11 +15,8 @@
            Float
            Double
            Vector2
-           Vector2.V2
            Vector3
-           Vector3.V3
            VectorN
-           VectorN.VN
            Geometry
            Statistics
            String

--- a/examples/reptile.carp
+++ b/examples/reptile.carp
@@ -11,7 +11,7 @@
 (Project.config "title" "Reptile")
 
 (deftype Snake
-    [body (Array V2)
+    [body (Array (Vector2 Double))
      dir SDL_Keycode
      freeze Int
      ])
@@ -20,7 +20,7 @@
 
 (deftype World
     [snake Snake
-     human V2
+     human (Vector2 Double)
      dead Bool])
 
 (use World)
@@ -32,8 +32,8 @@
   (let [body-length (length (body snake))]
     (for [i 0 body-length]
       (let [part (nth (body snake) i)
-            x (* grid-size (to-int @(Vector2.V2.x part)))
-            y (* grid-size (to-int @(Vector2.V2.y part)))]
+            x (* grid-size (to-int @(Vector2.x part)))
+            y (* grid-size (to-int @(Vector2.y part)))]
         (if (= i 0)
           (do
             (SDL.set-render-draw-color rend 200 255 (+ 100 (* body-length 10)) 255)
@@ -45,8 +45,8 @@
 (defn draw-human [rend human]
   (do
     (SDL.set-render-draw-color rend 100 100 250 255)
-    (let [x (* grid-size (to-int @(Vector2.V2.x human)))
-          y (* grid-size (to-int @(Vector2.V2.y human)))]
+    (let [x (* grid-size (to-int @(Vector2.x human)))
+          y (* grid-size (to-int @(Vector2.y human)))]
       (SDL.render-fill-rect rend (address (SDL.rect x y grid-size grid-size))))))
 
 (defn draw [rend world]
@@ -89,7 +89,7 @@
 
 (defn shift-body [body]
   (do
-     (let [i (- (Array.length body) 2)]
+     (let [i (- (length body) 2)]
        (while (> i -1)
          (do
            (aset! body (inc i) @(nth body i))
@@ -130,8 +130,8 @@
   (let [snake (World.snake world)
         b (Snake.body snake)
         head &(first b)
-        x @(Vector2.V2.x head)
-        y @(Vector2.V2.y head)]
+        x @(Vector2.x head)
+        y @(Vector2.y head)]
     (World.set-dead @world (or (< x 0.0)
                            (or (> x 26.0)
                            (or (< y 0.0) (> y 24.0)))))))


### PR DESCRIPTION
This PR refactors the Vector module to pull the types out of the module and rename them to the module they belong in. It also “generifies” the type, so that they’re not bound to the `Double` type. This means we can now also have `Int` vectors and such! Yay!

Cheers