### PR TITLE
Fix string escaping of backslashes (#358)

### DIFF
--- a/test/regression.carp
+++ b/test/regression.carp
@@ -15,4 +15,9 @@
                  (init)
                  "test that the right module gets resolved"
   )
+  (assert-equal test
+                 \\
+                 (String.char-at "\\" 0)
+                 "test that strings get escaped correctly"
+  )
 )


### PR DESCRIPTION
This PR fixes the issue that we encountered in #358 where the parser for escaped quotes was just a little too greedy. This PR special-cases this a bit more, which sadly makes the string parser a little more complex. Do tell me if there is a better way to do this!

I also added a test case!

Cheers