### PR TITLE
Make some properties about the documentation generator configurable

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -27,6 +27,10 @@ defaultProject =
           , projectCarpDir = "./"
           , projectOutDir = "./out/"
           , projectDocsDir = "./docs/"
+          , projectDocsLogo = ""
+          , projectDocsPrelude = ""
+          , projectDocsURL = ""
+          , projectDocsStyling = "carp_style.css"
           , projectPrompt = case platform of
                               MacOS -> "鲮 "
                               _     -> "> "

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -8,7 +8,7 @@
     </head>
     <body>
         <div class="content">
-            <a href="http://github.com/carp-lang/Carp">
+            <a href="https://github.com/carp-lang/carp">
                 <div class="logo">
                     <img src="logo.png" alt="Logo">
                     <div class="index">
@@ -121,9 +121,10 @@
                         </ul>
                     </div>
                 </div>
-                <h1 class="huge">
-                    core
-                </h1>
+                <div>
+                    <p>This website contains the documentation for the Carp standard library. You can download Carp <a href="https://github.com/carp-lang/carp">here</a>.</p>
+
+                </div>
             </a>
         </div>
     </body>

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -122,6 +122,9 @@
                     </div>
                 </div>
                 <div>
+                    <h1>
+                        core
+                    </h1>
                     <p>This website contains the documentation for the Carp standard library. You can download Carp <a href="https://github.com/carp-lang/carp">here</a>.</p>
 
                 </div>

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -1,5 +1,8 @@
 (Project.config "title" "core")
 (Project.config "docs-directory" "./docs/core/")
+(Project.config "docs-logo" "logo.png")
+(Project.config "docs-prelude" "This website contains the documentation for the Carp standard library. You can download Carp [here](https://github.com/carp-lang/carp).")
+(Project.config "docs-url" "https://github.com/carp-lang/carp")
 
 (load "SafeInt.carp")
 (load "Vector.carp")

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -126,6 +126,12 @@ commandProjectConfig [xobj@(XObj (Str key) _ _), value] =
                                               return (proj { projectOutDir = outDir })
                      "docs-directory" -> do docsDir <- unwrapStringXObj value
                                             return (proj { projectDocsDir = docsDir })
+                     "docs-logo" -> do logo <- unwrapStringXObj value
+                                       return (proj { projectDocsLogo = logo })
+                     "docs-prelude" -> do prelude <- unwrapStringXObj value
+                                          return (proj { projectDocsPrelude = prelude })
+                     "docs-url" -> do url <- unwrapStringXObj value
+                                      return (proj { projectDocsURL = url })
                      "file-path-print-length" -> do length <- unwrapStringXObj value
                                                     case length of
                                                       "short" -> return (proj { projectFilePathPrintLength = ShortPath })
@@ -160,6 +166,10 @@ commandProjectGetConfig [xobj@(XObj (Str key) _ _)] =
           "title" -> Right $ Str $ projectTitle proj
           "output-directory" -> Right $ Str $ projectOutDir proj
           "docs-directory" -> Right $ Str $ projectDocsDir proj
+          "docs-logo" -> Right $ Str $ projectDocsLogo proj
+          "docs-prelude" -> Right $ Str $ projectDocsPrelude proj
+          "docs-url" -> Right $ Str $ projectDocsURL proj
+          "docs-styling" -> Right $ Str $ projectDocsStyling proj
           "file-path-print-length" -> Right $ Str $ show (projectFilePathPrintLength proj)
           _ ->
             Left $ EvalError ("[CONFIG ERROR] Project.get-config can't understand the key '" ++
@@ -388,6 +398,10 @@ commandHelp [XObj(Str "project") _ _] =
               putStrLn "'title'              - Set the title of the current project, will affect the name of the binary produced."
               putStrLn "'output-directory'   - Where to put compiler artifacts, etc."
               putStrLn "'docs-directory'     - Where to put generated documentation."
+              putStrLn "'docs-logo'          - Location of the documentation logo."
+              putStrLn "'docs-prelude'       - The documentation foreword."
+              putStrLn "'docs-url'           - A URL for the project (useful for generated documentation)."
+              putStrLn "'docs-styling'        - A URL to CSS for the project documentation."
               putStrLn "'prompt'             - Set the prompt in the repl."
               putStrLn "'search-path'        - Add a path where the Carp compiler will look for '*.carp' files."
               putStrLn ""
@@ -761,8 +775,5 @@ commandSaveDocsInternal [modulePath] =
 saveDocs :: [(SymPath, Env)] -> StateT Context IO (Either EvalError XObj)
 saveDocs pathsAndEnvs =
   do ctx <- get
-     let proj = contextProj ctx
-         docsDir = projectDocsDir proj
-         title = projectTitle proj
-     liftIO (saveDocsForEnvs docsDir title pathsAndEnvs)
+     liftIO (saveDocsForEnvs (contextProj ctx) pathsAndEnvs)
      return dynamicNil

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -483,6 +483,10 @@ data Project = Project { projectTitle :: String
                        , projectCarpDir :: FilePath
                        , projectOutDir :: FilePath
                        , projectDocsDir :: FilePath
+                       , projectDocsLogo :: FilePath
+                       , projectDocsPrelude :: String
+                       , projectDocsURL :: String
+                       , projectDocsStyling :: String
                        , projectPrompt :: String
                        , projectCarpSearchPaths :: [FilePath]
                        , projectPrintTypedAST :: Bool
@@ -509,6 +513,10 @@ instance Show Project where
         carpDir
         outDir
         docsDir
+        docsLogo
+        docsPrelude
+        docsURL
+        docsStyling
         prompt
         searchPaths
         printTypedAST
@@ -530,6 +538,10 @@ instance Show Project where
             , "Can execute: " ++ if canExecute then "true" else "false"
             , "Output directory: " ++ outDir
             , "Docs directory: " ++ docsDir
+            , "Docs logo: " ++ docsLogo
+            , "Docs prelude: " ++ docsPrelude
+            , "Docs Project URL: " ++ docsURL
+            , "Docs CSS URL: " ++ docsStyling
             , "Library directory: " ++ libDir
             , "CARP_DIR: " ++ carpDir
             , "Prompt: " ++ prompt

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -25,7 +25,7 @@ saveDocsForEnvs ctx envs =
       allEnvNames = (fmap (getModuleName . snd) envs)
   in  do mapM_ (saveDocsForEnv ctx allEnvNames) envs
          writeFile (dir ++ "/" ++ title ++ "_index.html") (projectIndexPage ctx allEnvNames)
-         putStrLn ("Generated docs to '" ++ title ++ "'")
+         putStrLn ("Generated docs to '" ++ dirPath ++ "'")
 
 
 projectIndexPage :: Project -> [String] -> String

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -33,6 +33,7 @@ projectIndexPage ctx moduleNames =
   let logo = projectDocsLogo ctx
       url = projectDocsURL ctx
       css = projectDocsStyling ctx
+      htmlHeader = toHtml $ projectTitle ctx
       htmlDoc = commonmarkToHtml [optSafe] $ Text.pack $ projectDocsPrelude ctx
       html = renderHtml $ docTypeHtml $
                           do headOfPage css
@@ -42,7 +43,9 @@ projectIndexPage ctx moduleNames =
                                          do H.div ! A.class_ "logo" $
                                               do H.img ! A.src (H.stringValue logo) ! A.alt "Logo"
                                                  moduleIndex moduleNames
-                                            H.div (preEscapedToHtml htmlDoc)
+                                            H.div $
+                                              do H.h1 htmlHeader
+                                                 (preEscapedToHtml htmlDoc)
   in html
 
 headOfPage :: String -> H.Html

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -25,7 +25,7 @@ saveDocsForEnvs ctx envs =
       allEnvNames = (fmap (getModuleName . snd) envs)
   in  do mapM_ (saveDocsForEnv ctx allEnvNames) envs
          writeFile (dir ++ "/" ++ title ++ "_index.html") (projectIndexPage ctx allEnvNames)
-         putStrLn ("Generated docs to '" ++ dirPath ++ "'")
+         putStrLn ("Generated docs to '" ++ dir ++ "'")
 
 
 projectIndexPage :: Project -> [String] -> String


### PR DESCRIPTION
This PR adds properties to customize a bunch of properties about documentation generation, namely:

- the logo
- the prelude
- the URL
- the styling (CSS) URL

It doesn’t do everything described in #374, most notably it doesn’t allow for customized sections, but it’s a start!

Cheers