### PR TITLE
memory test: test shrinking

### DIFF
--- a/test/memory.carp
+++ b/test/memory.carp
@@ -205,9 +205,9 @@
     (assert (= &[@"b" @"b"] &result))))
 
 (defn array-copy-filter []
-  (let [xs [@"a" @"b" @"c" @"b" @"a" @"c"]
+  (let [xs [@"a" @"b" @"c" @"a" @"c"]
         result (Array.copy-filter &(fn [x] (= x "b")) &xs)]
-    (assert (= &[@"b" @"b"] &result))))
+    (assert (= &[@"b"] &result))))
 
 (defn array-first []
   (let [xs [@"a" @"b" @"c"]


### PR DESCRIPTION
This PR changes one of the filter memory tests so that we test the shrinking. It’s very basic and there a re probably more complex examples that are more likely to contain a memory bug, but this should be useful as a first smoke test.

Cheers