### PR TITLE
Add two special symbols to patterns parser

### DIFF
--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -115,7 +115,7 @@ parseInternalPattern = do maybeAnchor <- Parsec.optionMaybe (Parsec.char '^')
             c <- Parsec.oneOf ['1', '2', '3', '4', '5', '6', '7', '8', '9',
                                'a', 'c', 'd', 'g', 'l', 'p', 's', 'u', 'w',
                                'x', 'n', 't', 'b', 'f', '[', ']', '\\', '$',
-                               '(', ')', '^', '"']
+                               '(', ')', '^', '"', '*', '.']
             case c of
               'b' -> do c1 <- Parsec.noneOf ['"']
                         c2 <- Parsec.noneOf ['"']

--- a/test/pattern.carp
+++ b/test/pattern.carp
@@ -32,6 +32,10 @@
                 (find #"\d" "   ")
                 "find works as expected if not found")
   (assert-equal test
+                0
+                (find #"\.\*" ".*")
+                "find works as expected with special characters")
+  (assert-equal test
                 &[3 6]
                 &(find-all #"\d\d" "   12 67")
                 "find-all works as expected")


### PR DESCRIPTION
The patterns parser currently disallows escaped `.` and `*`. They should be allowed, because otherwise they cannot be used as literals in a pattern!

Cheers