### PR TITLE
core: fix Int.MAX and Int.MIN references

### DIFF
--- a/core/Int.carp
+++ b/core/Int.carp
@@ -1,8 +1,8 @@
 (system-include "carp_int.h")
 
 (defmodule Int
-  (register MAX Int "INT_MAX")
-  (register MIN Int "INT_MIN")
+  (register MAX Int "CARP_INT_MAX")
+  (register MIN Int "CARP_INT_MIN")
   (register + (λ [Int Int] Int))
   (register - (λ [Int Int] Int))
   (register * (λ [Int Int] Int))

--- a/core/carp_int.h
+++ b/core/carp_int.h
@@ -1,5 +1,9 @@
+#include <limits.h>
 #include <math.h>
 #include "carp_stdbool.h"
+
+int CARP_INT_MAX = INT_MAX;
+int CARP_INT_MIN = INT_MIN;
 
 int Int__PLUS_(int x, int y)   { return x + y; }
 int Int__MINUS_(int x, int y)  { return x - y; }

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -11,13 +11,18 @@
 
 (deftest test
   (assert-equal test
-                 1
-                 (init)
-                 "test that the right module gets resolved"
+                1
+                (init)
+                "test that the right module gets resolved"
   )
   (assert-equal test
-                 \\
-                 (String.char-at "\\" 0)
-                 "test that strings get escaped correctly"
+                \\
+                (String.char-at "\\" 0)
+                "test that strings get escaped correctly"
+  )
+  (assert-equal test
+                Int.MAX
+                @&Int.MAX
+                "test that the address of Int.MAX can be taken"
   )
 )


### PR DESCRIPTION
This PR makes `Int.MAX` and `INT.MIN` variables (aka proper rvalues), so we can take their references. This fixes #381!

Cheers