### PR TITLE
Build Carp on Windows

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -58,7 +58,7 @@ library
                      , blaze-html
                      , blaze-markup
                      , text
-                     , unix
+                     , ansi-terminal >= 0.9
                      , cmark
 
   default-language:    Haskell2010

--- a/core/core.h
+++ b/core/core.h
@@ -4,7 +4,11 @@
 #include <assert.h>
 #include "carp_stdbool.h"
 #include <stddef.h>
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#else
 #include <sys/wait.h>
+#endif
 #include <signal.h>
 
 typedef char* String;

--- a/src/ColorText.hs
+++ b/src/ColorText.hs
@@ -1,7 +1,7 @@
 module ColorText where
 
-import System.Posix.Terminal (queryTerminal)
-import System.Posix.IO (stdOutput)
+import System.Console.ANSI hiding (Blue, Red, Yellow, Green, White)
+import System.IO
 
 import Util
 
@@ -9,10 +9,11 @@ data TextColor = Blue | Red | Yellow | Green | White
 
 strWithColor :: TextColor -> String -> String
 strWithColor color str =
-    if useColors
-    then "\x1b[" ++ col ++ "m" ++ str ++ "\x1b[0m"
-    else str
-  where useColors = platform /= Windows
+    --if useColors
+    "\x1b[" ++ col ++ "m" ++ str ++ "\x1b[0m"
+    --then "\x1b[" ++ col ++ "m" ++ str ++ "\x1b[0m"
+    --else str
+  where --useColors = platform /= Windows
         col = case color of
                 Red -> "31"
                 Green -> "32"
@@ -23,7 +24,7 @@ strWithColor color str =
 putStrWithColor :: TextColor -> String -> IO ()
 putStrWithColor color str =
   do
-    istty <- queryTerminal stdOutput
+    istty <- hSupportsANSIColor stdout
     putStr $ if istty then strWithColor color str else str
 
 putStrLnWithColor :: TextColor -> String -> IO ()

--- a/src/ColorText.hs
+++ b/src/ColorText.hs
@@ -9,11 +9,8 @@ data TextColor = Blue | Red | Yellow | Green | White
 
 strWithColor :: TextColor -> String -> String
 strWithColor color str =
-    --if useColors
     "\x1b[" ++ col ++ "m" ++ str ++ "\x1b[0m"
-    --then "\x1b[" ++ col ++ "m" ++ str ++ "\x1b[0m"
-    --else str
-  where --useColors = platform /= Windows
+  where
         col = case color of
                 Red -> "31"
                 Green -> "32"

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,7 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: [intero-0.1.28]
+extra-deps: [intero-0.1.28, ansi-terminal-0.9]
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
I think this is the minimal set of changes that were needed to build Carp on Windows. These changes will at least allow one to compile on Windows using gcc. Compiling with the Windows compiler (cl.exe) still doesn't work due to some specific Posix functions that are used in some carp header files, specifically carp_system.h's clock_gettime usage. There may be other's, too, that will prevent compilation on Windows using cl.exe.