### PR TITLE
Fix variable lookup for deletion of non-locals in Concretization

### DIFF
--- a/test/regression.carp
+++ b/test/regression.carp
@@ -9,6 +9,13 @@
 
 (use-all Test Vector2 Foo)
 
+(defmodule T
+  (def v [1])
+
+  (defn get-v [] @&v)
+  (defn set-v [x] (set! v x))
+)
+
 (deftest test
   (assert-equal test
                  1
@@ -19,5 +26,10 @@
                  \\
                  (String.char-at "\\" 0)
                  "test that strings get escaped correctly"
+  )
+  (assert-equal test
+                &[1]
+                &(T.get-v)
+                "test that we're generating valid code for non-locals"
   )
 )


### PR DESCRIPTION
This PR solves a bug that occurs when non-locals need to be overriden. Consider
this, for example:

```clojure
(defmodule T
  ; a non-global, but non-local array
  (def x (the (Array Int) []))

  ; a setter function
  (defn set-x [v]
    (set! x v))
)
```

This will need to generate a call to delete the old value of `x` before
resetting it. It does, but it uses a temporary variable name that is generated
from the `info` on the `XObj`. The resultant error happens in the C compiler:

```
/Users/veitheller/.carp/out//main.c:2517:23: error: use of undeclared identifier
      '_5'
    Array_delete__int(_5);
                      ^
1 error generated.
carp: callCommand: clang -fPIC -lm /Users/veitheller/.carp/out//main.c -shared -o "/Users/veitheller/.carp/out//Untitled"   -I/Users/veitheller/Documents/Code/Github/carp/Carp//core/  -g  (exit 1): failed
```

The call to `Array_delete__int` should use `T.x` rather than `_5`. The fix in
this PR is to patch `varOfXObj` within the concretization step to return the
actual mangled name of the variable when the symbol mode is a global variable
lookup in Carp land, or `(LookupGlobal CarpLand AVariable)`. This seems to pass
all tests, but special caution needs to be taken here, since it changes the
behavior of the deletor creation and many other parts of the
concretization—basically everywhere a variable is looked up in the concretizer,
this new behavior will be observed.

A test case was added to `regression.carp`. It’s a little obtuse, but it will
raise an alarm if this behavior pops up again.

Cheers