### PR TITLE
Add Char.alpha?, Char.num?, and Char.alphanum?

### DIFF
--- a/core/Char.carp
+++ b/core/Char.carp
@@ -33,6 +33,18 @@
   (doc upper-case? "tests whether a character is upper case.")
   (defn upper-case? [c]
     (and (<= \A c) (<= c \Z)))
+
+  (doc alpha? "tests whether a character is alphabetical.")
+  (defn alpha? [c]
+    (or (lower-case? c) (upper-case? c)))
+
+  (doc num? "tests whether a character is numerical.")
+  (defn num? [c]
+    (and (<= \0 c) (<= c \9)))
+
+  (doc alphanum? "tests whether a character is alphanumerical.")
+  (defn alphanum? [c]
+    (or (alpha? c) (num? c)))
 )
 
 (defmodule CharRef

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -215,6 +215,46 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#alpha?">
+                    <h3 id="alpha?">
+                        alpha?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char] Bool)
+                </p>
+                <pre class="args">
+                    (alpha? c)
+                </pre>
+                <p class="doc">
+                    <p>tests whether a character is alphabetical.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#alphanum?">
+                    <h3 id="alphanum?">
+                        alphanum?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char] Bool)
+                </p>
+                <pre class="args">
+                    (alphanum? c)
+                </pre>
+                <p class="doc">
+                    <p>tests whether a character is alphanumerical.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#copy">
                     <h3 id="copy">
                         copy
@@ -327,6 +367,26 @@
                 </pre>
                 <p class="doc">
                     <p>converts a numerical char into the appropriate number (e.g. from <code>\1</code> to <code>1</code>).</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#num?">
+                    <h3 id="num?">
+                        num?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Char] Bool)
+                </p>
+                <pre class="args">
+                    (num? c)
+                </pre>
+                <p class="doc">
+                    <p>tests whether a character is numerical.</p>
 
                 </p>
             </div>

--- a/test/char.carp
+++ b/test/char.carp
@@ -54,4 +54,40 @@
   (assert-false test
                 (lower-case? \#)
                 "lower-case? works as expected III")
+  (assert-true  test
+                (alpha? \a)
+                "alpha? works as expected I")
+  (assert-true  test
+                (alpha? \A)
+                "alpha? works as expected II")
+  (assert-false test
+                (alpha? \#)
+                "alpha? works as expected III")
+  (assert-false test
+                (alpha? \0)
+                "alpha? works as expected III")
+  (assert-false test
+                (num? \a)
+                "num? works as expected I")
+  (assert-false test
+                (num? \A)
+                "num? works as expected II")
+  (assert-false test
+                (num? \#)
+                "num? works as expected III")
+  (assert-true  test
+                (num? \0)
+                "num? works as expected III")
+  (assert-true  test
+                (alphanum? \a)
+                "alphanum? works as expected I")
+  (assert-true  test
+                (alphanum? \A)
+                "alphanum? works as expected II")
+  (assert-false test
+                (alphanum? \#)
+                "alphanum? works as expected III")
+  (assert-true test
+                (alphanum? \0)
+                "alphanum? works as expected III")
 )


### PR DESCRIPTION
This PR adds the utility functions `alpha?`, `num?`, and `alphanum?` to the `Char` module. Test cases are included.

Cheers