### PR TITLE
Provide more context for error messages on type errors

### DIFF
--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -240,7 +240,7 @@ concretizeXObj allowAmbiguityRoot typeEnv rootEnv visitedDefinitions root =
                                                  fake1 = XObj (Sym (SymPath [] "theType") Symbol) Nothing Nothing
                                                  fake2 = XObj (Sym (SymPath [] "xobjType") Symbol) Nothing Nothing
                                                  Just i' = i
-                                       in  case solve [Constraint theType t' fake1 fake2 OrdMultiSym] of
+                                       in  case solve [Constraint theType t' fake1 fake2 fake1 OrdMultiSym] of
                                              Right mappings ->
                                                let replaced = replaceTyVars mappings t'
                                                    suffixed = suffixTyVars ("_x" ++ show (infoIdentifier i')) replaced -- Make sure it gets unique type variables. TODO: Is there a better way?
@@ -381,7 +381,7 @@ instantiateGenericStructType typeEnv originalStructTy@(StructTy _ originalTyVars
   let fake1 = XObj (Sym (SymPath [] "a") Symbol) Nothing Nothing
       fake2 = XObj (Sym (SymPath [] "b") Symbol) Nothing Nothing
       XObj (Arr memberXObjs) _ _ = head membersXObjs
-  in  case solve [Constraint originalStructTy genericStructTy fake1 fake2 OrdMultiSym] of
+  in  case solve [Constraint originalStructTy genericStructTy fake1 fake2 fake1 OrdMultiSym] of
         Left e -> error (show e)
         Right mappings ->
           let concretelyTypedMembers = replaceGenericTypeSymbolsOnMembers mappings memberXObjs
@@ -410,7 +410,7 @@ instantiateGenericSumtype typeEnv originalStructTy@(StructTy _ originalTyVars) g
   -- Turn (deftype (Maybe a) (Just a) (Nothing)) into (deftype (Maybe Int) (Just Int) (Nothing))
   let fake1 = XObj (Sym (SymPath [] "a") Symbol) Nothing Nothing
       fake2 = XObj (Sym (SymPath [] "b") Symbol) Nothing Nothing
-  in  case solve [Constraint originalStructTy genericStructTy fake1 fake2 OrdMultiSym] of
+  in  case solve [Constraint originalStructTy genericStructTy fake1 fake2 fake1 OrdMultiSym] of
         Left e -> error (show e)
         Right mappings ->
           let concretelyTypedCases = map (replaceGenericTypeSymbolsOnCase mappings) cases

--- a/src/GenerateConstraints.hs
+++ b/src/GenerateConstraints.hs
@@ -222,7 +222,7 @@ genConstraints typeEnv root = fmap sort (gen root)
                            let Just headTy = ty x
                                genObj o n = XObj (Sym (SymPath [] ("Whereas the " ++ enumerate n ++ " element in the array is " ++ show (getPath o))) Symbol)
                                   (info o) (ty o)
-                               headObj = XObj (Sym (SymPath [] ("I inferred the type of tge array from the first element of the array " ++ show (getPath x))) Symbol)
+                               headObj = XObj (Sym (SymPath [] ("I inferred the type of the array from the first element of the array " ++ show (getPath x))) Symbol)
                                   (info x) (Just headTy)
                                Just (StructTy "Array" [t]) = ty xobj
                                betweenExprConstraints = zipWith (\o n -> Constraint headTy (forceTy o) headObj (genObj o n) xobj OrdArrBetween) xs [1..]

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -151,9 +151,8 @@ machineReadableErrorStrings :: FilePathPrintLength -> TypeError -> [String]
 machineReadableErrorStrings fppl err =
   case err of
     (UnificationFailed constraint@(Constraint a b aObj bObj _ _) mappings constraints) ->
-      [machineReadableInfoFromXObj fppl aObj ++ " " ++ pretty aObj ++ " : " ++
-       showTypeFromXObj mappings aObj ++ ", can't unify with " ++ show (recursiveLookupTy mappings b) ++ "."
-      ,machineReadableInfoFromXObj fppl bObj ++ " " ++ pretty bObj ++ " : " ++
+      [machineReadableInfoFromXObj fppl aObj ++ " Inferred " ++ showTypeFromXObj mappings aObj ++ ", can't unify with " ++ show (recursiveLookupTy mappings b) ++ "."
+      ,machineReadableInfoFromXObj fppl bObj ++ " Inferred " ++
        showTypeFromXObj mappings bObj ++ ", can't unify with " ++ show (recursiveLookupTy mappings a) ++ "."]
 
     (DefnMissingType xobj) ->

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -76,8 +76,8 @@ instance Show TypeError where
     "There are too many expressions in the body of the form at " ++ prettyInfoFromXObj xobj ++ ".\n\nTry wrapping them in a `do`."
   show (NoFormsInBody xobj) =
     "There are no expressions in the body body of the form at " ++ prettyInfoFromXObj xobj ++ ".\n\nI need exactly one body form. For multiple forms, try using `do`."
-  show (UnificationFailed constraint@(Constraint a b aObj bObj _) mappings constraints) =
-    "I can’t match the types '" ++ show (recursiveLookupTy mappings a) ++ "' and '" ++ show (recursiveLookupTy mappings b) ++ "'.\n\n" ++
+  show (UnificationFailed constraint@(Constraint a b aObj bObj ctx _) mappings constraints) =
+    "I can’t match the types '" ++ show (recursiveLookupTy mappings a) ++ "' and '" ++ show (recursiveLookupTy mappings b) ++ "'" ++ extra ++ ".\n\n" ++
     --show aObj ++ "\nWITH\n" ++ show bObj ++ "\n\n" ++
     "  " ++ pretty aObj ++ " : " ++ showTypeFromXObj mappings aObj ++ "\n  At " ++ prettyInfoFromXObj aObj ++ "" ++
     "\n\n" ++
@@ -85,6 +85,8 @@ instance Show TypeError where
     -- ++ "Constraint: " ++ show constraint ++ "\n\n"
     -- "All constraints:\n" ++ show constraints ++ "\n\n" ++
     -- "Mappings: \n" ++ show mappings ++ "\n\n"
+    where extra = if ctx == aObj || ctx == bObj then "" else " within `" ++ snip (pretty ctx) ++ "`"
+          snip s = if length s > 25 then take 15 s ++ " ... " ++ drop (length s - 5) s else s
   show (CantDisambiguate xobj originalName theType options) =
     "I can’t disambiguate the symbol '" ++ originalName ++ "' of type " ++ show theType ++ " at " ++ prettyInfoFromXObj xobj ++
     "\nPossibilities:\n    " ++ joinWith "\n    " (map (\(t, p) -> show p ++ " : " ++ show t) options)
@@ -148,7 +150,7 @@ instance Show TypeError where
 machineReadableErrorStrings :: FilePathPrintLength -> TypeError -> [String]
 machineReadableErrorStrings fppl err =
   case err of
-    (UnificationFailed constraint@(Constraint a b aObj bObj _) mappings constraints) ->
+    (UnificationFailed constraint@(Constraint a b aObj bObj _ _) mappings constraints) ->
       [machineReadableInfoFromXObj fppl aObj ++ " " ++ pretty aObj ++ " : " ++
        showTypeFromXObj mappings aObj ++ ", can't unify with " ++ show (recursiveLookupTy mappings b) ++ "."
       ,machineReadableInfoFromXObj fppl bObj ++ " " ++ pretty bObj ++ " : " ++


### PR DESCRIPTION
This PR introduces context for type errors and it makes the array error messages especially nice. Here is an example error message for heterogenous types within an array:

```
I can’t match the types 'Int' and '&String' within `[1 2 "lol"]`.

  I inferred the type of the array from the first element of the array 1 : Int
  At line 1, column 9 in '/Users/veitheller/Documents/Code/Github/carp/carp/t.carp'

  Whereas the third element in the array is "lol" : &String
  At line 1, column 13 in '/Users/veitheller/Documents/Code/Github/carp/carp/t.carp'
```

I hope this makes for a better experience!

Cheers