### PR TITLE
Better error messages (2/?)

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -60,6 +60,7 @@ library
                      , text
                      , ansi-terminal >= 0.9
                      , cmark
+                     , edit-distance
 
   default-language:    Haskell2010
 

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -65,7 +65,7 @@ addCommandConfigurable name maybeArity callback =
         withArity arity args =
           if length args == arity
             then callback args
-            else return (Left (EvalError ("Invalid args to '" ++ name ++ "' command: " ++ joinWithComma (map pretty args))))
+            else return (Left (EvalError ("Invalid args to '" ++ name ++ "' command: " ++ joinWithComma (map pretty args)) Nothing))
         withoutArity args =
           callback args
 
@@ -175,7 +175,7 @@ commandProjectGetConfig [xobj@(XObj (Str key) _ _)] =
           "file-path-print-length" -> Right $ Str $ show (projectFilePathPrintLength proj)
           _ ->
             Left $ EvalError ("[CONFIG ERROR] Project.get-config can't understand the key '" ++
-                               key ++ "' at " ++ prettyInfoFromXObj xobj ++ ".")
+                               key) (info xobj)
 commandProjectGetConfig [faultyKey] =
   do presentError ("First argument to 'Project.config' must be a string: " ++ pretty faultyKey) dynamicNil
 
@@ -229,7 +229,10 @@ commandBuild args =
                          )
      case src of
        Left err ->
-         return (Left (EvalError ("[CODEGEN ERROR] " ++ show err)))
+         return (Left (EvalError
+                        ("I encountered an error when emitting code:\n\n" ++
+                         (show err))
+                        Nothing))
        Right okSrc ->
          do let compiler = projectCompiler proj
                 echoCompilationCommand = projectEchoCompilationCommand proj
@@ -506,48 +509,48 @@ commandLength [x] =
   case x of
     XObj (Lst lst) _ _ -> return (Right (XObj (Num IntTy (fromIntegral (length lst))) Nothing Nothing))
     XObj (Arr arr) _ _ -> return (Right (XObj (Num IntTy (fromIntegral (length arr))) Nothing Nothing))
-    _ -> return (Left (EvalError ("Applying 'length' to non-list: " ++ pretty x ++ " at " ++ prettyInfoFromXObj x)))
+    _ -> return (Left (EvalError ("Applying 'length' to non-list: " ++ pretty x) (info x)))
 
 commandCar :: CommandCallback
 commandCar [x] =
   case x of
     XObj (Lst (car : _)) _ _ -> return (Right car)
     XObj (Arr (car : _)) _ _ -> return (Right car)
-    _ -> return (Left (EvalError ("Applying 'car' to non-list: " ++ pretty x)))
+    _ -> return (Left (EvalError ("Applying 'car' to non-list: " ++ pretty x) (info x)))
 
 commandCdr :: CommandCallback
 commandCdr [x] =
   case x of
     XObj (Lst (_ : cdr)) i _ -> return (Right (XObj (Lst cdr) i Nothing))
     XObj (Arr (_ : cdr)) i _ -> return (Right (XObj (Arr cdr) i Nothing))
-    _ -> return (Left (EvalError "Applying 'cdr' to non-list or empty list"))
+    _ -> return (Left (EvalError "Applying 'cdr' to non-list or empty list" (info x)))
 
 commandLast :: CommandCallback
 commandLast [x] =
   case x of
     XObj (Lst lst) _ _ -> return (Right (last lst))
     XObj (Arr arr) _ _ -> return (Right (last arr))
-    _ -> return (Left (EvalError "Applying 'last' to non-list or empty list."))
+    _ -> return (Left (EvalError "Applying 'last' to non-list or empty list." (info x)))
 
 commandAllButLast :: CommandCallback
 commandAllButLast [x] =
   case x of
     XObj (Lst lst) i _ -> return (Right (XObj (Lst (init lst)) i Nothing))
     XObj (Arr arr) i _ -> return (Right (XObj (Arr (init arr)) i Nothing))
-    _ -> return (Left (EvalError "Applying 'all-but-last' to non-list or empty list."))
+    _ -> return (Left (EvalError "Applying 'all-but-last' to non-list or empty list." (info x)))
 
 commandCons :: CommandCallback
 commandCons [x, xs] =
   case xs of
     XObj (Lst lst) _ _ -> return (Right (XObj (Lst (x : lst)) (info x) (ty x))) -- TODO: probably not correct to just copy 'i' and 't'?
     XObj (Arr arr) _ _ -> return (Right (XObj (Arr (x : arr)) (info x) (ty x)))
-    _ -> return (Left (EvalError "Applying 'cons' to non-list or empty list."))
+    _ -> return (Left (EvalError "Applying 'cons' to non-list or empty list." (info x)))
 
 commandConsLast :: CommandCallback
 commandConsLast [x, xs] =
   case xs of
     XObj (Lst lst) i t -> return (Right (XObj (Lst (lst ++ [x])) i t)) -- TODO: should they get their own i:s and t:s
-    _ -> return (Left (EvalError "Applying 'cons-last' to non-list or empty list."))
+    _ -> return (Left (EvalError "Applying 'cons-last' to non-list or empty list." (info x)))
 
 commandAppend :: CommandCallback
 commandAppend [xs, ys] =
@@ -555,13 +558,13 @@ commandAppend [xs, ys] =
     (XObj (Lst lst1) i t, XObj (Lst lst2) _ _) ->
       return (Right (XObj (Lst (lst1 ++ lst2)) i t)) -- TODO: should they get their own i:s and t:s
     _ ->
-      return (Left (EvalError "Applying 'append' to non-list or empty list."))
+      return (Left (EvalError "Applying 'append' to non-list or empty list." (info xs)))
 
 commandMacroError :: CommandCallback
 commandMacroError [msg] =
   case msg of
-    XObj (Str msg) _ _ -> return (Left (EvalError msg))
-    x                  -> return (Left (EvalError (pretty x)))
+    XObj (Str smsg) _ _ -> return (Left (EvalError smsg (info msg)))
+    x                  -> return (Left (EvalError (pretty x) (info msg)))
 
 commandMacroLog :: CommandCallback
 commandMacroLog [msg] =
@@ -597,7 +600,7 @@ commandEq [a, b] =
     (XObj (Lst []) _ _, XObj (Lst []) _ _) ->
       Right trueXObj
     _ ->
-      Left (EvalError ("Can't compare " ++ pretty a ++ " with " ++ pretty b))
+      Left (EvalError ("Can't compare " ++ pretty a ++ " with " ++ pretty b) (info a))
 
 commandLt :: CommandCallback
 commandLt [a, b] =
@@ -615,7 +618,7 @@ commandLt [a, b] =
      if aNum < bNum
      then Right trueXObj else Right falseXObj
    _ ->
-     Left (EvalError ("Can't compare (<) " ++ pretty a ++ " with " ++ pretty b))
+     Left (EvalError ("Can't compare (<) " ++ pretty a ++ " with " ++ pretty b) (info a))
 
 commandGt :: CommandCallback
 commandGt [a, b] =
@@ -633,7 +636,7 @@ commandGt [a, b] =
       if aNum > bNum
       then Right trueXObj else Right falseXObj
     _ ->
-      Left (EvalError ("Can't compare (>) " ++ pretty a ++ " with " ++ pretty b))
+      Left (EvalError ("Can't compare (>) " ++ pretty a ++ " with " ++ pretty b) (info a))
 
 commandCharAt :: CommandCallback
 commandCharAt [a, b] =
@@ -641,7 +644,7 @@ commandCharAt [a, b] =
     (XObj (Str s) _ _, XObj (Num IntTy n) _ _) ->
       Right (XObj (Chr (s !! (round n :: Int))) (Just dummyInfo) (Just IntTy))
     _ ->
-      Left (EvalError ("Can't call char-at with " ++ pretty a ++ " and " ++ pretty b))
+      Left (EvalError ("Can't call char-at with " ++ pretty a ++ " and " ++ pretty b) (info a))
 
 commandIndexOf :: CommandCallback
 commandIndexOf [a, b] =
@@ -649,7 +652,7 @@ commandIndexOf [a, b] =
     (XObj (Str s) _ _, XObj (Chr c) _ _) ->
       Right (XObj (Num IntTy (getIdx c s)) (Just dummyInfo) (Just IntTy))
     _ ->
-      Left (EvalError ("Can't call index-of with " ++ pretty a ++ " and " ++ pretty b))
+      Left (EvalError ("Can't call index-of with " ++ pretty a ++ " and " ++ pretty b) (info a))
   where getIdx c s = fromIntegral $ fromMaybe (-1) $ elemIndex c s
 
 commandSubstring :: CommandCallback
@@ -658,7 +661,7 @@ commandSubstring [a, b, c] =
     (XObj (Str s) _ _, XObj (Num IntTy f) _ _, XObj (Num IntTy t) _ _) ->
       Right (XObj (Str (take (round t :: Int) (drop (round f :: Int) s))) (Just dummyInfo) (Just StringTy))
     _ ->
-      Left (EvalError ("Can't call substring with " ++ pretty a ++ ", " ++ pretty b ++ " and " ++ pretty c))
+      Left (EvalError ("Can't call substring with " ++ pretty a ++ ", " ++ pretty b ++ " and " ++ pretty c) (info a))
 
 commandStringLength :: CommandCallback
 commandStringLength [a] =
@@ -666,17 +669,17 @@ commandStringLength [a] =
     XObj (Str s) _ _ ->
       Right (XObj (Num IntTy (fromIntegral (length s))) (Just dummyInfo) (Just IntTy))
     _ ->
-      Left (EvalError ("Can't call length with " ++ pretty a))
+      Left (EvalError ("Can't call length with " ++ pretty a) (info a))
 
 commandStringJoin :: CommandCallback
 commandStringJoin [a] =
   return $ case a of
     XObj (Arr strings) _ _ ->
       case (sequence (map unwrapStringXObj strings)) of
-        Left err -> Left (EvalError err)
+        Left err -> Left (EvalError err (info a))
         Right result -> Right (XObj (Str (join result)) (Just dummyInfo) (Just StringTy))
     _ ->
-      Left (EvalError ("Can't call join with " ++ pretty a))
+      Left (EvalError ("Can't call join with " ++ pretty a) (info a))
 
 commandStringDirectory :: CommandCallback
 commandStringDirectory [a] =
@@ -684,7 +687,7 @@ commandStringDirectory [a] =
     XObj (Str s) _ _ ->
       Right (XObj (Str (takeDirectory s)) (Just dummyInfo) (Just StringTy))
     _ ->
-      Left (EvalError ("Can't call directory with " ++ pretty a))
+      Left (EvalError ("Can't call directory with " ++ pretty a) (info a))
 
 commandPlus :: CommandCallback
 commandPlus [a, b] =
@@ -692,9 +695,9 @@ commandPlus [a, b] =
     (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
       if aty == bty
       then Right (XObj (Num aty (aNum + bNum)) (Just dummyInfo) (Just aty))
-      else Left (EvalError ("Can't call + with " ++ pretty a ++ " and " ++ pretty b))
+      else Left (EvalError ("Can't call + with " ++ pretty a ++ " and " ++ pretty b) (info a))
     _ ->
-      Left (EvalError ("Can't call + with " ++ pretty a ++ " and " ++ pretty b))
+      Left (EvalError ("Can't call + with " ++ pretty a ++ " and " ++ pretty b) (info a))
 
 commandMinus :: CommandCallback
 commandMinus [a, b] =
@@ -702,9 +705,9 @@ commandMinus [a, b] =
     (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
       if aty == bty
       then Right (XObj (Num aty (aNum - bNum)) (Just dummyInfo) (Just aty))
-      else Left (EvalError ("Can't call - with " ++ pretty a ++ " and " ++ pretty b))
+      else Left (EvalError ("Can't call - with " ++ pretty a ++ " and " ++ pretty b) (info a))
     _ ->
-      Left (EvalError ("Can't call - with " ++ pretty a ++ " and " ++ pretty b))
+      Left (EvalError ("Can't call - with " ++ pretty a ++ " and " ++ pretty b) (info a))
 
 commandDiv :: CommandCallback
 commandDiv [a, b] =
@@ -714,9 +717,9 @@ commandDiv [a, b] =
     (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
       if aty == bty
       then Right (XObj (Num aty (aNum / bNum)) (Just dummyInfo) (Just aty))
-      else Left (EvalError ("Can't call / with " ++ pretty a ++ " and " ++ pretty b))
+      else Left (EvalError ("Can't call / with " ++ pretty a ++ " and " ++ pretty b) (info a))
     _ ->
-      Left (EvalError ("Can't call / with " ++ pretty a ++ " and " ++ pretty b))
+      Left (EvalError ("Can't call / with " ++ pretty a ++ " and " ++ pretty b) (info a))
 
 commandMul :: CommandCallback
 commandMul [a, b] =
@@ -724,9 +727,9 @@ commandMul [a, b] =
     (XObj (Num aty aNum) _ _, XObj (Num bty bNum) _ _) ->
       if aty == bty
       then Right (XObj (Num aty (aNum * bNum)) (Just dummyInfo) (Just aty))
-      else Left (EvalError ("Can't call * with " ++ pretty a ++ " and " ++ pretty b))
+      else Left (EvalError ("Can't call * with " ++ pretty a ++ " and " ++ pretty b) (info a))
     _ ->
-      Left (EvalError ("Can't call * with " ++ pretty a ++ " and " ++ pretty b))
+      Left (EvalError ("Can't call * with " ++ pretty a ++ " and " ++ pretty b) (info a))
 
 commandStr :: CommandCallback
 commandStr xs =
@@ -747,7 +750,7 @@ commandNot [x] =
       then return (Right falseXObj)
       else return (Right trueXObj)
     _ ->
-      return (Left (EvalError ("Can't perform logical operation (not) on " ++ pretty x)))
+      return (Left (EvalError ("Can't perform logical operation (not) on " ++ pretty x) (info x)))
 
 commandSaveDocsInternal :: CommandCallback
 commandSaveDocsInternal [modulePath] =
@@ -756,22 +759,22 @@ commandSaveDocsInternal [modulePath] =
      case modulePath of
        XObj (Lst xobjs) _ _ ->
          case sequence (map unwrapSymPathXObj xobjs) of
-           Left err -> return (Left (EvalError err))
+           Left err -> return (Left (EvalError err (info modulePath)))
            Right okPaths ->
              case sequence (map (getEnvironmentForDocumentation globalEnv) okPaths) of
                Left err -> return (Left err)
                Right okEnvs -> saveDocs (zip okPaths okEnvs)
        x ->
-         return (Left (EvalError ("Invalid arg to save-docs-internal (expected list of symbols): " ++ pretty x)))
+         return (Left (EvalError ("Invalid arg to save-docs-internal (expected list of symbols): " ++ pretty x) (info modulePath)))
   where getEnvironmentForDocumentation :: Env -> SymPath -> Either EvalError Env
         getEnvironmentForDocumentation env path =
           case lookupInEnv path env of
             Just (_, Binder _ (XObj (Mod foundEnv) _ _)) ->
               Right foundEnv
             Just (_, Binder _ x) ->
-              Left (EvalError ("Non module can't be saved: " ++ pretty x))
+              Left (EvalError ("Non module can't be saved: " ++ pretty x) (info modulePath))
             Nothing ->
-              Left (EvalError ("Can't find module at '" ++ show path ++ "'"))
+              Left (EvalError ("Can't find module at '" ++ show path ++ "'") (info modulePath))
 
 saveDocs :: [(SymPath, Env)] -> StateT Context IO (Either EvalError XObj)
 saveDocs pathsAndEnvs =

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -59,40 +59,40 @@ eval env xobj =
         [XObj (Sym (SymPath [] "file") _) _ _] ->
           case i of
             Just info -> return (Right (XObj (Str (infoFile info)) i t))
-            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj)))
+            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "line") _) _ _] ->
           case i of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "column") _) _ _] ->
           case i of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "file") _) _ _, XObj _ infoToCheck _] ->
           case infoToCheck of
             Just info -> return (Right (XObj (Str (infoFile info)) i t))
-            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj)))
+            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "line") _) _ _, XObj _ infoToCheck _] ->
           case infoToCheck of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "column") _) _ _, XObj _ infoToCheck _] ->
           case infoToCheck of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
 
         XObj Do _ _ : rest ->
           do evaledList <- fmap sequence (mapM (eval env) rest)
@@ -100,7 +100,7 @@ eval env xobj =
                Left e -> return (Left e)
                Right ok ->
                  case ok of
-                   [] -> return (Left (EvalError "No forms in 'do' statement."))
+                   [] -> return (Left (EvalError "No forms in 'do' statement." (info xobj)))
                    _ -> return (Right (last ok))
 
         XObj (Sym (SymPath [] "list") _) _ _ : rest ->
@@ -126,10 +126,10 @@ eval env xobj =
                                          XObj (Bol bb) _ _ ->
                                            if bb then Right trueXObj else Right falseXObj
                                          _ ->
-                                           Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okB))
+                                           Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okB) (info okB))
                                else Right falseXObj
                            _ ->
-                             Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okA))
+                             Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okA) (info okA))
 
         [XObj (Sym (SymPath ["Dynamic"] "or") _) _ _, a, b] ->
           do evaledA <- eval env a
@@ -144,9 +144,9 @@ eval env xobj =
                                          XObj (Bol bb) _ _ ->
                                            if bb then Right trueXObj else Right falseXObj
                                          _ ->
-                                           Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okB))
+                                           Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okB) (info okB))
                            _ ->
-                             Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okA))
+                             Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okA) (info okA))
 
         [XObj If _ _, condition, ifTrue, ifFalse] ->
           do evaledCondition <- eval env condition
@@ -156,11 +156,21 @@ eval env xobj =
                    Bol b -> if b
                             then eval env ifTrue
                             else eval env ifFalse
-                   _ -> return (Left (EvalError ("Non-boolean expression in if-statement: " ++ pretty okCondition)))
+                   _ -> return (Left (EvalError ("`if` condition contains non-boolean value: " ++ pretty okCondition) (info okCondition)))
                Left err -> return (Left err)
 
-        [defnExpr@(XObj Defn _ _), name, args, body] ->
-          specialCommandDefine xobj
+        [defnExpr@(XObj Defn _ _), name, args@(XObj (Arr a) _ _), body] ->
+            if all isSym a
+              then specialCommandDefine xobj
+              else return (Left (EvalError ("`defn` requires all arguments to be symbols, but it got `" ++ pretty args ++ "`") (info xobj)))
+            where isSym (XObj (Sym _ _) _ _) = True
+                  isSym _ = False
+
+        [defnExpr@(XObj Defn _ _), name, invalidArgs, _] ->
+            return (Left (EvalError ("`defn` requires an array of symbols as argument list, but it got `" ++ pretty invalidArgs ++ "`") (info xobj)))
+
+        (defnExpr@(XObj Defn _ _) : _) ->
+            return (Left (EvalError ("I didn’t understand the `defn` at " ++ prettyInfoFromXObj xobj ++ ":\n\n" ++ pretty xobj ++ "\n\nIs it valid? Every `defn` needs to follow the form `(defn name [arg] body)`.") Nothing))
 
         [defExpr@(XObj Def _ _), name, expr] ->
           specialCommandDefine xobj
@@ -187,12 +197,12 @@ eval env xobj =
                       evaledBody <- eval envWithBindings body
                       return $ do okBody <- evaledBody
                                   Right okBody
-          else return (Left (EvalError ("Uneven number of forms in let-statement: " ++ pretty xobj))) -- Unreachable?
+          else return (Left (EvalError ("Uneven number of forms in `let`: " ++ pretty xobj) (info xobj))) -- Unreachable?
 
         XObj (Sym (SymPath [] "register-type") _) _ _ : XObj (Sym (SymPath _ typeName) _) _ _ : rest ->
           specialCommandRegisterType typeName rest
         XObj (Sym (SymPath _ "register-type") _) _ _ : _ ->
-          return (Left (EvalError (show "Invalid ars to 'register-type': " ++ pretty xobj)))
+          return (Left (EvalError (show "Invalid args to `register-type`: " ++ pretty xobj) (info xobj)))
 
         XObj (Sym (SymPath [] "deftype") _) _ _ : nameXObj : rest ->
           specialCommandDeftype nameXObj rest
@@ -202,62 +212,62 @@ eval env xobj =
         [XObj (Sym (SymPath [] "register") _) _ _, XObj (Sym (SymPath _ name) _) _ _, typeXObj, XObj (Str overrideName) _ _] ->
           specialCommandRegister name typeXObj (Just overrideName)
         XObj (Sym (SymPath [] "register") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'register' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `register`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "definterface") _) _ _, nameXObj@(XObj (Sym _ _) _ _), typeXObj] ->
           specialCommandDefinterface nameXObj typeXObj
         XObj (Sym (SymPath [] "definterface") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'definterface' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `definterface`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "defdynamic") _) _ _, (XObj (Sym (SymPath [] name) _) _ _), params, body] ->
           specialCommandDefdynamic name params body
         XObj (Sym (SymPath [] "defdynamic") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'defdynamic' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `defdynamic`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "defmacro") _) _ _, (XObj (Sym (SymPath [] name) _) _ _), params, body] ->
           specialCommandDefmacro name params body
         XObj (Sym (SymPath [] "defmacro") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'defmacro' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `defmacro`: " ++ pretty xobj) (info xobj)))
 
         XObj (Sym (SymPath [] "defmodule") _) _ _ : (XObj (Sym (SymPath [] moduleName) _) _ _) : innerExpressions ->
           specialCommandDefmodule xobj moduleName innerExpressions
         XObj (Sym (SymPath [] "defmodule") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'defmodule' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `defmodule`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "info") _) _ _, target@(XObj (Sym path @(SymPath _ name) _) _ _)] ->
           specialCommandInfo target
         XObj (Sym (SymPath [] "info") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'info' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `info`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "type") _) _ _, target] ->
           specialCommandType target
         XObj (Sym (SymPath [] "type") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'type' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `type`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "meta-set!") _) _ _, target@(XObj (Sym path @(SymPath _ name) _) _ _), (XObj (Str key) _ _), value] ->
           specialCommandMetaSet path key value
         XObj (Sym (SymPath [] "meta-set!") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'meta-set!' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `meta-set!`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "meta") _) _ _, target@(XObj (Sym path @(SymPath _ name) _) _ _), (XObj (Str key) _ _)] ->
           specialCommandMetaGet path key
         XObj (Sym (SymPath [] "meta") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'meta' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `meta`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "members") _) _ _, target] ->
           specialCommandMembers target
         XObj (Sym (SymPath [] "members") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'members' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `members`: " ++ pretty xobj) (info xobj)))
 
         [XObj (Sym (SymPath [] "use") _) _ _, xobj@(XObj (Sym path _) _ _)] ->
           specialCommandUse xobj path
         XObj (Sym (SymPath [] "use") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'use' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `use`: " ++ pretty xobj) (info xobj)))
 
         XObj With _ _ : xobj@(XObj (Sym path _) _ _) : forms ->
           specialCommandWith xobj path forms
         XObj With _ _ : _ ->
-          return (Left (EvalError ("Invalid args to 'with.' command: " ++ pretty xobj)))
+          return (Left (EvalError ("Invalid args to `with`: " ++ pretty xobj) (info xobj)))
 
         f:args -> do evaledF <- eval env f
                      case evaledF of
@@ -285,8 +295,8 @@ eval env xobj =
                               Right okArgs -> getCommand callback okArgs
                               Left err -> return (Left err)
                        _ ->
-                         return (Left (EvalError ("Can't eval non-macro / non-dynamic function '" ++ pretty f ++ "' in " ++
-                                                  pretty xobj ++ " at " ++ prettyInfoFromXObj xobj)))
+                         return (Left (EvalError ("Can't eval '" ++ pretty f ++ "' (it’s neither a macro nor a dynamic function) in " ++
+                                                  pretty xobj) (info f)))
 
     evalList _ = error "Can't eval non-list in evalList."
 
@@ -297,7 +307,7 @@ eval env xobj =
         Nothing ->
           case lookupInEnv path env of
             Just (_, Binder _ found) -> return (Right found)
-            Nothing -> return (Left (EvalError ("Can't find symbol '" ++ show path ++ "' at " ++ prettyInfoFromXObj xobj)))
+            Nothing -> return (Left (EvalError ("Can't find symbol '" ++ show path ++ "'") (info xobj)))
     evalSymbol _ = error "Can't eval non-symbol in evalSymbol."
 
     evalArray :: XObj -> StateT Context IO (Either EvalError XObj)
@@ -319,9 +329,7 @@ checkMatchingNrOfArgs xobj params args =
         else show paramLen
   in  if (usesRestArgs && argsLen > paramLen) || (paramLen == argsLen)
       then Right ()
-      else Left (EvalError ("Wrong nr of arguments in call to '" ++ pretty xobj ++ "' at " ++ prettyInfoFromXObj xobj ++
-                            ", expected " ++ expected ++ " but got " ++ show argsLen ++ "."
-                           ))
+      else Left (EvalError ("Wrong number of arguments in call to '" ++ pretty xobj ++ "', expected " ++ expected ++ " but got " ++ show argsLen) (info xobj))
 
 -- | Apply a function to some arguments. The other half of 'eval'.
 apply :: Env -> XObj -> [XObj] -> [XObj] -> StateT Context IO (Either EvalError XObj)
@@ -356,9 +364,9 @@ found binder =
 notFound :: ExecutionMode -> XObj -> SymPath -> StateT Context IO (Either EvalError XObj)
 notFound execMode xobj path =
   do fppl <- fmap (projectFilePathPrintLength . contextProj) get
-     return $ Left $ EvalError $ case execMode of
+     return $ Left $ EvalError (case execMode of
                                    Check -> machineReadableInfoFromXObj fppl xobj ++ (" Can't find '" ++ show path ++ "'")
-                                   _ -> "Can't find '" ++ show path ++ "'"
+                                   _ -> "Can't find '" ++ show path ++ "'") (info xobj)
 
 -- | A command at the REPL
 -- | TODO: Is it possible to remove the error cases?
@@ -475,7 +483,7 @@ catcher ctx exception =
     CancelEvaluationException ->
       stop 1
     EvalException evalError ->
-      do putStrLnWithColor Red ("[EVAL ERROR] " ++ show evalError)
+      do putStrLnWithColor Red (show evalError)
          stop 1
   where stop returnCode =
           case contextExecMode ctx of
@@ -515,8 +523,8 @@ define hidden ctx@(Context globalEnv typeEnv _ proj _ _) annXObj =
               Just foundSignature ->
                 do let Just sigTy = xobjToTy foundSignature
                    when (not (areUnifiable (forceTy annXObj) sigTy)) $
-                     throw $ EvalException (EvalError ("Definition at " ++ prettyInfoFromXObj annXObj ++ " does not match 'sig' annotation " ++
-                                                       show sigTy ++ ", actual type is " ++ show (forceTy annXObj)))
+                     throw $ EvalException (EvalError ("Definition at " ++ prettyInfoFromXObj annXObj ++ " does not match `sig` annotation " ++
+                              show sigTy ++ ", actual type is `" ++ show (forceTy annXObj) ++ "`.") Nothing)
               Nothing ->
                 return ()
             --putStrLnWithColor Blue (show (getPath annXObj) ++ " : " ++ showMaybeTy (ty annXObj) ++ (if hidden then " [HIDDEN]" else ""))
@@ -582,7 +590,7 @@ specialCommandDefine xobj =
      expansionResult <- expandAll eval globalEnv xobj
      ctxAfterExpansion <- get
      case expansionResult of
-       Left err -> return (Left (EvalError (show err)))
+       Left err -> return (Left (EvalError (show err) Nothing))
        Right expanded ->
          let xobjFullPath = setFullyQualifiedDefn expanded (SymPath pathStrings (getName xobj))
              xobjFullSymbols = setFullyQualifiedSymbols typeEnv globalEnv innerEnv xobjFullPath
@@ -591,9 +599,9 @@ specialCommandDefine xobj =
                 case contextExecMode ctx of
                   Check ->
                     let fppl = projectFilePathPrintLength (contextProj ctx)
-                    in  return (Left (EvalError (joinWith "\n" (machineReadableErrorStrings fppl err))))
+                    in  return (Left (EvalError (joinWith "\n" (machineReadableErrorStrings fppl err)) Nothing))
                   _ ->
-                    return (Left (EvalError (show err)))
+                    return (Left (EvalError (show err) Nothing))
               Right (annXObj, annDeps) ->
                 do ctxWithDeps <- liftIO $ foldM (define True) ctxAfterExpansion annDeps
                    ctxWithDef <- liftIO $ define False ctxWithDeps annXObj
@@ -620,7 +628,7 @@ specialCommandRegisterType typeName rest =
        members ->
          case bindingsForRegisteredType typeEnv globalEnv pathStrings typeName members i preExistingModule of
            Left errorMessage ->
-             return (Left (EvalError (show errorMessage)))
+             return (Left (EvalError (show errorMessage) Nothing))
            Right (typeModuleName, typeModuleXObj, deps) ->
              let ctx' = (ctx { contextGlobalEnv = envInsertAt globalEnv (SymPath pathStrings typeModuleName) (Binder emptyMeta typeModuleXObj)
                              , contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) typeName typeDefinition)
@@ -670,11 +678,11 @@ deftypeInternal nameXObj typeName typeVariableXObjs rest =
                      Right ok -> put ok
                    return dynamicNil
            Left err ->
-             return (Left (EvalError ("Invalid type definition for '" ++ pretty nameXObj ++ "':\n\n" ++ show err)))
+             return (Left (EvalError ("Invalid type definition for '" ++ pretty nameXObj ++ "':\n\n" ++ show err) Nothing))
        (_, Nothing) ->
-         return (Left (EvalError ("Invalid type variables for type definition: " ++ pretty nameXObj)))
+         return (Left (EvalError ("Invalid type variables for type definition: " ++ pretty nameXObj) (info nameXObj)))
        _ ->
-         return (Left (EvalError ("Invalid name for type definition: " ++ pretty nameXObj)))
+         return (Left (EvalError ("Invalid name for type definition: " ++ pretty nameXObj) (info nameXObj)))
 
 specialCommandRegister :: String -> XObj -> Maybe String -> StateT Context IO (Either EvalError XObj)
 specialCommandRegister name typeXObj overrideName =
@@ -694,12 +702,12 @@ specialCommandRegister name typeXObj overrideName =
                                             Check -> let fppl = projectFilePathPrintLength (contextProj ctx)
                                                      in  machineReadableInfoFromXObj fppl typeXObj ++ " "
                                             _ -> ""
-                             in  return (Left (EvalError (prefix ++ err)))
+                             in  return (Left (EvalError (prefix ++ err) (info typeXObj)))
                            Right ctx' ->
                              do put (ctx' { contextGlobalEnv = env' })
                                 return dynamicNil
            Nothing ->
-             return (Left (EvalError ("Can't understand type when registering '" ++ name ++ "'")))
+             return (Left (EvalError ("Can't understand type when registering '" ++ name ++ "'") (info typeXObj)))
 
 specialCommandDefinterface :: XObj -> XObj -> StateT Context IO (Either EvalError XObj)
 specialCommandDefinterface nameXObj@(XObj (Sym path@(SymPath [] name) _) _ _) typeXObj =
@@ -722,7 +730,7 @@ specialCommandDefinterface nameXObj@(XObj (Sym path@(SymPath [] name) _) _ _) ty
                     return dynamicNil
        Nothing ->
          return (Left (EvalError ("Invalid type for interface '" ++ name ++ "': " ++
-                                   pretty typeXObj ++ " at " ++ prettyInfoFromXObj typeXObj ++ ".")))
+                                   pretty typeXObj) (info typeXObj)))
 
 specialCommandDefdynamic :: String -> XObj -> XObj -> StateT Context IO (Either EvalError XObj)
 specialCommandDefdynamic name params body =
@@ -762,7 +770,7 @@ specialCommandDefmodule xobj moduleName innerExpressions =
                       put (popModulePath ctxAfterModuleAdditions)
                       return dynamicNil -- TODO: propagate errors...
                  Just _ ->
-                   return (Left (EvalError ("Can't redefine '" ++ moduleName ++ "' as module.")))
+                   return (Left (EvalError ("Can't redefine '" ++ moduleName ++ "' as module") (info xobj)))
                  Nothing ->
                    do let parentEnv = getEnv env pathStrings
                           innerEnv = Env (Map.fromList []) (Just parentEnv) (Just moduleName) [] ExternalEnv 0
@@ -868,9 +876,9 @@ specialCommandMembers target =
                  ->
                       return (Right (XObj (Arr (map (\(a, b) -> (XObj (Lst [a, b]) Nothing Nothing)) (pairwise members))) Nothing Nothing))
                _ ->
-                 return (Left (EvalError ("Can't find a struct type named '" ++ name ++ "' in type environment.")))
+                 return (Left (EvalError ("Can't find a struct type named '" ++ name ++ "' in type environment") (info target)))
            _ ->
-             return (Left (EvalError ("Can't get the members of non-symbol: " ++ pretty target)))
+             return (Left (EvalError ("Can't get the members of non-symbol: " ++ pretty target) (info target)))
 
 specialCommandUse :: XObj -> SymPath -> StateT Context IO (Either EvalError XObj)
 specialCommandUse xobj path =
@@ -886,7 +894,7 @@ specialCommandUse xobj path =
          do put $ ctx { contextGlobalEnv = envReplaceEnvAt env pathStrings e' }
             return dynamicNil
        Nothing ->
-         return (Left (EvalError ("Can't find a module named '" ++ show path ++ "' at " ++ prettyInfoFromXObj xobj ++ ".")))
+         return (Left (EvalError ("Can't find a module named '" ++ show path ++ "'") (info xobj)))
 
 specialCommandWith :: XObj -> SymPath -> [XObj] -> StateT Context IO (Either EvalError XObj)
 specialCommandWith xobj path forms =
@@ -922,7 +930,7 @@ specialCommandMetaSet path key value =
                                               (Just dummyInfo)
                                               (Just (VarTy "a"))))
            (SymPath _ _) ->
-             return (Left (EvalError ("Special command 'meta-set!' failed, can't find '" ++ show path ++ "'.")))
+             return (Left (EvalError ("Special command 'meta-set!' failed, can't find '" ++ show path ++ "'") (info value)))
        where
          setMetaOn :: Context -> Binder -> StateT Context IO (Either EvalError XObj)
          setMetaOn ctx binder@(Binder metaData xobj) =
@@ -949,7 +957,7 @@ specialCommandMetaGet path key =
              Nothing ->
                return dynamicNil
        Nothing ->
-         return (Left (EvalError ("Special command 'meta' failed, can't find '" ++ show path ++ "'.")))
+         return (Left (EvalError ("Special command 'meta' failed, can't find '" ++ show path ++ "'") Nothing))
 
 
 
@@ -998,19 +1006,19 @@ commandLoad [xobj@(XObj (Str path) _ _)] =
     fppl ctx =
       projectFilePathPrintLength (contextProj ctx)
     invalidPath ctx path =
-      Left $ EvalError $
-        (case contextExecMode ctx of
+      Left $ EvalError
+        ((case contextExecMode ctx of
           Check ->
             (machineReadableInfoFromXObj (fppl ctx) xobj) ++ " Invalid path: '" ++ path ++ "'"
           _ -> "Invalid path: '" ++ path ++ "'") ++
-        "\n\nIf you tried loading an external package, try appending a version string (like `@master`)."
+        "\n\nIf you tried loading an external package, try appending a version string (like `@master`)") (info xobj)
     invalidPathWith ctx path stderr =
-      Left $ EvalError $
-        (case contextExecMode ctx of
+      Left $ EvalError
+        ((case contextExecMode ctx of
           Check ->
             (machineReadableInfoFromXObj (fppl ctx) xobj) ++ " Invalid path: '" ++ path ++ "'"
           _ -> "Invalid path: '" ++ path ++ "'") ++
-        "\n\nTried interpreting statement as git import, but got: " ++ stderr
+        "\n\nI tried interpreting the statement as a git import, but got: " ++ stderr) (info xobj)
     tryInstall path =
       let split = splitOn "@" path
       in tryInstallWithCheckout (joinWith "@" (init split)) (last split)
@@ -1061,7 +1069,7 @@ commandLoad [xobj@(XObj (Str path) _ _)] =
             ExitFailure _ -> do
                 return $ invalidPathWith ctx path stderr1
 commandLoad [x] =
-  return $ Left (EvalError ("Invalid args to 'load' command: " ++ pretty x))
+  return $ Left (EvalError ("Invalid args to 'load' command: " ++ pretty x) (info x))
 
 
 -- | Load several files in order.
@@ -1111,10 +1119,10 @@ commandC [xobj] =
          typeEnv = contextTypeEnv ctx
      result <- expandAll eval globalEnv xobj
      case result of
-       Left err -> return (Left (EvalError (show err)))
+       Left err -> return (Left (EvalError (show err) (info xobj)))
        Right expanded ->
          case annotate typeEnv globalEnv (setFullyQualifiedSymbols typeEnv globalEnv globalEnv expanded) of
-           Left err -> return (Left (EvalError (show err)))
+           Left err -> return (Left (EvalError (show err) (info xobj)))
            Right (annXObj, annDeps) ->
              do liftIO (printC annXObj)
                 liftIO (mapM printC annDeps)

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -48,7 +48,9 @@ eval env xobj =
 
   where
     evalList :: XObj -> StateT Context IO (Either EvalError XObj)
-    evalList listXObj@(XObj (Lst xobjs) i t) =
+    evalList listXObj@(XObj (Lst xobjs) i t) = do
+      ctx <- get
+      let fppl = projectFilePathPrintLength (contextProj ctx)
       case xobjs of
         [] ->
           return (Right xobj)
@@ -59,40 +61,40 @@ eval env xobj =
         [XObj (Sym (SymPath [] "file") _) _ _] ->
           case i of
             Just info -> return (Right (XObj (Str (infoFile info)) i t))
-            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
+            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "line") _) _ _] ->
           case i of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "column") _) _ _] ->
           case i of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "file") _) _ _, XObj _ infoToCheck _] ->
           case infoToCheck of
             Just info -> return (Right (XObj (Str (infoFile info)) i t))
-            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
+            Nothing -> return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "line") _) _ _, XObj _ infoToCheck _] ->
           case infoToCheck of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "column") _) _ _, XObj _ infoToCheck _] ->
           case infoToCheck of
             Just info ->
               return (Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
             Nothing ->
-              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj)))
+              return (Left (EvalError ("No information about object " ++ pretty xobj) (info xobj) fppl))
 
         XObj Do _ _ : rest ->
           do evaledList <- fmap sequence (mapM (eval env) rest)
@@ -100,7 +102,7 @@ eval env xobj =
                Left e -> return (Left e)
                Right ok ->
                  case ok of
-                   [] -> return (Left (EvalError "No forms in 'do' statement." (info xobj)))
+                   [] -> return (Left (EvalError "No forms in 'do' statement." (info xobj) fppl))
                    _ -> return (Right (last ok))
 
         XObj (Sym (SymPath [] "list") _) _ _ : rest ->
@@ -126,10 +128,10 @@ eval env xobj =
                                          XObj (Bol bb) _ _ ->
                                            if bb then Right trueXObj else Right falseXObj
                                          _ ->
-                                           Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okB) (info okB))
+                                           Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okB) (info okB) fppl)
                                else Right falseXObj
                            _ ->
-                             Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okA) (info okA))
+                             Left (EvalError ("Can't perform logical operation (and) on " ++ pretty okA) (info okA) fppl)
 
         [XObj (Sym (SymPath ["Dynamic"] "or") _) _ _, a, b] ->
           do evaledA <- eval env a
@@ -144,9 +146,9 @@ eval env xobj =
                                          XObj (Bol bb) _ _ ->
                                            if bb then Right trueXObj else Right falseXObj
                                          _ ->
-                                           Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okB) (info okB))
+                                           Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okB) (info okB) fppl)
                            _ ->
-                             Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okA) (info okA))
+                             Left (EvalError ("Can't perform logical operation (or) on " ++ pretty okA) (info okA) fppl)
 
         [XObj If _ _, condition, ifTrue, ifFalse] ->
           do evaledCondition <- eval env condition
@@ -156,21 +158,21 @@ eval env xobj =
                    Bol b -> if b
                             then eval env ifTrue
                             else eval env ifFalse
-                   _ -> return (Left (EvalError ("`if` condition contains non-boolean value: " ++ pretty okCondition) (info okCondition)))
+                   _ -> return (Left (EvalError ("`if` condition contains non-boolean value: " ++ pretty okCondition) (info okCondition) fppl))
                Left err -> return (Left err)
 
         [defnExpr@(XObj Defn _ _), name, args@(XObj (Arr a) _ _), body] ->
             if all isSym a
               then specialCommandDefine xobj
-              else return (Left (EvalError ("`defn` requires all arguments to be symbols, but it got `" ++ pretty args ++ "`") (info xobj)))
+              else return (Left (EvalError ("`defn` requires all arguments to be symbols, but it got `" ++ pretty args ++ "`") (info xobj) fppl))
             where isSym (XObj (Sym _ _) _ _) = True
                   isSym _ = False
 
         [defnExpr@(XObj Defn _ _), name, invalidArgs, _] ->
-            return (Left (EvalError ("`defn` requires an array of symbols as argument list, but it got `" ++ pretty invalidArgs ++ "`") (info xobj)))
+            return (Left (EvalError ("`defn` requires an array of symbols as argument list, but it got `" ++ pretty invalidArgs ++ "`") (info xobj) fppl))
 
         (defnExpr@(XObj Defn _ _) : _) ->
-            return (Left (EvalError ("I didn’t understand the `defn` at " ++ prettyInfoFromXObj xobj ++ ":\n\n" ++ pretty xobj ++ "\n\nIs it valid? Every `defn` needs to follow the form `(defn name [arg] body)`.") Nothing))
+            return (Left (EvalError ("I didn’t understand the `defn` at " ++ prettyInfoFromXObj xobj ++ ":\n\n" ++ pretty xobj ++ "\n\nIs it valid? Every `defn` needs to follow the form `(defn name [arg] body)`.") Nothing fppl))
 
         [defExpr@(XObj Def _ _), name, expr] ->
           specialCommandDefine xobj
@@ -197,12 +199,12 @@ eval env xobj =
                       evaledBody <- eval envWithBindings body
                       return $ do okBody <- evaledBody
                                   Right okBody
-          else return (Left (EvalError ("Uneven number of forms in `let`: " ++ pretty xobj) (info xobj))) -- Unreachable?
+          else return (Left (EvalError ("Uneven number of forms in `let`: " ++ pretty xobj) (info xobj) fppl)) -- Unreachable?
 
         XObj (Sym (SymPath [] "register-type") _) _ _ : XObj (Sym (SymPath _ typeName) _) _ _ : rest ->
           specialCommandRegisterType typeName rest
         XObj (Sym (SymPath _ "register-type") _) _ _ : _ ->
-          return (Left (EvalError (show "Invalid args to `register-type`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError (show "Invalid args to `register-type`: " ++ pretty xobj) (info xobj) fppl))
 
         XObj (Sym (SymPath [] "deftype") _) _ _ : nameXObj : rest ->
           specialCommandDeftype nameXObj rest
@@ -212,67 +214,67 @@ eval env xobj =
         [XObj (Sym (SymPath [] "register") _) _ _, XObj (Sym (SymPath _ name) _) _ _, typeXObj, XObj (Str overrideName) _ _] ->
           specialCommandRegister name typeXObj (Just overrideName)
         XObj (Sym (SymPath [] "register") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `register`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `register`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "definterface") _) _ _, nameXObj@(XObj (Sym _ _) _ _), typeXObj] ->
           specialCommandDefinterface nameXObj typeXObj
         XObj (Sym (SymPath [] "definterface") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `definterface`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `definterface`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "defdynamic") _) _ _, (XObj (Sym (SymPath [] name) _) _ _), params, body] ->
           specialCommandDefdynamic name params body
         XObj (Sym (SymPath [] "defdynamic") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `defdynamic`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `defdynamic`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "defmacro") _) _ _, (XObj (Sym (SymPath [] name) _) _ _), params, body] ->
           specialCommandDefmacro name params body
         XObj (Sym (SymPath [] "defmacro") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `defmacro`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `defmacro`: " ++ pretty xobj) (info xobj) fppl))
 
         XObj (Sym (SymPath [] "defmodule") _) _ _ : (XObj (Sym (SymPath [] moduleName) _) _ _) : innerExpressions ->
           specialCommandDefmodule xobj moduleName innerExpressions
         XObj (Sym (SymPath [] "defmodule") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `defmodule`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `defmodule`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "info") _) _ _, target@(XObj (Sym path @(SymPath _ name) _) _ _)] ->
           specialCommandInfo target
         XObj (Sym (SymPath [] "info") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `info`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `info`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "type") _) _ _, target] ->
           specialCommandType target
         XObj (Sym (SymPath [] "type") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `type`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `type`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "meta-set!") _) _ _, target@(XObj (Sym path @(SymPath _ name) _) _ _), (XObj (Str key) _ _), value] ->
           specialCommandMetaSet path key value
         XObj (Sym (SymPath [] "meta-set!") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `meta-set!`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `meta-set!`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "meta") _) _ _, target@(XObj (Sym path @(SymPath _ name) _) _ _), (XObj (Str key) _ _)] ->
           specialCommandMetaGet path key
         XObj (Sym (SymPath [] "meta") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `meta`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `meta`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "members") _) _ _, target] ->
           specialCommandMembers target
         XObj (Sym (SymPath [] "members") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `members`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `members`: " ++ pretty xobj) (info xobj) fppl))
 
         [XObj (Sym (SymPath [] "use") _) _ _, xobj@(XObj (Sym path _) _ _)] ->
           specialCommandUse xobj path
         XObj (Sym (SymPath [] "use") _) _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `use`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `use`: " ++ pretty xobj) (info xobj) fppl))
 
         XObj With _ _ : xobj@(XObj (Sym path _) _ _) : forms ->
           specialCommandWith xobj path forms
         XObj With _ _ : _ ->
-          return (Left (EvalError ("Invalid args to `with`: " ++ pretty xobj) (info xobj)))
+          return (Left (EvalError ("Invalid args to `with`: " ++ pretty xobj) (info xobj) fppl))
 
         f:args -> do evaledF <- eval env f
                      case evaledF of
                        Right (XObj (Lst [XObj Dynamic _ _, _, XObj (Arr params) _ _, body]) _ _) ->
-                         case checkMatchingNrOfArgs f params args of
+                         case checkMatchingNrOfArgs fppl f params args of
                            Left err -> return (Left err)
                            Right () ->
                              do evaledArgs <- fmap sequence (mapM (eval env) args)
@@ -281,7 +283,7 @@ eval env xobj =
                                   Left err -> return (Left err)
 
                        Right (XObj (Lst [XObj Macro _ _, _, XObj (Arr params) _ _, body]) _ _) ->
-                         case checkMatchingNrOfArgs f params args of
+                         case checkMatchingNrOfArgs fppl f params args of
                            Left err ->
                              return (Left err)
                            Right () ->
@@ -296,18 +298,20 @@ eval env xobj =
                               Left err -> return (Left err)
                        _ ->
                          return (Left (EvalError ("Can't eval '" ++ pretty f ++ "' (it’s neither a macro nor a dynamic function) in " ++
-                                                  pretty xobj) (info f)))
+                                                  pretty xobj) (info f) fppl))
 
     evalList _ = error "Can't eval non-list in evalList."
 
     evalSymbol :: XObj -> StateT Context IO (Either EvalError XObj)
-    evalSymbol xobj@(XObj (Sym path@(SymPath pathStrings name) _) _ _) =
+    evalSymbol xobj@(XObj (Sym path@(SymPath pathStrings name) _) _ _) = do
+      ctx <- get
+      let fppl = projectFilePathPrintLength (contextProj ctx)
       case lookupInEnv (SymPath ("Dynamic" : pathStrings) name) env of -- A slight hack!
         Just (_, Binder _ found) -> return (Right found) -- use the found value
         Nothing ->
           case lookupInEnv path env of
             Just (_, Binder _ found) -> return (Right found)
-            Nothing -> return (Left (EvalError ("Can't find symbol '" ++ show path ++ "'") (info xobj)))
+            Nothing -> return (Left (EvalError ("Can't find symbol '" ++ show path ++ "'") (info xobj) fppl))
     evalSymbol _ = error "Can't eval non-symbol in evalSymbol."
 
     evalArray :: XObj -> StateT Context IO (Either EvalError XObj)
@@ -318,8 +322,8 @@ eval env xobj =
     evalArray _ = error "Can't eval non-array in evalArray."
 
 -- | Make sure the arg list is the same length as the parameter list
-checkMatchingNrOfArgs :: XObj -> [XObj] -> [XObj] -> Either EvalError ()
-checkMatchingNrOfArgs xobj params args =
+checkMatchingNrOfArgs :: FilePathPrintLength -> XObj -> [XObj] -> [XObj] -> Either EvalError ()
+checkMatchingNrOfArgs fppl xobj params args =
   let usesRestArgs = not (null (filter isRestArgSeparator (map getName params)))
       paramLen = if usesRestArgs then length params - 2 else length params
       argsLen = length args
@@ -329,7 +333,7 @@ checkMatchingNrOfArgs xobj params args =
         else show paramLen
   in  if (usesRestArgs && argsLen > paramLen) || (paramLen == argsLen)
       then Right ()
-      else Left (EvalError ("Wrong number of arguments in call to '" ++ pretty xobj ++ "', expected " ++ expected ++ " but got " ++ show argsLen) (info xobj))
+      else Left (EvalError ("Wrong number of arguments in call to '" ++ pretty xobj ++ "', expected " ++ expected ++ " but got " ++ show argsLen) (info xobj) fppl)
 
 -- | Apply a function to some arguments. The other half of 'eval'.
 apply :: Env -> XObj -> [XObj] -> [XObj] -> StateT Context IO (Either EvalError XObj)
@@ -366,7 +370,7 @@ notFound execMode xobj path =
   do fppl <- fmap (projectFilePathPrintLength . contextProj) get
      return $ Left $ EvalError (case execMode of
                                    Check -> machineReadableInfoFromXObj fppl xobj ++ (" Can't find '" ++ show path ++ "'")
-                                   _ -> "Can't find '" ++ show path ++ "'") (info xobj)
+                                   _ -> "Can't find '" ++ show path ++ "'") (info xobj) fppl
 
 -- | A command at the REPL
 -- | TODO: Is it possible to remove the error cases?
@@ -510,6 +514,7 @@ define hidden ctx@(Context globalEnv typeEnv _ proj _ _) annXObj =
       adjustedMeta = if hidden
                      then previousMeta { getMeta = Map.insert "hidden" trueXObj (getMeta previousMeta) }
                      else previousMeta
+      fppl = projectFilePathPrintLength proj
   in case annXObj of
        XObj (Lst (XObj (Defalias _) _ _ : _)) _ _ ->
          --putStrLnWithColor Yellow (show (getPath annXObj) ++ " : " ++ show annXObj)
@@ -524,7 +529,7 @@ define hidden ctx@(Context globalEnv typeEnv _ proj _ _) annXObj =
                 do let Just sigTy = xobjToTy foundSignature
                    when (not (areUnifiable (forceTy annXObj) sigTy)) $
                      throw $ EvalException (EvalError ("Definition at " ++ prettyInfoFromXObj annXObj ++ " does not match `sig` annotation " ++
-                              show sigTy ++ ", actual type is `" ++ show (forceTy annXObj) ++ "`.") Nothing)
+                              show sigTy ++ ", actual type is `" ++ show (forceTy annXObj) ++ "`.") Nothing fppl)
               Nothing ->
                 return ()
             --putStrLnWithColor Blue (show (getPath annXObj) ++ " : " ++ showMaybeTy (ty annXObj) ++ (if hidden then " [HIDDEN]" else ""))
@@ -584,13 +589,14 @@ specialCommandDefine :: XObj -> StateT Context IO (Either EvalError XObj)
 specialCommandDefine xobj =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          globalEnv = contextGlobalEnv ctx
          typeEnv = contextTypeEnv ctx
          innerEnv = getEnv globalEnv pathStrings
      expansionResult <- expandAll eval globalEnv xobj
      ctxAfterExpansion <- get
      case expansionResult of
-       Left err -> return (Left (EvalError (show err) Nothing))
+       Left err -> return (Left (EvalError (show err) Nothing fppl))
        Right expanded ->
          let xobjFullPath = setFullyQualifiedDefn expanded (SymPath pathStrings (getName xobj))
              xobjFullSymbols = setFullyQualifiedSymbols typeEnv globalEnv innerEnv xobjFullPath
@@ -599,9 +605,9 @@ specialCommandDefine xobj =
                 case contextExecMode ctx of
                   Check ->
                     let fppl = projectFilePathPrintLength (contextProj ctx)
-                    in  return (Left (EvalError (joinWith "\n" (machineReadableErrorStrings fppl err)) Nothing))
+                    in  return (Left (EvalError (joinWith "\n" (machineReadableErrorStrings fppl err)) Nothing fppl))
                   _ ->
-                    return (Left (EvalError (show err) Nothing))
+                    return (Left (EvalError (show err) Nothing fppl))
               Right (annXObj, annDeps) ->
                 do ctxWithDeps <- liftIO $ foldM (define True) ctxAfterExpansion annDeps
                    ctxWithDef <- liftIO $ define False ctxWithDeps annXObj
@@ -612,6 +618,7 @@ specialCommandRegisterType :: String -> [XObj] -> StateT Context IO (Either Eval
 specialCommandRegisterType typeName rest =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          globalEnv = contextGlobalEnv ctx
          typeEnv = contextTypeEnv ctx
          innerEnv = getEnv globalEnv pathStrings
@@ -628,7 +635,7 @@ specialCommandRegisterType typeName rest =
        members ->
          case bindingsForRegisteredType typeEnv globalEnv pathStrings typeName members i preExistingModule of
            Left errorMessage ->
-             return (Left (EvalError (show errorMessage) Nothing))
+             return (Left (EvalError (show errorMessage) Nothing fppl))
            Right (typeModuleName, typeModuleXObj, deps) ->
              let ctx' = (ctx { contextGlobalEnv = envInsertAt globalEnv (SymPath pathStrings typeModuleName) (Binder emptyMeta typeModuleXObj)
                              , contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) typeName typeDefinition)
@@ -647,6 +654,7 @@ deftypeInternal :: XObj -> String -> [XObj] -> [XObj] -> StateT Context IO (Eith
 deftypeInternal nameXObj typeName typeVariableXObjs rest =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          env = contextGlobalEnv ctx
          typeEnv = contextTypeEnv ctx
          typeVariables = sequence (map xobjToTy typeVariableXObjs)
@@ -678,16 +686,17 @@ deftypeInternal nameXObj typeName typeVariableXObjs rest =
                      Right ok -> put ok
                    return dynamicNil
            Left err ->
-             return (Left (EvalError ("Invalid type definition for '" ++ pretty nameXObj ++ "':\n\n" ++ show err) Nothing))
+             return (Left (EvalError ("Invalid type definition for '" ++ pretty nameXObj ++ "':\n\n" ++ show err) Nothing fppl))
        (_, Nothing) ->
-         return (Left (EvalError ("Invalid type variables for type definition: " ++ pretty nameXObj) (info nameXObj)))
+         return (Left (EvalError ("Invalid type variables for type definition: " ++ pretty nameXObj) (info nameXObj) fppl))
        _ ->
-         return (Left (EvalError ("Invalid name for type definition: " ++ pretty nameXObj) (info nameXObj)))
+         return (Left (EvalError ("Invalid name for type definition: " ++ pretty nameXObj) (info nameXObj) fppl))
 
 specialCommandRegister :: String -> XObj -> Maybe String -> StateT Context IO (Either EvalError XObj)
 specialCommandRegister name typeXObj overrideName =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          globalEnv = contextGlobalEnv ctx
      case xobjToTy typeXObj of
            Just t -> let path = SymPath pathStrings name
@@ -702,17 +711,18 @@ specialCommandRegister name typeXObj overrideName =
                                             Check -> let fppl = projectFilePathPrintLength (contextProj ctx)
                                                      in  machineReadableInfoFromXObj fppl typeXObj ++ " "
                                             _ -> ""
-                             in  return (Left (EvalError (prefix ++ err) (info typeXObj)))
+                             in  return (Left (EvalError (prefix ++ err) (info typeXObj) fppl))
                            Right ctx' ->
                              do put (ctx' { contextGlobalEnv = env' })
                                 return dynamicNil
            Nothing ->
-             return (Left (EvalError ("Can't understand type when registering '" ++ name ++ "'") (info typeXObj)))
+             return (Left (EvalError ("Can't understand type when registering '" ++ name ++ "'") (info typeXObj) fppl))
 
 specialCommandDefinterface :: XObj -> XObj -> StateT Context IO (Either EvalError XObj)
 specialCommandDefinterface nameXObj@(XObj (Sym path@(SymPath [] name) _) _ _) typeXObj =
   do ctx <- get
      let env = contextGlobalEnv ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          typeEnv = getTypeEnv (contextTypeEnv ctx)
      case xobjToTy typeXObj of
        Just t ->
@@ -730,7 +740,7 @@ specialCommandDefinterface nameXObj@(XObj (Sym path@(SymPath [] name) _) _ _) ty
                     return dynamicNil
        Nothing ->
          return (Left (EvalError ("Invalid type for interface '" ++ name ++ "': " ++
-                                   pretty typeXObj) (info typeXObj)))
+                                   pretty typeXObj) (info typeXObj) fppl))
 
 specialCommandDefdynamic :: String -> XObj -> XObj -> StateT Context IO (Either EvalError XObj)
 specialCommandDefdynamic name params body =
@@ -758,6 +768,7 @@ specialCommandDefmodule :: XObj -> String -> [XObj] -> StateT Context IO (Either
 specialCommandDefmodule xobj moduleName innerExpressions =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          env = contextGlobalEnv ctx
          typeEnv = contextTypeEnv ctx
          lastInput = contextLastInput ctx
@@ -770,7 +781,7 @@ specialCommandDefmodule xobj moduleName innerExpressions =
                       put (popModulePath ctxAfterModuleAdditions)
                       return dynamicNil -- TODO: propagate errors...
                  Just _ ->
-                   return (Left (EvalError ("Can't redefine '" ++ moduleName ++ "' as module") (info xobj)))
+                   return (Left (EvalError ("Can't redefine '" ++ moduleName ++ "' as module") (info xobj) fppl))
                  Nothing ->
                    do let parentEnv = getEnv env pathStrings
                           innerEnv = Env (Map.fromList []) (Just parentEnv) (Just moduleName) [] ExternalEnv 0
@@ -865,6 +876,7 @@ specialCommandMembers :: XObj -> StateT Context IO (Either EvalError XObj)
 specialCommandMembers target =
   do ctx <- get
      let typeEnv = contextTypeEnv ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
      case target of
            XObj (Sym path@(SymPath [] name) _) _ _ ->
              case lookupInEnv path (getTypeEnv typeEnv) of
@@ -876,14 +888,15 @@ specialCommandMembers target =
                  ->
                       return (Right (XObj (Arr (map (\(a, b) -> (XObj (Lst [a, b]) Nothing Nothing)) (pairwise members))) Nothing Nothing))
                _ ->
-                 return (Left (EvalError ("Can't find a struct type named '" ++ name ++ "' in type environment") (info target)))
+                 return (Left (EvalError ("Can't find a struct type named '" ++ name ++ "' in type environment") (info target) fppl))
            _ ->
-             return (Left (EvalError ("Can't get the members of non-symbol: " ++ pretty target) (info target)))
+             return (Left (EvalError ("Can't get the members of non-symbol: " ++ pretty target) (info target) fppl))
 
 specialCommandUse :: XObj -> SymPath -> StateT Context IO (Either EvalError XObj)
 specialCommandUse xobj path =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          env = contextGlobalEnv ctx
          e = getEnv env pathStrings
          useThese = envUseModules e
@@ -894,7 +907,7 @@ specialCommandUse xobj path =
          do put $ ctx { contextGlobalEnv = envReplaceEnvAt env pathStrings e' }
             return dynamicNil
        Nothing ->
-         return (Left (EvalError ("Can't find a module named '" ++ show path ++ "'") (info xobj)))
+         return (Left (EvalError ("Can't find a module named '" ++ show path ++ "'") (info xobj) fppl))
 
 specialCommandWith :: XObj -> SymPath -> [XObj] -> StateT Context IO (Either EvalError XObj)
 specialCommandWith xobj path forms =
@@ -916,6 +929,7 @@ specialCommandMetaSet :: SymPath -> String -> XObj -> StateT Context IO (Either 
 specialCommandMetaSet path key value =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          globalEnv = contextGlobalEnv ctx
      case lookupInEnv (consPath pathStrings path) globalEnv of
        Just (_, binder@(Binder _ xobj)) ->
@@ -930,7 +944,7 @@ specialCommandMetaSet path key value =
                                               (Just dummyInfo)
                                               (Just (VarTy "a"))))
            (SymPath _ _) ->
-             return (Left (EvalError ("Special command 'meta-set!' failed, can't find '" ++ show path ++ "'") (info value)))
+             return (Left (EvalError ("Special command 'meta-set!' failed, can't find '" ++ show path ++ "'") (info value) fppl))
        where
          setMetaOn :: Context -> Binder -> StateT Context IO (Either EvalError XObj)
          setMetaOn ctx binder@(Binder metaData xobj) =
@@ -948,6 +962,7 @@ specialCommandMetaGet :: SymPath -> String -> StateT Context IO (Either EvalErro
 specialCommandMetaGet path key =
   do ctx <- get
      let pathStrings = contextPath ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          globalEnv = contextGlobalEnv ctx
      case lookupInEnv (consPath pathStrings path) globalEnv of
        Just (_, Binder metaData _) ->
@@ -957,7 +972,7 @@ specialCommandMetaGet path key =
              Nothing ->
                return dynamicNil
        Nothing ->
-         return (Left (EvalError ("Special command 'meta' failed, can't find '" ++ show path ++ "'") Nothing))
+         return (Left (EvalError ("Special command 'meta' failed, can't find '" ++ show path ++ "'") Nothing fppl))
 
 
 
@@ -1011,14 +1026,14 @@ commandLoad [xobj@(XObj (Str path) _ _)] =
           Check ->
             (machineReadableInfoFromXObj (fppl ctx) xobj) ++ " Invalid path: '" ++ path ++ "'"
           _ -> "Invalid path: '" ++ path ++ "'") ++
-        "\n\nIf you tried loading an external package, try appending a version string (like `@master`)") (info xobj)
+        "\n\nIf you tried loading an external package, try appending a version string (like `@master`)") (info xobj) (fppl ctx)
     invalidPathWith ctx path stderr =
       Left $ EvalError
         ((case contextExecMode ctx of
           Check ->
             (machineReadableInfoFromXObj (fppl ctx) xobj) ++ " Invalid path: '" ++ path ++ "'"
           _ -> "Invalid path: '" ++ path ++ "'") ++
-        "\n\nI tried interpreting the statement as a git import, but got: " ++ stderr) (info xobj)
+        "\n\nI tried interpreting the statement as a git import, but got: " ++ stderr) (info xobj) (fppl ctx)
     tryInstall path =
       let split = splitOn "@" path
       in tryInstallWithCheckout (joinWith "@" (init split)) (last split)
@@ -1068,8 +1083,10 @@ commandLoad [xobj@(XObj (Str path) _ _)] =
                   Left _ ->  commandLoad [XObj (Str mainToLoad) Nothing Nothing]
             ExitFailure _ -> do
                 return $ invalidPathWith ctx path stderr1
-commandLoad [x] =
-  return $ Left (EvalError ("Invalid args to 'load' command: " ++ pretty x) (info x))
+commandLoad [x] = do
+  ctx <- get
+  let fppl = projectFilePathPrintLength (contextProj ctx)
+  return $ Left (EvalError ("Invalid args to 'load' command: " ++ pretty x) (info x) fppl)
 
 
 -- | Load several files in order.
@@ -1116,13 +1133,14 @@ commandC :: CommandCallback
 commandC [xobj] =
   do ctx <- get
      let globalEnv = contextGlobalEnv ctx
+         fppl = projectFilePathPrintLength (contextProj ctx)
          typeEnv = contextTypeEnv ctx
      result <- expandAll eval globalEnv xobj
      case result of
-       Left err -> return (Left (EvalError (show err) (info xobj)))
+       Left err -> return (Left (EvalError (show err) (info xobj) fppl))
        Right expanded ->
          case annotate typeEnv globalEnv (setFullyQualifiedSymbols typeEnv globalEnv globalEnv expanded) of
-           Left err -> return (Left (EvalError (show err) (info xobj)))
+           Left err -> return (Left (EvalError (show err) (info xobj) fppl))
            Right (annXObj, annDeps) ->
              do liftIO (printC annXObj)
                 liftIO (mapM printC annDeps)

--- a/src/GenerateConstraints.hs
+++ b/src/GenerateConstraints.hs
@@ -222,7 +222,7 @@ genConstraints typeEnv root = fmap sort (gen root)
                            let Just headTy = ty x
                                genObj o n = XObj (Sym (SymPath [] ("Whereas the " ++ enumerate n ++ " element in the array is " ++ show (getPath o))) Symbol)
                                   (info o) (ty o)
-                               headObj = XObj (Sym (SymPath [] ("I inferred the type of the array from the first element of the array " ++ show (getPath x))) Symbol)
+                               headObj = XObj (Sym (SymPath [] ("I inferred the type of the array from its first element " ++ show (getPath x))) Symbol)
                                   (info x) (Just headTy)
                                Just (StructTy "Array" [t]) = ty xobj
                                betweenExprConstraints = zipWith (\o n -> Constraint headTy (forceTy o) headObj (genObj o n) xobj OrdArrBetween) xs [1..]

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -118,7 +118,7 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
                                                             return (Right (xobj { ty = Just renamed }))
                              | otherwise -> return (Right (xobj { ty = Just theType }))
                 Nothing -> return (Left (SymbolMissingType xobj foundEnv))
-            Nothing -> return (Left (SymbolNotDefined symPath xobj)) -- Gives the error message "Trying to refer to an undefined symbol ..."
+            Nothing -> return (Left (SymbolNotDefined symPath xobj env)) -- Gives the error message "Trying to refer to an undefined symbol ..."
 
     visitMultiSym :: Env -> XObj -> [SymPath] -> State Integer (Either TypeError XObj)
     visitMultiSym _ xobj@(XObj (MultiSym name _) _ _) _ =

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -294,10 +294,12 @@ pretty = visit 0
             Interface _ _ -> "interface"
             With -> "with"
 
-newtype EvalError = EvalError String deriving (Eq)
+data EvalError = EvalError String (Maybe Info) deriving (Eq)
 
 instance Show EvalError where
-  show (EvalError msg) = msg
+  show (EvalError msg info) = msg ++ getInfo info
+    where getInfo (Just i) = " at " ++ prettyInfo i ++ "."
+          getInfo Nothing = ""
 
 -- | Get the type of an XObj as a string.
 typeStr :: XObj -> String

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -147,7 +147,7 @@ prettyInfoFromXObj xobj = case info xobj of
                             Nothing -> "no info"
 
 data FilePathPrintLength = FullPath
-                         | ShortPath
+                         | ShortPath deriving Eq
 
 instance Show FilePathPrintLength where
   show FullPath = "full"
@@ -294,11 +294,11 @@ pretty = visit 0
             Interface _ _ -> "interface"
             With -> "with"
 
-data EvalError = EvalError String (Maybe Info) deriving (Eq)
+data EvalError = EvalError String (Maybe Info) FilePathPrintLength deriving (Eq)
 
 instance Show EvalError where
-  show (EvalError msg info) = msg ++ getInfo info
-    where getInfo (Just i) = " at " ++ prettyInfo i ++ "."
+  show (EvalError msg info fppl) = msg ++ getInfo info
+    where getInfo (Just i) = " at " ++ machineReadableInfo fppl i ++ "."
           getInfo Nothing = ""
 
 -- | Get the type of an XObj as a string.

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -148,7 +148,7 @@ instance Show TypeError where
     "I found the following holes:\n\n    " ++
     joinWith "\n    " (map (\(name, t) -> name ++ " : " ++ show t) holes) ++
     "\n"
-  show (FailedToExpand xobj err@(EvalError _ _)) =
+  show (FailedToExpand xobj err@(EvalError _ _ _)) =
     "I failed to expand a macro at " ++ prettyInfoFromXObj xobj ++
     ".\n\nThe error message I got was: " ++ show err
   show (NotAValidType xobj) =
@@ -273,7 +273,7 @@ machineReadableErrorStrings fppl err =
     -- (HolesFound holes) ->
     --   (map (\(name, t) -> machineReadableInfoFromXObj fppl xobj ++ " " ++ name ++ " : " ++ show t) holes)
 
-    (FailedToExpand xobj (EvalError errorMessage _)) ->
+    (FailedToExpand xobj (EvalError errorMessage _ _)) ->
       [machineReadableInfoFromXObj fppl xobj ++ "Failed to expand: " ++ errorMessage]
 
     -- TODO: Remove overlapping errors:

--- a/test/output/test-for-errors/no_forms_in_match.carp.output.expected
+++ b/test/output/test-for-errors/no_forms_in_match.carp.output.expected
@@ -1,1 +1,1 @@
-No forms in match-expression: no_forms_in_match.carp:4:3
+I encountered a `match` without forms at no_forms_in_match.carp:4:3.

--- a/test/output/test-for-errors/type_mismatch.carp.output.expected
+++ b/test/output/test-for-errors/type_mismatch.carp.output.expected
@@ -1,2 +1,2 @@
-type_mismatch.carp:4:13 20.0f : Float, can't unify with Int.
-type_mismatch.carp:4:4 Expected second argument to 'Int.+' : Int, can't unify with Float.
+type_mismatch.carp:4:13 Inferred Float, can't unify with Int.
+type_mismatch.carp:4:4 Inferred Int, can't unify with Float.

--- a/test/output/test-for-errors/uneven_nr_of_forms_in_match.carp.output.expected
+++ b/test/output/test-for-errors/uneven_nr_of_forms_in_match.carp.output.expected
@@ -1,1 +1,1 @@
-Uneven number of forms in match-expression: uneven_nr_of_forms_in_match.carp:4:3
+I encountered an odd number of forms inside a `match` at uneven_nr_of_forms_in_match.carp:4:3.


### PR DESCRIPTION
This PR adds some more better error messages and, as such, build on #394 and #395.

Some highlights:

```
Invalid type definition for 'x':

The number of members and types is uneven: 'a' at line 1, column 13 in '/Users/veitheller/Documents/Code/Github/carp/carp/t.carp'.

Because they are pairs of names and their types, they need to be even.
Did you forget a name or type?
```

```
I didn’t understand the `defn` at line 1, column 1 in '/Users/veitheller/Documents/Code/Github/carp/carp/t.carp':

(defn x [a b c d] a b c)

Is it valid? Every `defn` needs to follow the form `(defn name [arg] body)`.
```

```
I couldn’t find the symbol 'Array.ast' at line 15, column 12 in '/Users/veitheller/Documents/Code/Github/carp/carp/t.carp'.

Maybe you wanted one of the following?
    Array.aset
    Array.aset!
    Array.last
    Array.str
```

```
`defn` requires all arguments to be symbols, but it got `["hi"]` at line 1, column 1 in '/Users/veitheller/Documents/Code/Github/carp/carp/t2.carp'.
```

Cheers