### PR TITLE
Change "defdynamic" to "defndynamic" in guide

### DIFF
--- a/docs/LanguageGuide.md
+++ b/docs/LanguageGuide.md
@@ -60,7 +60,7 @@ foo ; symbol
 (definterface interface-name (Fn [<t1> <t2>] <return>)) ;; Define a generic function that can have multiple implementations
 (def variable-name value) ;; Define a global variable (only handles primitive constants for the moment)
 (defmacro <name> [<arg1> <arg2> ...] <macro-body>) ;; Define a macro, its argument will not be evaluated when called
-(defdynamic <name> [<arg1> <arg2> ...] <function-body>) ;; A function that can only be used at the REPL or during compilation
+(defndynamic <name> [<arg1> <arg2> ...] <function-body>) ;; A function that can only be used at the REPL or during compilation
 (defmodule <name> <definition1> <definition2> ...) ;; The main way to organize your program into smaller parts
 ```
 


### PR DESCRIPTION
Based on the docs, I expected that `defdynamic` would allow me to define and use a function at the REPL. Instead I got the following error:

```
> (defdynamic square [x]
     (* x x))
Invalid args to `defdynamic`: (defdynamic square [x] (* x x))
(did you try to define a dynamic function - use 'defndynamic' instead) at REPL:1:1.
```

Definitely props on the helpfulness of the error message, which makes this an easily overcome issue. However, I'd like to propose this change to the guide so that any other newcomers don't hit a bump the first time they try something.