### PR TITLE
Make `Array.range` more general

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -216,7 +216,7 @@ Returns `Nothing` if the array is empty.")
   ; cannot use for, because we want also be able to go downwards
   (doc range "creates an array from `start` to `end` with `step` between them (the elements must support `<`, `<=`, and `>=`).")
   (defn range [start end step]
-    (let-do [x (allocate (Int.inc (Int.abs (/ (- end start) step))))
+    (let-do [x (allocate (Int.inc (Int.abs (to-int (/ (- end start) step)))))
              e start
              i 0
              op (if (< start end) <= >=)]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -214,7 +214,7 @@ Returns `Nothing` if the array is empty.")
       (aset! a j x)))
 
   ; cannot use for, because we want also be able to go downwards
-  (doc range "creates an array from `start` to `end` with `step` between them (the elements must support `<`, `<=`, and `>=`).")
+  (doc range "creates an array from `start` to `end` with `step` between them (the elements must support `<`, `<=`, `>=`, and `to-int`).")
   (defn range [start end step]
     (let-do [x (allocate (Int.inc (Int.abs (to-int (/ (- end start) step)))))
              e start

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -60,6 +60,14 @@
       (if (> 0 r)
         (+ r n)
         r)))
+
+  (doc to-int "acts as the identity function to implement the interface.")
+  (sig to-int (Fn [Int] Int))
+  (defn to-int [a] a)
+
+  (doc from-int "acts as the identity function to implement the interface.")
+  (sig from-int (Fn [Int] Int))
+  (defn from-int [a] a)
 )
 
 (defmodule IntRef

--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -24,6 +24,9 @@
 (definterface inc (λ [a] a))
 (definterface dec (λ [a] a))
 
+(definterface to-int (λ [a] Int))
+(definterface from-int (λ [Int] a))
+
 (definterface format (λ [&String a] String))
 (definterface from-string (λ [&String] a))
 

--- a/core/Random.carp
+++ b/core/Random.carp
@@ -66,10 +66,10 @@
 
 (defmodule Char
   (defn random []
-    (from-int (Int.random)))
+    (Char.from-int (Int.random)))
 
   (defn random-between [a b]
-    (from-int (Int.random-between (to-int a) (to-int b))))
+    (Char.from-int (Int.random-between (Char.to-int a) (Char.to-int b))))
 )
 
 (defmodule String

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -857,13 +857,13 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, Int, Int] (Array Int))
+                    (λ [a, a, a] (Array a))
                 </p>
                 <pre class="args">
                     (range start end step)
                 </pre>
                 <p class="doc">
-                    <p>creates an array from <code>start</code> to <code>end</code> with <code>step</code> between them (the elements must support <code>&lt;</code>, <code>&lt;=</code>, and <code>&gt;=</code>).</p>
+                    <p>creates an array from <code>start</code> to <code>end</code> with <code>step</code> between them (the elements must support <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;=</code>, and <code>to-int</code>).</p>
 
                 </p>
             </div>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -577,6 +577,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#from-int">
+                    <h3 id="from-int">
+                        from-int
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a] a)
+                </p>
+                <pre class="args">
+                    (from-int a)
+                </pre>
+                <p class="doc">
+                    <p>acts as the identity function to implement the interface.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#from-string">
                     <h3 id="from-string">
                         from-string
@@ -845,6 +865,26 @@
                 </span>
                 <p class="doc">
                     
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#to-int">
+                    <h3 id="to-int">
+                        to-int
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a] a)
+                </p>
+                <pre class="args">
+                    (to-int a)
+                </pre>
+                <p class="doc">
+                    <p>acts as the identity function to implement the interface.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -247,7 +247,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double))] Double)
+                    (λ [(Ref (Array a))] a)
                 </p>
                 <pre class="args">
                     (mean data)

--- a/test/array.carp
+++ b/test/array.carp
@@ -112,6 +112,10 @@
                 &(range 10 15 1)
                 "range works as expected")
   (assert-equal test
+                &[10.0 10.5 11.0 11.5 12.0]
+                &(range 10.0 12.0 0.5)
+                "range works as expected on non-integers")
+  (assert-equal test
                 &[10 9 8 7 6 5 4 3 2 1 0]
                 &(range 10 0 -1)
                 "range backwards works as expected")


### PR DESCRIPTION
This PR generalizes `Array.range`. Prior to this change, `Array.range` assumed that we could use some `Int` functions on the input that prevented it from being generalized. By using `to-int` and making `to-int` and `from-int` interfaces, we can use other types in the function as well, and do cool stuff like `(Array.range 0.0 10.0 0.5)`!

A test case is included.

Cheers