### PR TITLE
REPL: better autocompletion based on starting environment

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import Repl
 import StartingEnv
 import Eval
 import Util
+import Lookup
 
 defaultProject :: Project
 defaultProject =
@@ -27,7 +28,7 @@ defaultProject =
           , projectLibDir = ".carp/libs/"
           , projectCarpDir = "./"
           , projectOutDir = case platform of
-                              Windows -> ".\\out" 
+                              Windows -> ".\\out"
                               _ -> "./out"
           , projectDocsDir = "./docs/"
           , projectDocsLogo = ""
@@ -83,7 +84,7 @@ main = do setLocaleEncoding utf8
                       else do --putStrLn ("No '" ++ carpProfile ++ "' found.")
                               return context
           finalContext <- loadFiles context' argFilesToLoad
-          settings <- readlineSettings
+          settings <- readlineSettings (bindingNames $ contextGlobalEnv finalContext)
           case execMode of
             Repl -> do putStrLn "Welcome to Carp 0.2.0"
                        putStrLn "This is free software with ABSOLUTELY NO WARRANTY."

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -225,3 +225,9 @@ keysInEnvEditDistance path@(SymPath (p : ps) name) env distance =
       case envParent env of
         Just parent -> keysInEnvEditDistance path parent distance
         Nothing -> []
+
+bindingNames :: Env -> [String]
+bindingNames = concatMap select . envBindings
+  where select :: Binder -> [String]
+        select (Binder _ (XObj (Mod i) _ _)) = bindingNames i
+        select (Binder _ obj) = [getName obj]

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -20,8 +20,8 @@ import ColorText
 import Eval
 import Parsing (balance)
 
-completeKeywords :: Monad m => String -> String -> m [Completion]
-completeKeywords _ word = return $ findKeywords word keywords []
+completeKeywordsAnd :: Monad m => [String ] -> String -> String -> m [Completion]
+completeKeywordsAnd words _ word = return $ findKeywords word (words ++ keywords) []
   where
         findKeywords match [] res = res
         findKeywords match (x : xs) res =
@@ -67,11 +67,11 @@ completeKeywords _ word = return $ findKeywords word keywords []
                    ]
 
 
-readlineSettings :: Monad m => IO (Settings m)
-readlineSettings = do
+readlineSettings :: Monad m => [String] -> IO (Settings m)
+readlineSettings words = do
   home <- getHomeDirectory
   return $ Settings {
-    complete = completeWordWithPrev Nothing ['(', ')', '[', ']', ' ', '\t', '\n'] completeKeywords,
+    complete = completeWordWithPrev Nothing ['(', ')', '[', ']', ' ', '\t', '\n'] (completeKeywordsAnd words),
     historyFile = Just $ home ++ "/.carp/history",
     autoAddHistory = True
   }


### PR DESCRIPTION
This PR injects the starting environment into the REPL autocompletion. This means that all standard functions can now be autocompleted.

You can try this out by typing `In` in your REPL, having it autocomplete (by hitting TAB) to `Int.`, and then, if you hit TAB again, see a list of functions defined in the `Int` module!

Cheers