### PR TITLE
core: add Symbol.join

### DIFF
--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -310,6 +310,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#Sym">
+                    <h3 id="Sym">
+                        Sym
+                    </h3>
+                </a>
+                <div class="description">
+                    module
+                </div>
+                <p class="sig">
+                    
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#all-but-last">
                     <h3 id="all-but-last">
                         all-but-last

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -693,6 +693,16 @@ commandStringJoin [a] =
     _ ->
       Left (EvalError ("Can't call join with " ++ pretty a) (info a))
 
+commandSymJoin :: CommandCallback
+commandSymJoin [a] =
+  return $ case a of
+    XObj (Arr syms) _ _ ->
+      case (sequence (map unwrapSymPathXObj syms)) of
+        Left err -> Left (EvalError err (info a))
+        Right result -> Right (XObj (Sym (SymPath [] (join (map show result))) (LookupGlobal CarpLand AVariable)) (Just dummyInfo) Nothing)
+    _ ->
+      Left (EvalError ("Can't call join with " ++ pretty a) (info a))
+
 commandStringDirectory :: CommandCallback
 commandStringDirectory [a] =
   return $ case a of

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -238,6 +238,7 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "save-docs-internal" 1 commandSaveDocsInternal
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
+                       ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))
                        ,("Project", Binder emptyMeta (XObj (Mod dynamicProjectModule) Nothing Nothing))
                        ]
 
@@ -255,6 +256,17 @@ dynamicStringModule = Env { envBindings = bindings
                                 , addCommand "length" 1 commandStringLength
                                 , addCommand "join" 1 commandStringJoin
                                 , addCommand "directory" 1 commandStringDirectory
+                                ]
+
+-- | A submodule of the Dynamic module. Contains functions for working with symbolss in the repl or during compilation.
+dynamicSymModule :: Env
+dynamicSymModule = Env { envBindings = bindings
+                       , envParent = Nothing
+                       , envModuleName = Just "Sym"
+                       , envUseModules = []
+                       , envMode = ExternalEnv
+                       , envFunctionNestingLevel = 0 }
+  where bindings = Map.fromList [ addCommand "join" 1 commandSymJoin
                                 ]
 
 -- | A submodule of the Dynamic module. Contains functions for working with the active Carp project.

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -31,6 +31,10 @@
 (defndynamic gc- [key] (Project.get-config key))
 (defmacro gc [key] (gc- key))
 
+(def xy 1)
+(defndynamic test-join- [] (Symbol.join ['x 'y]))
+(defmacro test-join [] (test-join-))
+
 (deftest test
   (assert-true test
                (test-do-let)
@@ -176,4 +180,9 @@
   (assert-equal test
                 "Untitled"
                 (gc "title")
-                "Project.get-config works as expected II"))
+                "Project.get-config works as expected II")
+  (assert-equal test
+                1
+                (test-join)
+                "Symbol.join works as expected")
+)


### PR DESCRIPTION
This PR adds the dynamic function `Symbol.join`. It can be used to prefix or suffix symbols inside dynamic functions or macros, for instance.

A test case is included.

Cheers