### PR TITLE
Remove headers that are problematic for embedded applications

### DIFF
--- a/core/carp_int.h
+++ b/core/carp_int.h
@@ -1,5 +1,4 @@
 #include <limits.h>
-#include <math.h>
 #include "carp_stdbool.h"
 
 int CARP_INT_MAX = INT_MAX;

--- a/core/core.h
+++ b/core/core.h
@@ -8,7 +8,6 @@
 #include <stddef.h>
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 #include <windows.h>
-#else
 #endif
 
 typedef char* String;

--- a/core/core.h
+++ b/core/core.h
@@ -1,15 +1,15 @@
 #ifndef PRELUDE_H
 #define PRELUDE_H
 
+#ifndef OPTIMIZE
 #include <assert.h>
+#endif
 #include "carp_stdbool.h"
 #include <stddef.h>
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 #include <windows.h>
 #else
-#include <sys/wait.h>
 #endif
-#include <signal.h>
 
 typedef char* String;
 typedef char* Pattern;


### PR DESCRIPTION
This PR removes some headers—or makes them conditional—that are either unnecessary or only needed under certain circumstances (like `assert`, which is only used for unoptimized builds).

The test cases still compile and run, so this should be fine.

Cheers

CC @mathk