### PR TITLE
Require defn symbols to be unqualified

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -164,12 +164,13 @@ eval env xobj =
 
         [defnExpr@(XObj Defn _ _), name, args@(XObj (Arr a) _ _), body] ->
             case (obj name) of
-              (Sym _ _) -> if all isSym a
-                           then specialCommandDefine xobj
-                           else return (makeEvalError ctx Nothing ("`defn` requires all arguments to be symbols, but it got `" ++ pretty args ++ "`") (info xobj))
-                        where isSym (XObj (Sym _ _) _ _) = True
-                              isSym _ = False
-              _         -> return (makeEvalError ctx Nothing ("`defn` identifiers must be symbols, but it got `" ++ pretty name ++ "`") (info xobj))
+              (Sym (SymPath [] _) _) ->
+                  if all isSym a
+                  then specialCommandDefine xobj
+                  else return (makeEvalError ctx Nothing ("`defn` requires all arguments to be unqualified symbols, but it got `" ++ pretty args ++ "`") (info xobj))
+                  where isSym (XObj (Sym (SymPath [] _) _) _ _) = True
+                        isSym _ = False
+              _                      -> return (makeEvalError ctx Nothing ("`defn` identifiers must be unqualified symbols, but it got `" ++ pretty name ++ "`") (info xobj))
 
         [defnExpr@(XObj Defn _ _), name, invalidArgs, _] ->
             return (makeEvalError ctx Nothing ("`defn` requires an array of symbols as argument list, but it got `" ++ pretty invalidArgs ++ "`") (info xobj))


### PR DESCRIPTION
This PR follows up on #419 and makes sure that all symbols put in the head of `defn`s are unqualified.

Cheers

CC @scolsen 