### PR TITLE
Return an error on invalid the expression

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -186,6 +186,9 @@ eval env xobj =
              return $ do okValue <- evaledValue
                          Right (XObj (Lst [theExpr, typeXObj, okValue]) i t)
 
+        (XObj The _ _ : _) ->
+            return (makeEvalError ctx Nothing ("I didn’t understand the `the` at " ++ prettyInfoFromXObj xobj ++ ":\n\n" ++ pretty xobj ++ "\n\nIs it valid? Every `the` needs to follow the form `(the type expression)`.") Nothing)
+
         [letExpr@(XObj Let _ _), XObj (Arr bindings) bindi bindt, body] ->
           if even (length bindings)
           then do bind <- mapM (\(n, x) -> do x' <- eval env x

--- a/src/Expand.hs
+++ b/src/Expand.hs
@@ -60,6 +60,8 @@ expand eval env xobj =
           do expandedValue <- expand eval env value
              return $ do okValue <- expandedValue
                          Right (XObj (Lst [theExpr, typeXObj, okValue]) i t)
+        (XObj The _ _ : _) ->
+            return (makeEvalError ctx Nothing ("I didn’t understand the `the` at " ++ prettyInfoFromXObj xobj ++ ":\n\n" ++ pretty xobj ++ "\n\nIs it valid? Every `the` needs to follow the form `(the type expression)`.") Nothing)
         [ifExpr@(XObj If _ _), condition, trueBranch, falseBranch] ->
           do expandedCondition <- expand eval env condition
              expandedTrueBranch <- expand eval env trueBranch


### PR DESCRIPTION
This PR fixes #421 by returning an error on invalid `the` expressions instead of trying to expand them.

`the` expressions with invalid bodies are now detected everywhere, and appropriate error messages are returned.

Cheers