### PR TITLE
Return errors on non unqualified symbol identifiers for def and deftype

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -165,11 +165,9 @@ eval env xobj =
         [defnExpr@(XObj Defn _ _), name, args@(XObj (Arr a) _ _), body] ->
             case (obj name) of
               (Sym (SymPath [] _) _) ->
-                  if all isSym a
+                  if all isUnqualifiedSym a
                   then specialCommandDefine xobj
                   else return (makeEvalError ctx Nothing ("`defn` requires all arguments to be unqualified symbols, but it got `" ++ pretty args ++ "`") (info xobj))
-                  where isSym (XObj (Sym (SymPath [] _) _) _ _) = True
-                        isSym _ = False
               _                      -> return (makeEvalError ctx Nothing ("`defn` identifiers must be unqualified symbols, but it got `" ++ pretty name ++ "`") (info xobj))
 
         [defnExpr@(XObj Defn _ _), name, invalidArgs, _] ->
@@ -182,8 +180,6 @@ eval env xobj =
           if isUnqualifiedSym name
           then specialCommandDefine xobj
           else return (makeEvalError ctx Nothing ("`def` identifiers must be unqualified symbols, but it got `" ++ pretty name ++ "`") (info xobj))
-          where isUnqualifiedSym (XObj (Sym (SymPath [] _) _) _ _) = True
-                isUnqualifiedSym _ = False
 
         [theExpr@(XObj The _ _), typeXObj, value] ->
           do evaledValue <- expandAll eval env value -- TODO: Why expand all here?
@@ -224,9 +220,7 @@ eval env xobj =
           (XObj (Arr a) _ _ : _) -> if all isUnqualifiedSym (map fst (members a))
                                    then specialCommandDeftype nameXObj rest
                                    else return (makeEvalError ctx Nothing ("Type members must be unqualified symbols, but got `" ++ (concat (map pretty rest)) ++ "`") (info xobj))
-                                   where isUnqualifiedSym (XObj (Sym (SymPath [] _) _) _ _) = True
-                                         isUnqualifiedSym _ = False
-                                         members (binding:val:xs) = (binding, val):members xs
+                                   where members (binding:val:xs) = (binding, val):members xs
                                          members [] = []
           _ -> specialCommandDeftype nameXObj rest
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -179,7 +179,11 @@ eval env xobj =
             return (makeEvalError ctx Nothing ("I didn’t understand the `defn` at " ++ prettyInfoFromXObj xobj ++ ":\n\n" ++ pretty xobj ++ "\n\nIs it valid? Every `defn` needs to follow the form `(defn name [arg] body)`.") Nothing)
 
         [defExpr@(XObj Def _ _), name, expr] ->
-          specialCommandDefine xobj
+          if isUnqualifiedSym name
+          then specialCommandDefine xobj
+          else return (makeEvalError ctx Nothing ("`def` identifiers must be unqualified symbols, but it got `" ++ pretty name ++ "`") (info xobj))
+          where isUnqualifiedSym (XObj (Sym (SymPath [] _) _) _ _) = True
+                isUnqualifiedSym _ = False
 
         [theExpr@(XObj The _ _), typeXObj, value] ->
           do evaledValue <- expandAll eval env value -- TODO: Why expand all here?

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -771,3 +771,8 @@ wrapInParens xobj@(XObj _ i t) =
 isVarName :: String -> Bool
 isVarName (firstLetter:_) =
   not (isUpper firstLetter) -- This allows names beginning with special chars etc. to be OK for vars
+
+-- | Is the given XObj an unqualified symbol.
+isUnqualifiedSym :: XObj -> Bool
+isUnqualifiedSym (XObj (Sym (SymPath [] _) _) _ _) = True
+isUnqualifiedSym _ = False


### PR DESCRIPTION
I've added a few more checks to `Eval.hs` to ensure the identifiers passed to `def` and `deftype` members (e.g. `(deftype Name <[members Int]>)`) are unqualified symbols. This prevents the evaluator from allowing instances in which, for example, Nums are passed to defs, `(def 4 5)`, resulting in invalid C. 

@eriksvedang @hellerve Let me know what you think!

...also, let me know if there are other cases we should catch with this. If not, we can probably close up #414 once this looks ok!