### PR TITLE
docs: Make generating index.html optional

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -34,6 +34,7 @@ defaultProject =
           , projectDocsLogo = ""
           , projectDocsPrelude = ""
           , projectDocsURL = ""
+          , projectDocsGenerateIndex = True
           , projectDocsStyling = "carp_style.css"
           , projectPrompt = case platform of
                               MacOS -> "鲮 "

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -135,6 +135,9 @@ commandProjectConfig [xobj@(XObj (Str key) _ _), value] =
                                               return (proj { projectOutDir = outDir })
                      "docs-directory" -> do docsDir <- unwrapStringXObj value
                                             return (proj { projectDocsDir = docsDir })
+                     "docs-generate-index" ->
+                       do docsGenerateIndex <- unwrapBoolXObj value
+                          return (proj { projectDocsGenerateIndex = docsGenerateIndex })
                      "docs-logo" -> do logo <- unwrapStringXObj value
                                        return (proj { projectDocsLogo = logo })
                      "docs-prelude" -> do prelude <- unwrapStringXObj value
@@ -182,6 +185,7 @@ commandProjectGetConfig [xobj@(XObj (Str key) _ _)] =
           "docs-logo" -> Right $ Str $ projectDocsLogo proj
           "docs-prelude" -> Right $ Str $ projectDocsPrelude proj
           "docs-url" -> Right $ Str $ projectDocsURL proj
+          "docs-generate-index" -> Right $ Bol $ projectDocsGenerateIndex proj
           "docs-styling" -> Right $ Str $ projectDocsStyling proj
           "file-path-print-length" -> Right $ Str $ show (projectFilePathPrintLength proj)
           "generate-only" -> Right $ Str $ show (projectGenerateOnly proj)
@@ -418,6 +422,7 @@ commandHelp [XObj(Str "project") _ _] =
               putStrLn "'docs-logo'          - Location of the documentation logo."
               putStrLn "'docs-prelude'       - The documentation foreword."
               putStrLn "'docs-url'           - A URL for the project (useful for generated documentation)."
+              putStrLn "'docs-generate-index'- Whether to generate the documentation index."
               putStrLn "'docs-styling'        - A URL to CSS for the project documentation."
               putStrLn "'prompt'             - Set the prompt in the repl."
               putStrLn "'search-path'        - Add a path where the Carp compiler will look for '*.carp' files."

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -495,6 +495,7 @@ data Project = Project { projectTitle :: String
                        , projectDocsLogo :: FilePath
                        , projectDocsPrelude :: String
                        , projectDocsURL :: String
+                       , projectDocsGenerateIndex :: Bool
                        , projectDocsStyling :: String
                        , projectPrompt :: String
                        , projectCarpSearchPaths :: [FilePath]
@@ -526,6 +527,7 @@ instance Show Project where
         docsLogo
         docsPrelude
         docsURL
+        docsGenerateIndex
         docsStyling
         prompt
         searchPaths
@@ -552,6 +554,7 @@ instance Show Project where
             , "Docs logo: " ++ docsLogo
             , "Docs prelude: " ++ docsPrelude
             , "Docs Project URL: " ++ docsURL
+            , "Docs generate index: " ++ show docsGenerateIndex
             , "Docs CSS URL: " ++ docsStyling
             , "Library directory: " ++ libDir
             , "CARP_DIR: " ++ carpDir

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -22,9 +22,13 @@ saveDocsForEnvs :: Project -> [(SymPath, Env)] -> IO ()
 saveDocsForEnvs ctx envs =
   let dir = projectDocsDir ctx
       title = projectTitle ctx
+      generateIndex = projectDocsGenerateIndex ctx
       allEnvNames = (fmap (getModuleName . snd) envs)
   in  do mapM_ (saveDocsForEnv ctx allEnvNames) envs
-         writeFile (dir ++ "/" ++ title ++ "_index.html") (projectIndexPage ctx allEnvNames)
+         if generateIndex
+         then writeFile (dir ++ "/" ++ title ++ "_index.html")
+                        (projectIndexPage ctx allEnvNames)
+         else return ()
          putStrLn ("Generated docs to '" ++ dir ++ "'")
 
 


### PR DESCRIPTION
This PR introduces the Project configuration variable `docs-generate-index`, which is a boolean indicating whether the index file should be generated. I often do not want to generate it for many of my projects, so I manually have to delete the file after generation afterwards.

This PR is part of my ongoing work on #374.

Cheers