### PR TITLE
Add while-do macro

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -218,6 +218,10 @@
   (list 'let bindings
     (cons 'do forms)))
 
+(defmacro while-do [condition :rest forms]
+  (list 'while condition
+    (cons 'do forms)))
+
 (defmacro defn-do [name arguments :rest body]
   (list 'defn name arguments (cons 'do body)))
 

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -1,10 +1,18 @@
 (load "Test.carp")
 (use Test)
 
-(defn test-do-let []
+(defn test-let-do []
   (let-do [x 1]
     (set! x (+ x 1))
     (= x 2)))
+
+(defn test-while-do []
+  (let-do [i 0
+           x 0]
+    (while-do (< i 10)
+      (set! x (+ x 2))
+      (set! i (+ i 1)))
+    (= x 20)))
 
 (defn test-comment []
   (let-do [x 1]
@@ -37,8 +45,11 @@
 
 (deftest test
   (assert-true test
-               (test-do-let)
-               "do-let works as expected")
+               (test-let-do)
+               "let-do works as expected")
+  (assert-true test
+               (test-while-do)
+               "while-do works as expected")
   (assert-true test
                (test-case-dflt)
                "case correctly selects default")


### PR DESCRIPTION
This PR adds the `while-do` macro to accompany the existing `let-do` and `defn-do`.

Test cases are included.

Cheers