### PR TITLE
Add Maybe.ptr and Maybe.from-ptr

### DIFF
--- a/core/Maybe.carp
+++ b/core/Maybe.carp
@@ -44,4 +44,18 @@ It is the inverse of [`just?`](#just?).")
         (match @b
           (Nothing) false
           (Just y) (= x y))))
+
+  (doc ptr "Creates a `(Ptr a)` from a `(Maybe a)`. If the `Maybe` was
+`Nothing`, this function will return a `NULL` value.")
+  (defn ptr [a]
+    (match a
+      (Nothing) NULL
+      (Just x) (address x)))
+
+ (doc from-ptr "Creates a `(Maybe a)` from a `(Ptr a)`. If the `Ptr` was
+`NULL`, this function will return `Nothing`.")
+ (defn from-ptr [a]
+   (if (null? a)
+     (Nothing)
+     (Just @(Pointer.to-ref a))))
 )

--- a/test/maybe.carp
+++ b/test/maybe.carp
@@ -53,4 +53,23 @@
                 &(to-result (Nothing) @"error")
                 "to-result works on Nothing"
   )
+  (assert-equal test
+                1
+                @(Pointer.to-ref (ptr (Just 1)))
+                "ptr works on Just"
+  )
+  (assert-true test
+               (null? (ptr (the (Maybe Int) (Nothing))))
+               "ptr works on Nothing"
+  )
+  (assert-equal test
+                &(Just 0)
+                &(from-ptr (address (zero)))
+                "from-ptr works on Ptr/Just"
+  )
+  (assert-equal test
+                &(Nothing)
+                &(the (Maybe Int) (from-ptr NULL))
+                "from-ptr works on NULL/Nothing"
+  )
 )


### PR DESCRIPTION
This PR adds `Maybe.ptr` and `Maybe.from-ptr`, which convert Maybe values to pointers (and `Nothing` to `NULL`). This shoudl fix #287, although it isn’t quite automatic conversion.

Test cases are included.

Cheers