### PR TITLE
Add Pair.reverse and Map.reverse

### DIFF
--- a/core/Map.carp
+++ b/core/Map.carp
@@ -276,6 +276,9 @@
                          @"{"
                          m)]
       (String.append &res " }")))
+
+  (defn reverse [m]
+    (from-array &(Array.copy-map &Pair.reverse &(to-array m))))
 )
 
 (deftype (SetBucket a) [entries (Array a)])

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -277,6 +277,7 @@
                          m)]
       (String.append &res " }")))
 
+  (doc reverse "reverses they keys and values in a given map `m`.")
   (defn reverse [m]
     (from-array &(Array.copy-map &Pair.reverse &(to-array m))))
 )

--- a/core/Tuples.carp
+++ b/core/Tuples.carp
@@ -33,4 +33,7 @@
   (defn > [p1 p2]
     (PairRef.> &p1 &p2))
 
+  (doc reverse "reverses a `Pair` `p` such that its first member is its second member and vice versa.")
+  (defn reverse [p]
+    (Pair.init @(Pair.b p) @(Pair.a p)))
   )

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -611,6 +611,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#reverse">
+                    <h3 id="reverse">
+                        reverse
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Map a b))] (Map b a))
+                </p>
+                <pre class="args">
+                    (reverse m)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#set-buckets">
                     <h3 id="set-buckets">
                         set-buckets

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -626,7 +626,8 @@
                     (reverse m)
                 </pre>
                 <p class="doc">
-                    
+                    <p>reverses they keys and values in a given map <code>m</code>.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/test/map.carp
+++ b/test/map.carp
@@ -198,6 +198,11 @@
                 "Pairs work as keys"
   )
   (assert-equal test
+                &{1 @"hi" 2 @"bye"}
+                &(Map.reverse &{@"hi" 1 @"bye" 2})
+                "reverse works"
+  )
+  (assert-equal test
                 1
                 (Set.length &(Set.put (Set.create) "1"))
                 "length works"

--- a/test/tuples.carp
+++ b/test/tuples.carp
@@ -21,4 +21,9 @@
                "comparison works with (Ref (Pair String Int)) I")
   (assert-false test
                 (< &(Pair.init @"a" 2) &(Pair.init @"a" 1))
-                "comparison works with (Ref (Pair String Int)) II"))
+                "comparison works with (Ref (Pair String Int)) II")
+  (assert-equal test
+                &(Pair.init 2 @"a")
+                &(Pair.reverse &(Pair.init @"a" 2))
+                "reverse works")
+)


### PR DESCRIPTION
This PR adds `Pair.reverse` and `Map.reverse`. `Pair.reverse` switches the `a` and `b` members of a pair, whereas `Map.reverse` switches keys and values.

Test cases are included.

Cheers