### PR TITLE
Safe IO.read->EOF

### DIFF
--- a/core/IO.carp
+++ b/core/IO.carp
@@ -48,13 +48,15 @@
 
   (doc read->EOF "reads a file given by name until the End-Of-File character is reached.")
   (defn read->EOF [filename]
-    (let [f (IO.fopen filename "rb")
-          c (Char.from-int 0)
-          r []]
-      (do
-        (while (do (set! c (IO.fgetc f))
-                   (/= c IO.EOF))
-          (set! r (Array.push-back r c)))
-        (IO.fclose f)
-        (String.from-chars &r))))
+    (let [f (IO.fopen filename "rb")]
+      (if (null? f)
+        (Result.Error (fmt "File “%s” couldn’t be opened!" filename))
+        (let [c (Char.from-int 0)
+              r []]
+          (do
+            (while (do (set! c (IO.fgetc f))
+                       (/= c IO.EOF))
+              (set! r (Array.push-back r c)))
+            (IO.fclose f)
+            (Result.Success (String.from-chars &r)))))))
 )

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -565,7 +565,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [&amp;String] String)
+                    (λ [&amp;String] (Result String String))
                 </p>
                 <pre class="args">
                     (read-&gt;EOF filename)

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -25,4 +25,9 @@
                 @&Int.MAX
                 "test that the address of Int.MAX can be taken"
   )
+  (assert-equal test
+                &(Result.Error @"File “foobar” couldn’t be opened!")
+                &(IO.read->EOF "foobar")
+                "test that reading from an undefined file works"
+  )
 )


### PR DESCRIPTION
This PR fixes #286 by making the result of `IO.read->EOF` a `Result` type.

A regression test case is included.

Cheers