### PR TITLE
Make Array module safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ To build this example, save it to a file called 'example.carp' and load it with 
 [Veit Heller](http://veitheller.de) ([@hellerve](https://github.com/hellerve))
 
 ### Contributors
+* Markus Gustavsson
+* Fyodor Shchukin
 * Anes Lihovac
 * Chris Hall
-* Dan Connolly
-* Eric Shimizu Karbstein ([@GrayJack](https://github.com/GrayJack))
-* Fyodor Shchukin
-* Joel Kaasinen ([@opqdonut](https://github.com/opqdonut))
-* Jonas Granquist
-* Markus Gustavsson
-* Reini Urban
 * Tom Smeding
+* Dan Connolly
+* Reini Urban
+* Jonas Granquist
+* Joel Kaasinen ([@opqdonut](https://github.com/opqdonut))
+* Eric Shimizu Karbstein ([@GrayJack](https://github.com/GrayJack))
 
 Are you missing from the contributors list? Please send a pull request!
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,16 @@ To build this example, save it to a file called 'example.carp' and load it with 
 [Veit Heller](http://veitheller.de) ([@hellerve](https://github.com/hellerve))
 
 ### Contributors
-* Markus Gustavsson
-* Fyodor Shchukin
 * Anes Lihovac
 * Chris Hall
-* Tom Smeding
 * Dan Connolly
-* Reini Urban
-* Jonas Granquist
+* Eric Shimizu Karbstein ([@GrayJack](https://github.com/GrayJack))
+* Fyodor Shchukin
 * Joel Kaasinen ([@opqdonut](https://github.com/opqdonut))
+* Jonas Granquist
+* Markus Gustavsson
+* Reini Urban
+* Tom Smeding
 
 Are you missing from the contributors list? Please send a pull request!
 

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -173,11 +173,11 @@ If the array is empty, returns `Nothing`")
 
   (doc index-of "gets the index of element `e` in an array.")
   (defn index-of [a e]
-    (let-do [idx -1]
+    (let-do [idx (Maybe.Nothing)]
       (for [i 0 (length a)]
         (when (= (nth a i) e)
           (do
-            (set! idx i)
+            (set! idx (Maybe.Just i))
             (break))))
       idx))
 

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -111,30 +111,35 @@ Returns `Nothing` if the array is empty.")
     (not (= (the (Ref (Array a)) a) b)))
 
   ; TODO unsafe!
-  (doc maximum "gets the maximum in an array (elements must support `<`).")
-  (defn maximum [xs]
-    (let [result (unsafe-first xs)
-          n (length xs)]
-      (do
-        (for [i 1 n]
-          (let [x @(nth xs i)]
-            (if (< &result &x)
-              (set! result x)
-              ())))
-        result)))
+  (doc maximum "gets the maximum in an array (elements must support `<`)and wraps it in a `Just`.
 
-  ; TODO unsafe!
-  (doc minimum "gets the minimum in an array (elements must support `>`).")
+If the array is empty, returns `Nothing`")
+  (defn maximum [xs]
+    (let-do [result (first xs)
+          n (length xs)
+          res (Maybe.from @&result (zero))]
+      (for [i 0 n]
+        (let [x @(nth xs i)]
+          (when (< &res &x)
+            (do
+              (set! result (Maybe.Just x))
+              (set! res x)))))
+      result))
+
+  (doc minimum "gets the minimum in an array (elements must support `>`) and wraps it in a `Just`.
+
+If the array is empty, returns `Nothing`")
   (defn minimum [xs]
-    (let [result (unsafe-first xs)
-          n (length xs)]
-      (do
-        (for [i 1 n]
-          (let [x @(nth xs i)]
-            (if (> &result &x)
-              (set! result x)
-              ())))
-        result)))
+    (let-do [result (first xs)
+          n (length xs)
+          res (Maybe.from @&result (zero))]
+      (for [i 0 n]
+        (let [x @(nth xs i)]
+          (when (> &res &x)
+            (do
+              (set! res x)
+              (set! result (Maybe.Just x))))))
+      result))
 
   (doc sum "sums an array (elements must support `+` and `zero`).")
   (defn sum [xs]
@@ -142,11 +147,10 @@ Returns `Nothing` if the array is empty.")
 
   (doc subarray "gets a subarray from `start-index` to `end-index`.")
   (defn subarray [xs start-index end-index]
-    (let [result []]
-      (do
-        (for [i start-index end-index]
-          (set! result (push-back result @(nth xs i))))
-        result)))
+    (let-do [result []]
+      (for [i start-index end-index]
+        (set! result (push-back result @(nth xs i))))
+      result))
 
   (doc prefix-array "gets a prefix array to `end-index`.")
   (defn prefix-array [xs end-index]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -110,35 +110,33 @@ Returns `Nothing` if the array is empty.")
   (defn /= [a b]
     (not (= (the (Ref (Array a)) a) b)))
 
-  (doc maximum "gets the maximum in an array (elements must support `<` and `zero`)and wraps it in a `Just`.
+    (doc maximum "gets the maximum in an array (elements must support `<`) and wraps it in a `Just`.
+
+If the array is empty, it returns `Nothing`.")
+  (defn maximum [xs]
+    (if (empty? xs)
+      (Maybe.Nothing)
+      (let-do [result (nth xs 0)
+               n (length xs)]
+        (for [i 1 n]
+          (let [x (nth xs i)]
+            (when (< result x)
+              (set! result x))))
+        (Maybe.Just @result))))
+
+  (doc minimum "gets the minimum in an array (elements must support `>`) and wraps it in a `Just`.
 
 If the array is empty, returns `Nothing`")
   (defn maximum [xs]
-    (let-do [result (first xs)
-          n (length xs)
-          res (Maybe.from @&result (zero))]
-      (for [i 0 n]
-        (let [x @(nth xs i)]
-          (when (< &res &x)
-            (do
-              (set! result (Maybe.Just x))
-              (set! res x)))))
-      result))
-
-  (doc minimum "gets the minimum in an array (elements must support `>` and `zero`) and wraps it in a `Just`.
-
-If the array is empty, returns `Nothing`")
-  (defn minimum [xs]
-    (let-do [result (first xs)
-          n (length xs)
-          res (Maybe.from @&result (zero))]
-      (for [i 0 n]
-        (let [x @(nth xs i)]
-          (when (> &res &x)
-            (do
-              (set! res x)
-              (set! result (Maybe.Just x))))))
-      result))
+    (if (empty? xs)
+      (Maybe.Nothing)
+      (let-do [result (nth xs 0)
+             n (length xs)]
+        (for [i 1 n]
+          (let [x (nth xs i)]
+            (when (< result x)
+              (set! result x))))
+        (Maybe.Just @result))))
 
   (doc sum "sums an array (elements must support `+` and `zero`).")
   (defn sum [xs]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -41,13 +41,15 @@ It will sum the previous sum with each new value, starting at `0`.")
             (break))))
       res))
 
-  (doc find "finds an element in `a` that matches the function `f`.")
+  (doc find "finds an element in `a` that matches the function `f` and wraps it in a `Just`.
+
+If it doesn’t find an element, `Nothing` will be returned.")
   (defn find [f a]
-    (let-do [res (zero)]
+    (let-do [res (Maybe.Nothing)]
       (for [i 0 (length a)]
         (when (~f (nth a i))
           (do
-            (set! res @(nth a i))
+            (set! res (Maybe.Just @(nth a i)))
             (break))))
       res))
 
@@ -122,7 +124,7 @@ Returns `Nothing` if the array is empty.")
         result)))
 
   ; TODO unsafe!
-  (doc minimum "gets the maximum in an array (elements must support `>`).")
+  (doc minimum "gets the minimum in an array (elements must support `>`).")
   (defn minimum [xs]
     (let [result (unsafe-first xs)
           n (length xs)]
@@ -134,7 +136,7 @@ Returns `Nothing` if the array is empty.")
               ())))
         result)))
 
-  (doc sum "ums an array (elements must support `+` and `zero`).")
+  (doc sum "sums an array (elements must support `+` and `zero`).")
   (defn sum [xs]
     (Array.reduce &(fn [x y] (+ x @y)) (zero) xs))
 

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -111,7 +111,7 @@ Returns `Nothing` if the array is empty.")
     (not (= (the (Ref (Array a)) a) b)))
 
   ; TODO unsafe!
-  (doc maximum "gets the maximum in an array (elements must support `<`)and wraps it in a `Just`.
+  (doc maximum "gets the maximum in an array (elements must support `<` and `zero`)and wraps it in a `Just`.
 
 If the array is empty, returns `Nothing`")
   (defn maximum [xs]
@@ -126,7 +126,7 @@ If the array is empty, returns `Nothing`")
               (set! res x)))))
       result))
 
-  (doc minimum "gets the minimum in an array (elements must support `>`) and wraps it in a `Just`.
+  (doc minimum "gets the minimum in an array (elements must support `>` and `zero`) and wraps it in a `Just`.
 
 If the array is empty, returns `Nothing`")
   (defn minimum [xs]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -171,7 +171,9 @@ If the array is empty, returns `Nothing`")
           (set! j (Int.dec j))))
       a))
 
-  (doc index-of "gets the index of element `e` in an array.")
+  (doc index-of "gets the index of element `e` in an array and wraps it on a `Just`.
+
+If the element is not found, returns `Nothing`")
   (defn index-of [a e]
     (let-do [idx (Maybe.Nothing)]
       (for [i 0 (length a)]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -127,14 +127,14 @@ If the array is empty, it returns `Nothing`.")
   (doc minimum "gets the minimum in an array (elements must support `>`) and wraps it in a `Just`.
 
 If the array is empty, returns `Nothing`")
-  (defn maximum [xs]
+  (defn minimum [xs]
     (if (empty? xs)
       (Maybe.Nothing)
       (let-do [result (nth xs 0)
              n (length xs)]
         (for [i 1 n]
           (let [x (nth xs i)]
-            (when (< result x)
+            (when (> result x)
               (set! result x))))
         (Maybe.Just @result))))
 

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -110,7 +110,6 @@ Returns `Nothing` if the array is empty.")
   (defn /= [a b]
     (not (= (the (Ref (Array a)) a) b)))
 
-  ; TODO unsafe!
   (doc maximum "gets the maximum in an array (elements must support `<` and `zero`)and wraps it in a `Just`.
 
 If the array is empty, returns `Nothing`")

--- a/core/Statistics.carp
+++ b/core/Statistics.carp
@@ -5,8 +5,8 @@
 (defmodule Statistics
   (deftype Summary [
     sum Double,
-    min Double,
-    max Double,
+    min (Maybe Double),
+    max (Maybe Double),
     mean Double,
     median Double,
     var Double,
@@ -82,7 +82,7 @@
             (= n 1) @(Array.nth data 0)
             (let [x @(Array.nth data (/ n 2)) ; else
                   l (- x (/ (from-int interval) 2.0))
-                  cf (Array.index-of data &x)
+                  cf (Maybe.from (Array.index-of data &x) -1)
                   f (Array.element-count data &x)]
               (+ l (/ (* (from-int interval) (- (/ (from-int n) 2.0) (from-int cf)))
                       (from-int f)))))))

--- a/core/Statistics.carp
+++ b/core/Statistics.carp
@@ -5,8 +5,8 @@
 (defmodule Statistics
   (deftype Summary [
     sum Double,
-    min (Maybe Double),
-    max (Maybe Double),
+    min Double,
+    max Double,
     mean Double,
     median Double,
     var Double,
@@ -177,8 +177,8 @@
   (defn summary [samples]
     (Summary.init
       (Array.sum samples)
-      (Array.minimum samples)
-      (Array.maximum samples)
+      (Maybe.from (Array.minimum samples) 0.0)
+      (Maybe.from (Array.maximum samples) 0.0)
       (mean samples)
       (median samples)
       (variance samples)

--- a/core/Tuples.carp
+++ b/core/Tuples.carp
@@ -36,4 +36,8 @@
   (doc reverse "reverses a `Pair` `p` such that its first member is its second member and vice versa.")
   (defn reverse [p]
     (Pair.init @(Pair.b p) @(Pair.a p)))
-  )
+
+  (doc zero "return default values of the type inside `Pair`")
+  (defn zero []
+      (Pair.init (zero) (zero)))
+)

--- a/test/array.carp
+++ b/test/array.carp
@@ -247,12 +247,12 @@
                 (all? &(fn [x] (= 0 @x)) &(range 10 1 -1))
                 "all? works as expected II")
   (assert-equal test
-                3
-                (find &(fn [x] (= 3 @x)) &(range 1 10 1))
+                &(Maybe.Just 3)
+                &(find &(fn [x] (= 3 @x)) &(range 1 10 1))
                 "find works as expected I")
   (assert-equal test
-                0
-                (find &(fn [x] (= 0 @x)) &(range 1 10 1))
+                &(Maybe.Nothing)
+                &(find &(fn [x] (= 0 @x)) &(range 1 10 1))
                 "find works as expected II")
   (assert-equal test
                 &(Maybe.Nothing)

--- a/test/array.carp
+++ b/test/array.carp
@@ -76,19 +76,19 @@
                 &(reverse [1 2 3])
                 "reverse works as expected")
   (assert-equal test
-                10
-                (maximum &(range 1 10 1))
+                &(Maybe.Just 10)
+                &(maximum &(range 1 10 1))
                 "maximum works as expected")
   (assert-equal test
-                1
-                (minimum &(range 1 10 1))
+                &(Maybe.Just 1)
+                &(minimum &(range 1 10 1))
                 "minimum works as expected")
   (assert-equal test
-                &(Pair.init 2 1)
+                &(Maybe.Just (Pair.init 2 1))
                 &(maximum &[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
                 "maximum works on pairs")
   (assert-equal test
-                &(Pair.init 1 3)
+                &(Maybe.Just (Pair.init 1 3))
                 &(minimum &[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
                 "minimum works on pairs")
   (assert-equal test

--- a/test/array.carp
+++ b/test/array.carp
@@ -92,6 +92,14 @@
                 &(minimum &[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
                 "minimum works on pairs")
   (assert-equal test
+                &(Maybe.Just 3)
+                &(index-of &[1 2 3 4] &4)
+                "index-of works as expected when element is in the array")
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(index-of &[1 2 3 4] &7)
+                "index-of works as expected when element is not in the array")
+  (assert-equal test
                 55
                 (sum &(range 1 10 1))
                 "sum works as expected")

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -252,7 +252,7 @@
 
 (defn array-index-of []
   (let [xs [@"a" @"b" @"c" @"d" @"e"]]
-    (assert (= (Maybe.Just 2) (Array.index-of &xs "c")))))
+    (assert (= &(Maybe.Just 2) &(Array.index-of &xs "c")))))
 
 (defn array-element-count []
   (let [xs [@"a" @"b" @"a" @"a" @"b"]]

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -231,11 +231,11 @@
 
 (defn array-maximum []
   (let [xs [1 7 2 9 3 8 4 6 5]]
-    (assert (= 9 (maximum &xs)))))
+    (assert (= (Maybe.Just 9) (maximum &xs)))))
 
 (defn array-minimum []
   (let [xs [8 4 6 5 1 7 2 9 3]]
-    (assert (= 1 (minimum &xs)))))
+    (assert (= (Maybe.Just 1) (minimum &xs)))))
 
 (defn array-sum []
   (let [xs [10 20 30 40 50]]
@@ -252,7 +252,7 @@
 
 (defn array-index-of []
   (let [xs [@"a" @"b" @"c" @"d" @"e"]]
-    (assert (= 2 (Array.index-of &xs "c")))))
+    (assert (= (Maybe.Just 2) (Array.index-of &xs "c")))))
 
 (defn array-element-count []
   (let [xs [@"a" @"b" @"a" @"a" @"b"]]

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -231,11 +231,11 @@
 
 (defn array-maximum []
   (let [xs [1 7 2 9 3 8 4 6 5]]
-    (assert (= (Maybe.Just 9) (maximum &xs)))))
+    (assert (= &(Maybe.Just 9) &(maximum &xs)))))
 
 (defn array-minimum []
   (let [xs [8 4 6 5 1 7 2 9 3]]
-    (assert (= (Maybe.Just 1) (minimum &xs)))))
+    (assert (= &(Maybe.Just 1) &(minimum &xs)))))
 
 (defn array-sum []
   (let [xs [10 20 30 40 50]]


### PR DESCRIPTION
- Made Array.find wrapped in a Result (tests included, though I couldn't run it)
- Made Array.maximum and Array.minimum safe (tests included, though I couldn't run it)
- Made Array.index-of safe (tests included, though I couldn't run it)
- Added Pair.zero to maintain compatibility with Array.maximum and Array.minimum
- Also some typo fixes in Array module doc string

Please, try to run the tests on your machine