### PR TITLE
dynamic: add read-file

### DIFF
--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -1431,6 +1431,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#read-file">
+                    <h3 id="read-file">
+                        read-file
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#reload">
                     <h3 id="reload">
                         reload

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -153,6 +153,7 @@ toC toCMode root = emitterSrc (execState (visit startingIndent root) (EmitterSta
         visitString indent (XObj (Pattern str) (Just i) _) = visitStr' indent str i
         visitString _ _ = error "Not a string."
         escaper '\"' acc = "\\\"" ++ acc
+        escaper '\n' acc = "\\n" ++ acc
         escaper x acc = x : acc
         escapeString = foldr escaper ""
 

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -236,6 +236,7 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "system-include" 1 commandAddSystemInclude
                     , addCommand "local-include" 1 commandAddLocalInclude
                     , addCommand "save-docs-internal" 1 commandSaveDocsInternal
+                    , addCommand "read-file" 1 commandReadFile
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))

--- a/test/fixture_file.txt
+++ b/test/fixture_file.txt
@@ -1,0 +1,1 @@
+test file contents

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -196,4 +196,8 @@
                 1
                 (test-join)
                 "Symbol.join works as expected")
+  (assert-equal test
+                "test file contents\n"
+                (Dynamic.read-file "test/fixture_file.txt")
+                "Dynamic.read-file works as expected")
 )


### PR DESCRIPTION
This PR adds `Dynamic.read-file`, which embeds file contents into a Carp source file at compile time.

Test cases are included.

Cheers