### PR TITLE
Only allow Symbols in Let bindings

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -189,7 +189,7 @@ eval env xobj =
 
         [letExpr@(XObj Let _ _), XObj (Arr bindings) bindi bindt, body] 
           | odd (length bindings) -> return (makeEvalError ctx Nothing ("Uneven number of forms in `let`: " ++ pretty xobj) (info xobj)) -- Unreachable?
-          | not (all isSym bindings) -> return (makeEvalError ctx Nothing ("`let` identifiers must be symbols, but it got `" ++ concatMap pretty bindings ++ "`") (info xobj))
+          | not (all isSym (evenIndicies bindings)) -> return (makeEvalError ctx Nothing ("`let` identifiers must be symbols, but it got `" ++ concatMap pretty bindings ++ "`") (info xobj))
           | otherwise -> 
               do bind <- mapM (\(n, x) -> do x' <- eval env x
                                              return $ do okX <- x'
@@ -206,6 +206,7 @@ eval env xobj =
                      evaledBody <- eval envWithBindings body
                      return $ do okBody <- evaledBody
                                  Right okBody
+          where evenIndicies xs = map snd . filter (even . fst) $ zip [0..] xs
           
 
         XObj (Sym (SymPath [] "register-type") _) _ _ : XObj (Sym (SymPath _ typeName) _) _ _ : rest ->

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -206,7 +206,7 @@ eval env xobj =
                      evaledBody <- eval envWithBindings body
                      return $ do okBody <- evaledBody
                                  Right okBody
-          where evenIndicies xs = map snd . filter (even . fst) $ zip [0..] xs
+          
           
 
         XObj (Sym (SymPath [] "register-type") _) _ _ : XObj (Sym (SymPath _ typeName) _) _ _ : rest ->

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -360,7 +360,7 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
                 (Sym (SymPath _ name) _) ->
                   do visited <- visit env' expr
                      return (envAddBinding env' name . Binder emptyMeta <$> visited)
-                _ -> error ("Can't create let-binder for non-symbol: " ++ show sym) -- TODO: Use proper error mechanism
+                _ -> return (Left (InvalidLetBinding xobjs (sym, expr))) 
 
     extendEnvWithParamList :: Env -> [XObj] -> State Integer Env
     extendEnvWithParamList env xobjs =

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -775,3 +775,7 @@ isVarName (firstLetter:_) =
 isUnqualifiedSym :: XObj -> Bool
 isUnqualifiedSym (XObj (Sym (SymPath [] _) _) _ _) = True
 isUnqualifiedSym _ = False
+
+isSym :: XObj -> Bool
+isSym (XObj (Sym (SymPath _ _) _) _ _) = True
+isSym _ = False

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -48,6 +48,7 @@ data TypeError = SymbolMissingType XObj Env
                | InvalidMemberTypeWhenConcretizing Ty XObj TypeError
                | NotAmongRegisteredTypes Ty XObj
                | UnevenMembers [XObj]
+               | InvalidLetBinding [XObj] (XObj, XObj)
 
 instance Show TypeError where
   show (SymbolMissingType xobj env) =
@@ -219,6 +220,10 @@ instance Show TypeError where
     joinWithComma (map pretty xobjs) ++ "` at " ++
     prettyInfoFromXObj (head xobjs) ++
     ".\n\nBecause they are pairs of names and their types, they need to be even.\nDid you forget a name or type?"
+  show (InvalidLetBinding xobjs (sym, expr)) =
+    "The binding:` [" ++ pretty sym ++ " " ++ pretty expr ++ "]` is invalid at: " ++ 
+    prettyInfoFromXObj (head xobjs) ++ ". \n\n Because binding names must be symbols."
+
 
 machineReadableErrorStrings :: FilePathPrintLength -> TypeError -> [String]
 machineReadableErrorStrings fppl err =
@@ -329,7 +334,8 @@ machineReadableErrorStrings fppl err =
       [machineReadableInfoFromXObj fppl xobj ++ " The type '" ++ show t ++ "' isn't defined."]
     (UnevenMembers xobjs) ->
       [machineReadableInfoFromXObj fppl (head xobjs) ++ " Uneven nr of members / types: " ++ joinWithComma (map pretty xobjs)]
-
+    (InvalidLetBinding xobjs (sym, expr)) ->
+      [machineReadableInfoFromXObj fppl (head xobjs) ++ "Invalid let binding: " ++ pretty sym ++ pretty expr ++ " at: " ++ joinWithComma (map pretty xobjs)]
     _ ->
       [show err]
 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -85,3 +85,6 @@ intersectionOfSetsInList (x:xs) =
   foldl' Set.intersection x xs
 intersectionOfSetsInList [] =
   Set.empty
+
+evenIndicies :: [a] -> [a]
+evenIndicies xs = map snd . filter (even . fst) $ zip [0..] xs


### PR DESCRIPTION
This change ensures let bindings cannot have invalid identifiers, such as numbers `(let [4 4] true)`. 

I've also adopted guard syntax to handle potential failure conditions.