### PR TITLE
Catch double definitions in let

### DIFF
--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -49,6 +49,7 @@ data TypeError = SymbolMissingType XObj Env
                | NotAmongRegisteredTypes Ty XObj
                | UnevenMembers [XObj]
                | InvalidLetBinding [XObj] (XObj, XObj)
+               | DuplicateBinding XObj
 
 instance Show TypeError where
   show (SymbolMissingType xobj env) =
@@ -221,9 +222,11 @@ instance Show TypeError where
     prettyInfoFromXObj (head xobjs) ++
     ".\n\nBecause they are pairs of names and their types, they need to be even.\nDid you forget a name or type?"
   show (InvalidLetBinding xobjs (sym, expr)) =
-    "The binding:` [" ++ pretty sym ++ " " ++ pretty expr ++ "]` is invalid at: " ++ 
-    prettyInfoFromXObj (head xobjs) ++ ". \n\n Because binding names must be symbols."
+    "The binding `[" ++ pretty sym ++ " " ++ pretty expr ++ "]` is invalid at " ++
+    prettyInfoFromXObj (head xobjs) ++ ". \n\n Binding names must be symbols."
 
+  show (DuplicateBinding xobj) =
+    "I encountered a duplicate binding `" ++ pretty xobj ++ "` inside the `let` at " ++ prettyInfoFromXObj xobj ++ "."
 
 machineReadableErrorStrings :: FilePathPrintLength -> TypeError -> [String]
 machineReadableErrorStrings fppl err =
@@ -335,7 +338,10 @@ machineReadableErrorStrings fppl err =
     (UnevenMembers xobjs) ->
       [machineReadableInfoFromXObj fppl (head xobjs) ++ " Uneven nr of members / types: " ++ joinWithComma (map pretty xobjs)]
     (InvalidLetBinding xobjs (sym, expr)) ->
-      [machineReadableInfoFromXObj fppl (head xobjs) ++ "Invalid let binding: " ++ pretty sym ++ pretty expr ++ " at: " ++ joinWithComma (map pretty xobjs)]
+      [machineReadableInfoFromXObj fppl (head xobjs) ++ "Invalid let binding `" ++ pretty sym ++ pretty expr ++ "` at " ++ joinWithComma (map pretty xobjs)]
+    (DuplicateBinding xobj) ->
+      [machineReadableInfoFromXObj fppl xobj ++ " Duplicate binding `" ++ pretty xobj ++ "` inside `let`."]
+
     _ ->
       [show err]
 

--- a/test-for-errors/duplicate_binding.carp
+++ b/test-for-errors/duplicate_binding.carp
@@ -1,0 +1,6 @@
+(Project.config "file-path-print-length" "short")
+
+(defn f []
+  (let [x 1
+        x 2]
+    x))

--- a/test/output/test-for-errors/duplicate_binding.carp.output.expected
+++ b/test/output/test-for-errors/duplicate_binding.carp.output.expected
@@ -1,0 +1,1 @@
+duplicate_binding.carp:5:9 Duplicate binding `x` inside `let`.


### PR DESCRIPTION
This PR fixes #320 by analyzing `let` bindings for duplicates and returning an error message if there are any.

A test case is included.

Cheers