### PR TITLE
Macros: Add defproject macro

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -294,3 +294,13 @@
 (defmacro save-docs [:rest modules]
   ;; A trick to be able to send unquoted symbols to 'save-docs'
   (list 'save-docs-internal (list 'quote modules)))
+
+(defndynamic project-config [bindings] 
+  (if (< (length bindings) 2)
+    (list)
+    (cons-last (project-config (cdr (cdr bindings))) (list 'do (list 'Project.config
+    (car bindings) (car (cdr bindings)))))))
+
+(doc defproject "Define a project configuration.")
+(defmacro defproject [:rest bindings] 
+  (project-config bindings))


### PR DESCRIPTION
Adds the `defproject` macro. 

This macro enables you to specify a project configuration with slightly less redundancy. Instead of writing:

```clojure
(Project.config "title" "foo")
(Project.config "docs-directory" "bar")
(Project.config "search-path" "baz")
```

users can write:

```clojure
(defproject "title" "foo"
            "docs-directory" "bar"
            "search-path" "baz")
```

etc.

Note that at the moment this is a fairly 'dumb (or transparent)' macro--It doesn't do any additional type checking against the configuration, so improper types will cause the typical errors, and it doesn't have any special handing for cases in which the user provides an odd number of arguments.