### PR TITLE
Add const-assert

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -304,3 +304,10 @@
 (doc defproject "Define a project configuration.")
 (defmacro defproject [:rest bindings] 
   (project-config bindings))
+
+(doc const-assert "asserts that the expression `expr` is true at compile time.
+Otherwise it will fail with the message `msg`.
+
+The expression must be evaluable at compile time.")
+(defndynamic const-assert [expr msg]
+  (if expr () (macro-error msg)))

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -1,6 +1,11 @@
 (load "Test.carp")
 (use Test)
 
+; this won’t show up in the test output, sadly
+(const-assert true "const-assert works I")
+(const-assert (= 1 1) "const-assert works II")
+(const-assert (= false (= 1 2)) "const-assert works III")
+
 (defn test-let-do []
   (let-do [x 1]
     (set! x (+ x 1))


### PR DESCRIPTION
This PR adds `const-assert`, a dynamic function that behaves like `assert`, but gets run at compile time.

Test cases are included.

Cheers