### PR TITLE
Also split by newline in String.words

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -108,7 +108,7 @@ If you want to replace all occurrences of the pattern, use `-1`.")
 
   (doc words "splits a string into words.")
   (defn words [s]
-    (split-by s &[\tab \space]))
+    (split-by s &[\tab \space \newline]))
 
   (doc lines "splits a string into lines.")
   (defn lines [s]

--- a/test/string.carp
+++ b/test/string.carp
@@ -179,7 +179,7 @@
                 "collapse-whitespace works as expected")
   (assert-equal test
                 &[@"erik" @"sved" @"hej" @"foo"]
-                &(words "erik sved hej\tfoo")
+                &(words "erik sved\nhej\tfoo")
                 "words works correctly")
   (assert-equal test
                 &[@"erik" @"sved" @"hej" @"foo"]


### PR DESCRIPTION
This PR changes `String.words` to also split words on newlines, which is probably the desired behavior in most cases.

Test cases were updated.

Cheers