### PR TITLE
Macros: Add unit macro.

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -284,6 +284,13 @@
 (defmacro ignore [form]
   (list 'let (array '_ form) (list)))
 
+;; Also expose this as 'void' for those familiar with C?
+(doc unit "Convenience macro for specifing a return type of unit '()' for
+side-effecting functions. Can be slightly clearer than plain () in certain
+contexts, though this form is more verbose.")
+(defmacro unit []
+  (list))
+
 ;; Allows inclusion of C headers relative to the Carp file in which this macro is called.
 (defmacro relative-include [file]
   (list 'local-include


### PR DESCRIPTION
Adds a unit macro, a convenience macro for returning () in
side-effecting functions. This is useful, for example, for match forms
in which only one match should result in a side effect. The other
matches still require forms for completeness, but they should simply
return (). Unit might be easier to read in these cases, as parens can
get lost in the sea of surrounding parens in the definition.

I'm not totally convinced of the value of this macro, so please feel free to let me know if it seems redundant and unneeded, or if you have other ideas! Here's an example use-case:

```clojure
;; Without using `unit`                                                                            
    (sig add-propagator (Fn [Cell a] ()))                                                                            
    (defn add-propagator [cell propagator]                                                                           
      (let [props (Cell.propagators cell)]                                                                           
      (match (index-of props propagator)                                                                             
          (Nothing)                                                                                                  
            (do (Cell.update-propagators cell (push-back props propagator))                                          
                (alert-propagator propagator))                                                                       
          (Just x) ()))) ;; do nothing case must return unit to match the sig. Straight up '()' is a little easy to miss here and could be interpreted as an error at first glance.

;; Using `unit`                                                                           
    (sig add-propagator (Fn [Cell a] ()))                                                                            
    (defn add-propagator [cell propagator]                                                                           
      (let [props (Cell.propagators cell)]                                                                           
      (match (index-of props propagator)                                                                             
          (Nothing)                                                                                                  
            (do (Cell.update-propagators cell (push-back props propagator))                                          
                (alert-propagator propagator))                                                                       
          (Just x) (unit)))) ;; Our intentions here are a little bit clearer when we use a macro. We can be confident that doing nothing on this branch is intentional, and not a mistake or something to be filled in later.
```
