### PR TITLE
Remove StringCopy.append

### DIFF
--- a/core/Bench.carp
+++ b/core/Bench.carp
@@ -20,10 +20,10 @@ If your functions takes a large amount of time, experimenting with this might ma
   (hidden get-unit)
   (defn get-unit [n]
     (cond
-      (< n 1000.0) (StringCopy.append (Double.str n) @"ns")
-      (< n 1000000.0) (StringCopy.append (Double.str (/ n 1000.0)) @"µs")
-      (< n 1000000000.0) (StringCopy.append (Double.str (/ n 1000000.0)) @"ms")
-      (StringCopy.append (Double.str (/ n 1000000000.0)) @"s")))
+      (< n 1000.0) (String.append &(Double.str n) "ns")
+      (< n 1000000.0) (String.append &(Double.str (/ n 1000.0)) "µs")
+      (< n 1000000000.0) (String.append &(Double.str (/ n 1000000.0)) "ms")
+      (String.append &(Double.str (/ n 1000000000.0)) "s")))
 
   (private print)
   (hidden print)

--- a/core/Format.carp
+++ b/core/Format.carp
@@ -6,9 +6,10 @@
     (if (= idx -1)
       (list 'copy s) ; no more splits found, just return string
       (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
-        (list 'StringCopy.append
-              (list 'copy "%")
-              (fmt-internal (String.substring s (+ idx 2) len) args))
+        (list 'ref
+          (list 'String.append
+                "%"
+                (fmt-internal (String.substring s (+ idx 2) len) args)))
         (if (= 0 (length args)) ; we need to insert something, but have nothing
           (macro-error "error in format string: not enough arguments to format string")
           ; okay, this is the meat:
@@ -17,12 +18,14 @@
             (if (= -1 next)
               (if (< 1 (length args))
                 (macro-error "error in format string: too many arguments to format string")
-                (list 'format s (car args)))
+                (list 'ref (list 'format s (car args))))
               (let [slice (String.substring s 0 (+ (inc idx) next))]
-                (list 'StringCopy.append (list 'format slice (car args))
-                                         (fmt-internal (String.substring s (+ (inc idx) next) len)
-                                                       (cdr args)))))))))))
+                (list 'ref
+                  (list 'String.append
+                    (list 'ref (list 'format slice (car args)))
+                    (fmt-internal (String.substring s (+ (inc idx) next) len)
+                                      (cdr args))))))))))))
 
 (doc fmt "formats a string. It supports all of the string interpolations defined in format of the type that should be interpolated (e.g. %d and %x on integers).")
 (defmacro fmt [s :rest args]
-  (fmt-internal s args))
+  (list 'copy (fmt-internal s args)))

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -269,17 +269,17 @@
   (if (= (length forms) 0)
     (list "")
     (if (= (length forms) 1)
-      (list 'str (car forms))
-      (list 'StringCopy.append (list 'str (car forms)) (build-str* (cdr forms))))))
+      (list 'ref (list 'str (car forms)))
+      (list 'ref (list 'String.append (list 'ref (list 'str (car forms))) (build-str* (cdr forms)))))))
 
 (defmacro str* [:rest forms]
-  (build-str* forms))
+  (list 'copy (build-str* forms)))
 
 (defmacro println* [:rest forms]
-  (list 'IO.println (list 'ref (build-str* forms))))
+  (list 'IO.println (build-str* forms)))
 
 (defmacro print* [:rest forms]
-  (list 'IO.print (list 'ref (build-str* forms))))
+  (list 'IO.print (build-str* forms)))
 
 (defmacro ignore [form]
   (list 'let (array '_ form) (list)))

--- a/core/String.carp
+++ b/core/String.carp
@@ -152,8 +152,6 @@
 )
 
 (defmodule StringCopy
-  (register append     (Fn [String String] String))
-
   (defn str [s] (the String s))
 
   (defn = [a b]

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -91,11 +91,11 @@
         (if (Int.> (Int.+ passed failed) 0)
           (do
             (IO.color "green")
-            (if (Int.> passed 0) (IO.print &(StringCopy.append @"\t|" (String.repeat passed "="))) ())
+            (if (Int.> passed 0) (IO.print &(String.append "\t|" &(String.repeat passed "="))) ())
             (if (Int.= failed 0) (IO.print "|") ())
             (IO.color "red")
             (if (Int.= passed 0) (IO.print "\t|") ())
-            (if (Int.> failed 0) (IO.print &(StringCopy.append (String.repeat failed "=") @"|")) ())
+            (if (Int.> failed 0) (IO.print &(String.append &(String.repeat failed "=") "|")) ())
             (IO.println ""))
           ())
         (IO.color "green")

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -633,11 +633,11 @@ String Pattern_internal_add_value(PatternMatchState *ms, String res, String src,
         }
         res = Pattern_internal_add_char(res, tr[i]);
       }
-      else if (tr[i] == '0') res = StringCopy_append(res, src);
+      else if (tr[i] == '0') res = String_append(&res, &src);
       else {
         Array a = {.len = 0, .capacity = 0, .data = NULL};
         Pattern_internal_push_onecapture(ms, tr[i] - '1', src, e, a);
-        res = StringCopy_append(res, ((String*)a.data)[0]);  /* add capture to accumulated result */
+        res = String_append(&res, &((String*)a.data)[0]);  /* add capture to accumulated result */
       }
     }
   }

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -105,13 +105,6 @@ String String_append(String *a, String *b) {
     return buffer;
 }
 
-String StringCopy_append(String a, String b) {
-    String buffer = String_append(&a, &b);
-    CARP_FREE(a);
-    CARP_FREE(b);
-    return buffer;
-}
-
 int String_length(String *s) {
     return strlen(*s);
 }

--- a/docs/LanguageGuide.md
+++ b/docs/LanguageGuide.md
@@ -100,7 +100,7 @@ be used at a specific point in your program. In such cases the concept of 'holes
 add a hole in your source code and reload (":r") to let the Carp compiler figure out what type goes there.
 
 ```clojure
-(StringCopy.append ?w00t @"!") ;; Will generate a type error telling you that the type of '?w00t' is String
+(String.append ?w00t "!") ;; Will generate a type error telling you that the type of '?w00t' is &String
 ```
 
 ### Special forms during evaluation of dynamic code

--- a/docs/Todo.org
+++ b/docs/Todo.org
@@ -19,7 +19,6 @@
 ** 0.3
 *** Prevent usage of 'private' functions from outside their module.
 *** Type annotations should affect the type, not just check it.
-*** Remove StringCopy.append, use String.append in all those cases.
 *** Unified signatures for struct updaters and aupdate
 *** Allow matching on references, to avoid copying
 ** 1.0

--- a/examples/basics.carp
+++ b/examples/basics.carp
@@ -13,10 +13,10 @@
 
 (defmodule Things
   (defn inside [s]
-    (let [msg (StringCopy.append s (String.copy "!"))]
+    (let [msg (String.append s "!")]
       (println (ref msg))))
   (defn call []
-    (inside (String.copy "Hello"))))
+    (inside "Hello")))
 
 (defn use-doubles []
   (println (ref (str (Double.to-int (Double.+ 2.0 3.0))))))
@@ -132,7 +132,7 @@
 (defn print-last-string []
   (println &(get-last-string [(String.copy "NO") (String.copy "NO") (String.copy "YES")])))
 
-(defn exclaim [x] (StringCopy.append x @"!"))
+(defn exclaim [x] (String.append &x "!"))
 
 (deftype Simple [])
 (deftype Complex [x Int f Float d Double s String c Char])
@@ -185,7 +185,7 @@
         b [1 2 3]
         c1 (length &a)
         c2 (length &b)]
-    (println* &(str (+ c1 c2)))))
+    (println* (+ c1 c2))))
 
 (defn changing-target-of-ref []
   (let [s1 @"hello"

--- a/test/array.carp
+++ b/test/array.carp
@@ -8,8 +8,8 @@
    [4 5 6]
    [7 8 9]])
 
-(defn excl [x] (StringCopy.append x @"!"))
-(defn excl-ref [x] (StringCopy.append @x @"!"))
+(defn excl [x] (String.append &x "!"))
+(defn excl-ref [x] (String.append x "!"))
 
 (defn inc-ref [x] (+ @x 1))
 

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -192,7 +192,7 @@
         (assert (= &[@"q" @"b" @"c"] &xs)))))
 
 (defn append-ref [a b]
-  (StringCopy.append a @b))
+  (String.append &a b))
 
 (defn array-reduce []
   (let [xs [@"a" @"b" @"c"]
@@ -332,12 +332,6 @@
   (let [a "abcdef"
         b "ghijklmnopqrstuvwxyz"]
        (let [result (String.append a b)]
-            (assert (StringCopy.= result @"abcdefghijklmnopqrstuvwxyz")))))
-
-(defn stringcopy-append-leak-test []
-  (let [a "abcdef"
-        b "ghijklmnopqrstuvwxyz"]
-       (let [result (StringCopy.append @a @b)]
             (assert (StringCopy.= result @"abcdefghijklmnopqrstuvwxyz")))))
 
 (defn lambda-1 []
@@ -486,7 +480,6 @@
   (assert-no-leak test array-copy-map-1 "array-copy-map-1 does not leak")
   (assert-no-leak test array-copy-map-2 "array-copy-map-2 does not leak")
   (assert-no-leak test string-append-leak-test "String.append does not leak")
-  (assert-no-leak test stringcopy-append-leak-test "StringCopy.append does not leak")
   (assert-no-leak test lambda-1 "lambda-1 does not leak")
   (assert-no-leak test lambda-2 "lambda-2 does not leak")
   (assert-no-leak test lambda-3 "lambda-3 does not leak")


### PR DESCRIPTION
This PR removes `StringCopy.append` and replaces all instances of it by `String.append`, which is always a better idea.

It also removes it from `Todo.org` and the Language Guide.

Cheers