### PR TITLE
Make map’s higher order functions take refs

### DIFF
--- a/core/Map.carp
+++ b/core/Map.carp
@@ -160,7 +160,7 @@
               i (Bucket.find n k)]
           (if (<= 0 i)
             ;; currently can't write a Bucket.update that takes f due to bug #347
-            (Array.aset b idx (Bucket.set-idx @n i &(f (Bucket.get-idx n i))))
+            (Array.aset b idx (Bucket.set-idx @n i &(~f (Bucket.get-idx n i))))
             b))))))
 
   (doc update-with-default "Update value at key k in map with function f. If k doesn't exist in map, set k to (f v).")
@@ -170,8 +170,8 @@
         (let [n (Array.nth &b idx)
               i (Bucket.find n k)]
           (if (<= 0 i)
-            (Array.aset b idx (Bucket.set-idx @n i &(f (Bucket.get-idx n i))))
-            (Array.aset b idx (Bucket.push-back @n k &(f v)))))))))
+            (Array.aset b idx (Bucket.set-idx @n i &(~f (Bucket.get-idx n i))))
+            (Array.aset b idx (Bucket.push-back @n k &(~f v)))))))))
 
   (doc length "Get the length of the map m.")
   (defn length [m]
@@ -222,7 +222,7 @@
             entries (Bucket.entries bucket)]
         (for [j 0 len]
           (let [e (Array.nth entries j)]
-            (f (Pair.a e) (Pair.b e)))))))
+            (~f (Pair.a e) (Pair.b e)))))))
 
   (doc endo-map "Transform values of the given map in place. f gets two arguments, key and value, and should return new value")
   (defn endo-map [f m]
@@ -234,7 +234,7 @@
           (for [j 0 len]
             (let [e (Array.nth entries j)]
               (Array.aset! entries j (Pair.init @(Pair.a e)
-                                                (f (Pair.a e) (Pair.b e))))))))
+                                                (~f (Pair.a e) (Pair.b e))))))))
       m))
 
   (doc kv-reduce "Reduce a map with a function of three arguments: state, key and value. Reduction order is not guaranteed.")
@@ -246,18 +246,18 @@
               entries (Bucket.entries bucket)]
           (for [j 0 len]
             (let [e (Array.nth entries j)]
-              (set! init (f init (Pair.a e) (Pair.b e)))))))
+              (set! init (~f init (Pair.a e) (Pair.b e)))))))
       init))
 
   (doc vals "Return an array of the values of the map. Order corresponds to order of (keys m)")
   (defn vals [m]
-    (kv-reduce (fn [arr _ v] (Array.push-back arr @v))
+    (kv-reduce &(fn [arr _ v] (Array.push-back arr @v))
                []
                m))
 
   (doc keys "Return an array of the keys of the map. Order corresponds to order of (vals m)")
   (defn keys [m]
-    (kv-reduce (fn [arr k _] (Array.push-back arr @k))
+    (kv-reduce &(fn [arr k _] (Array.push-back arr @k))
                []
                m))
 
@@ -273,12 +273,12 @@
 
   (doc to-array "Convert Map to Array of Pairs")
   (defn to-array [m]
-    (kv-reduce (fn [arr k v] (Array.push-back arr (Pair.init-from-refs k v)))
+    (kv-reduce &(fn [arr k v] (Array.push-back arr (Pair.init-from-refs k v)))
                []
                m))
 
   (defn str [m]
-    (let [res (kv-reduce (fn [s k v]
+    (let [res (kv-reduce &(fn [s k v]
                            (String.join @"" &[s @" " (prn @k) @" " (prn @v)]))
                          @"{"
                          m)]
@@ -404,7 +404,7 @@
             entries (SetBucket.entries bucket)]
         (for [j 0 len]
           (let [e (Array.nth entries j)]
-            (f e))))))
+            (~f e))))))
 
   (doc from-array "Create a set from the values in array a.")
   (defn from-array [a]
@@ -423,33 +423,33 @@
               entries (SetBucket.entries bucket)]
           (for [j 0 len]
             (let [e (Array.nth entries j)]
-              (set! init (f init e))))))
+              (set! init (~f init e))))))
       init))
 
   (doc intersection "Set of elements that are in both set-a and set-b")
   (defn intersection [set-a set-b]
-    (reduce (fn [s a] (if (Set.contains? set-b a) (Set.put s a) s))
+    (reduce &(fn [s a] (if (Set.contains? set-b a) (Set.put s a) s))
             (Set.create)
             set-a))
 
   (doc union "Set of elements that are in either set-a or set-b (or both)")
   (defn union [set-a set-b]
-    (reduce Set.put
+    (reduce &Set.put
             @set-a
             set-b))
 
   (doc difference "Set of elements that are in set-a but not set-b")
   (defn difference [set-a set-b]
-    (reduce Set.remove
+    (reduce &Set.remove
             @set-a
             set-b))
 
   (doc to-array "Convert Set to Array of elements")
   (defn to-array [s]
-    (reduce (fn [arr elt] (Array.push-back arr @elt)) [] s))
+    (reduce &(fn [arr elt] (Array.push-back arr @elt)) [] s))
 
   (defn str [set]
-    (let [res (reduce (fn [s e] (String.join @"" &[s @" " (prn e)]))
+    (let [res (reduce &(fn [s e] (String.join @"" &[s @" " (prn e)]))
                       @"{"
                       set)]
       (String.append &res " }")))

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -327,7 +327,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [&amp;a, &amp;b] b), (Map a b)] (Map a b))
+                    (λ [(Ref (λ [&amp;a, &amp;b] b)), (Map a b)] (Map a b))
                 </p>
                 <pre class="args">
                     (endo-map f m)
@@ -347,7 +347,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b)), (λ [&amp;a, &amp;b] ())] ())
+                    (λ [(Ref (Map a b)), (Ref (λ [&amp;a, &amp;b] ()))] ())
                 </p>
                 <pre class="args">
                     (for-each m f)
@@ -487,7 +487,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, &amp;b, &amp;c] a), a, (Ref (Map b c))] a)
+                    (λ [(Ref (λ [a, &amp;b, &amp;c] a)), a, (Ref (Map b c))] a)
                 </p>
                 <pre class="args">
                     (kv-reduce f init m)
@@ -767,7 +767,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), &amp;a, (λ [b] b)] (Map a b))
+                    (λ [(Map a b), &amp;a, (Ref (λ [b] b))] (Map a b))
                 </p>
                 <pre class="args">
                     (update m k f)
@@ -827,7 +827,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), &amp;a, (λ [b] b), b] (Map a b))
+                    (λ [(Map a b), &amp;a, (Ref (λ [b] b)), b] (Map a b))
                 </p>
                 <pre class="args">
                     (update-with-default m k f v)

--- a/test/map.carp
+++ b/test/map.carp
@@ -43,12 +43,12 @@
   )
   (assert-equal test
                 true
-                (Map.empty? &(Map.update (Map.create) "x" Int.inc))
+                (Map.empty? &(Map.update (Map.create) "x" &Int.inc))
                 "update works with empty map"
   )
   (assert-equal test
                 2
-                (Map.get &(Map.update {@"x" 1} "x" Int.inc) "x")
+                (Map.get &(Map.update {@"x" 1} "x" &Int.inc) "x")
                 "update works"
   )
   (assert-equal test
@@ -63,12 +63,12 @@
   )
   (assert-equal test
                 8
-                (Map.get &(Map.update-with-default (Map.create) "x" Int.inc 7) "x")
+                (Map.get &(Map.update-with-default (Map.create) "x" &Int.inc 7) "x")
                 "update-with-default works with empty map"
   )
   (assert-equal test
                 2
-                (Map.get &(Map.update-with-default {@"x" 1} "x" Int.inc 7) "x")
+                (Map.get &(Map.update-with-default {@"x" 1} "x" &Int.inc 7) "x")
                 "update-with-default works"
   )
   (assert-equal test
@@ -178,13 +178,13 @@
   )
   (assert-equal test
                 "{ 1 12 3 34 }"
-                &(str &(Map.endo-map (fn [k v] (+ @v (* 10 @k)))
+                &(str &(Map.endo-map &(fn [k v] (+ @v (* 10 @k)))
                                      {1 2 3 4}))
                 "endo-map works"
   )
   (assert-equal test
                 641
-                (Map.kv-reduce (fn [sum k v] (+ sum (+ (* 100 @k) (* 10 @v))))
+                (Map.kv-reduce &(fn [sum k v] (+ sum (+ (* 100 @k) (* 10 @v))))
                                1
                                &{1 1 2 1 3 2})
                 "kv-reduce works"
@@ -312,7 +312,7 @@
   )
   (assert-equal test
                 61
-                (Set.reduce (fn [state i] (+ state (* 10 @i)))
+                (Set.reduce &(fn [state i] (+ state (* 10 @i)))
                             1
                             &(Set.from-array &[1 2 3]))
                 "reduce works"


### PR DESCRIPTION
This PR makes all the higher-order functions  in `Map` and `Set` be non-owning.

Test cases were updated.

Cheers