### PR TITLE
Correctly classify sumtypes with single case

### DIFF
--- a/docs/Todo.org
+++ b/docs/Todo.org
@@ -44,7 +44,6 @@
 ** 0.3
 *** 'local-include' not needed, just need 'relative-include'?
 *** Tweak the weight of the constraints to make error messages better for type errors
-*** Defining a sumtype with just one case gives strange error message.
 *** Use same terminology in long and short error messages
 *** The error reporting in Eval is a mess, must make it possible to return errors with correct location for all kinds of errors.
 *** Errors in macros should present the code location of _both_ the macro and of the code that uses of it.

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -705,7 +705,10 @@ deftypeInternal nameXObj typeName typeVariableXObjs rest =
          preExistingModule = case lookupInEnv (SymPath pathStrings typeName) env of
                                Just (_, Binder _ (XObj (Mod found) _ _)) -> Just found
                                _ -> Nothing
-         (creatorFunction, typeConstructor) = if length rest == 1 then (moduleForDeftype, Typ) else (moduleForSumtype, DefSumtype)
+         (creatorFunction, typeConstructor) =
+            if length rest == 1 && isArray (head rest)
+            then (moduleForDeftype, Typ)
+            else (moduleForSumtype, DefSumtype)
      case (nameXObj, typeVariables) of
        (XObj (Sym (SymPath _ typeName) _) i _, Just okTypeVariables) ->
          case creatorFunction typeEnv env pathStrings typeName okTypeVariables rest i preExistingModule of

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -779,3 +779,7 @@ isUnqualifiedSym _ = False
 isSym :: XObj -> Bool
 isSym (XObj (Sym (SymPath _ _) _) _ _) = True
 isSym _ = False
+
+isArray :: XObj -> Bool
+isArray (XObj (Arr _) _ _) = True
+isArray _ = False

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -7,6 +7,10 @@
   (register init (Fn [] Int) "fooInit")
 )
 
+; test whether sumtypes with single cases get classified correctly
+(deftype (SumT x)
+  (SingleC [x]))
+
 (use-all Test Vector2 Foo)
 
 (deftest test
@@ -29,5 +33,10 @@
                 &(Result.Error @"File “foobar” couldn’t be opened!")
                 &(IO.read->EOF "foobar")
                 "test that reading from an undefined file works"
+  )
+  (assert-equal test
+                "(SingleC 1)"
+                &(str &(SumT.SingleC 1))
+                "test that sumtypes with single cases work"
   )
 )


### PR DESCRIPTION
This PR fixes a bug where sumtype definitions with a single case didn’t work. It works now, and a regression test has been added.

Technical aside: the problem was that the classification of “regular deftypes” and sumtypes was the number of forms in the definition, which doesn’t word. Instead, we now look at the length and if the element in question is an array. If it is, then it’s a regular type, otherwise it’s a sumtype.

Cheers