### PR TITLE
Fix headerparse for comments after decl

### DIFF
--- a/headerparse/Main.hs
+++ b/headerparse/Main.hs
@@ -102,7 +102,7 @@ parseHeaderFile path src prefix kebab =
                                                  argList
                                Parsec.many spaceOrTab
                                Parsec.char ';'
-                               Parsec.many spaceOrTab
+                               Parsec.many (Parsec.noneOf "\n")
                                let tyXObj = toFnTypeXObj argTypeStrings (returnTypeString, length stars1 + length stars2)
                                return (createRegisterForm name tyXObj prefix kebab)
 


### PR DESCRIPTION
This PR fixes the headerparse to accept input such as:

```c
int x(); // this comment destroys headerparse
void y();
```

Inline comments made the header parser choke before because it expected the rest of the line to consist of `stringOrTab` parsemes.

Cheers