### PR TITLE
Concretize: Fix top level lambda naming

### DIFF
--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -476,6 +476,10 @@ pathToEnv rootEnv = visit rootEnv
 showImportIndented :: Int -> SymPath -> String
 showImportIndented indent path = replicate indent ' ' ++ " * " ++ show path
 
+incrementEnvNestLevel :: Env -> Env
+incrementEnvNestLevel env = let current = envFunctionNestingLevel env
+                            in env { envFunctionNestingLevel = current + 1 }
+
 -- | Project (represents a lot of useful information for working at the REPL and building executables)
 data Project = Project { projectTitle :: String
                        , projectIncludes :: [Includer]

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -88,3 +88,13 @@ intersectionOfSetsInList [] =
 
 evenIndicies :: [a] -> [a]
 evenIndicies xs = map snd . filter (even . fst) $ zip [0..] xs
+
+-- 'Naked' Lmabdas declared at the top level have their own s-expression forms
+-- as names, e.g. (fn <> [] ()). This can result in invalid c code. This
+-- function checks a lambda's nesting level. If the lambda is declared at the
+-- top level it returns a constant string, otherwise it returns the provided
+-- name (usually the name of the function in which the lambda is defined).
+lambdaToCName :: String -> Int -> String
+lambdaToCName name nestLevel = if nestLevel > 0
+                               then name
+                               else "NAKED_LAMBDA"


### PR DESCRIPTION
This change adjusts the way in which function nest levels are
incremented to ensure top level lambdas are assigned the correct nest
level. Top level lambdas used to use their expressions as names,
resulting in invalid c. A check on nest levels in the lambda naming code
now prevents this.

Essentially, this change makes the following sorts of definitions in the REPL ok:

```clojure
[(fn [] ())]
(deftype Foo [f (Fn [] ())])
(Foo.init (fn [] ()))
```

Note that this *doesn't* cover sumtypes, which still can't emit valid C for lambdas. Looks like there's some other portion of the compiler that needs to be modified for Sumtypes to work with lambda/function members.

Please let me know about any stylistic preferences! I just used what Haskell I know to implement this, happy to reimplement in a style more idiomatic for the code base.