### PR TITLE
Add annotations

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -32,6 +32,12 @@
 (defmacro hidden? [name]
   (list 'not (list '= () (list 'meta name "hidden")))) ;; TODO: This is buggy, will report true when meta is set to 'false'!
 
+(defndynamic annotate-helper [name annotation]
+  (cons annotation (meta name "annotations")))
+
+(doc annotate "Add an annotation to this binding.")
+(defmacro annotate [name annotation]
+  (list 'meta-set! name "annotations" (annotate-helper name annotation)))
 
 (defmodule Dynamic
   (defndynamic caar [pair] (car (car pair)))

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -787,3 +787,7 @@ isSym _ = False
 isArray :: XObj -> Bool
 isArray (XObj (Arr _) _ _) = True
 isArray _ = False
+
+-- construct an empty list xobj
+emptyList :: XObj
+emptyList = XObj (Lst []) Nothing Nothing


### PR DESCRIPTION
This PR adds a mechanism for “annotations”, which is what I call the prefixes that are often used in C by certain libraries—`GLFWAPI` and `EMSCRIPTEN_KEEPALIVE` spring to mind—to signal some kind of special behaviour of the function.

This is important for things like #294 where we need to emit it for the compiler.

A few adjustments to the emitter needed to be made to make sure it honours these annotations, but otherwise this change is relatively trivial, and extensible too!

In pretty great news, it now enables us to do things like this:

```clojure
(system-include "emscripten/emscripten.h")
(Project.config "compiler" "emcc")
(Project.config "title" "example.wasm")
(Project.config "output-directory" ".")
(add-cflag "-s ONLY_MY_CODE=1")

(defn dosth [i z] (Int.+ i z))
(annotate dosth "EMSCRIPTEN_KEEPALIVE")
```

which will emit a standalone WASM file that exports a function called `dosth`! It doesn’t yet handle polymorphic functions, sadly, because they don’t seem to inherit the meta data of their parent, and I couldn’t find where this happens currently.

Anyway, it’s a step into exciting new territory: running Carp in a browser natively!

Cheers