### PR TITLE
Remove Maybe.ptr for now

### DIFF
--- a/core/Maybe.carp
+++ b/core/Maybe.carp
@@ -52,12 +52,13 @@ It is the inverse of [`just?`](#just?).")
           (Nothing) false
           (Just y) (= x y))))
 
-  (doc ptr "Creates a `(Ptr a)` from a `(Maybe a)`. If the `Maybe` was
-`Nothing`, this function will return a `NULL` value.")
-  (defn ptr [a]
-    (match a
-      (Nothing) NULL
-      (Just x) (address x)))
+; TODO: figure out how to make this work (see #494)
+;  (doc ptr "Creates a `(Ptr a)` from a `(Maybe a)`. If the `Maybe` was
+;`Nothing`, this function will return a `NULL` value.")
+;  (defn ptr [a]
+;    (match a
+;      (Nothing) NULL
+;      (Just x) (address x)))
 
  (doc from-ptr "Creates a `(Maybe a)` from a `(Ptr a)`. If the `Ptr` was
 `NULL`, this function will return `Nothing`.")

--- a/test/maybe.carp
+++ b/test/maybe.carp
@@ -63,15 +63,15 @@
                 &(to-result (Nothing) @"error")
                 "to-result works on Nothing"
   )
-  (assert-equal test
-                1
-                @(Pointer.to-ref (ptr (Just 1)))
-                "ptr works on Just"
-  )
-  (assert-true test
-               (null? (ptr (the (Maybe Int) (Nothing))))
-               "ptr works on Nothing"
-  )
+  ;(assert-equal test
+  ;              1
+  ;              @(Pointer.to-ref (ptr (Just 1)))
+  ;              "ptr works on Just"
+  ;)
+  ;(assert-true test
+  ;             (null? (ptr (the (Maybe Int) (Nothing))))
+  ;             "ptr works on Nothing"
+  ;)
   (assert-equal test
                 &(Just 0)
                 &(from-ptr (address (zero)))


### PR DESCRIPTION
This PR removes `Maybe.ptr` for now, because as discovered in #494 it leads to a memory error. That’s a little sad, since it removes the dual to `from-ptr`, and the isomorphism is gone. But we’ll figure out how to make it work again, I’m sure!

Cheers