### PR TITLE
Optionally check malloc

### DIFF
--- a/core/Debug.carp
+++ b/core/Debug.carp
@@ -8,6 +8,11 @@ This might not work on all compilers, but reasonably new versions of GCC and Cla
   (defndynamic sanitize-addresses []
     (add-cflag "-fsanitize=address"))
 
+  (doc check-allocations "will check the allocations made by the program
+immediately, raising a `SIGABRT` if it fails.")
+  (defndynamic check-allocations []
+    (add-cflag "-DCHECK_ALLOCATIONS"))
+
   (register memory-balance (Fn [] Long))
   (register reset-memory-balance! (Fn [] ()))
   (register log-memory-balance! (Fn [Bool] ()))

--- a/core/carp_memory.h
+++ b/core/carp_memory.h
@@ -49,7 +49,16 @@ void Debug_reset_MINUS_memory_MINUS_balance_BANG_() {
 
 #else
 
+#ifdef CHECK_ALLOCATIONS
+void* CARP_MALLOC(size_t size) {
+  void* res = malloc(size);
+  if (!res) abort();
+  return res;
+}
+#else
 #define CARP_MALLOC(size) malloc(size)
+#endif
+
 #define CARP_FREE(ptr) free(ptr)
 
 #include <stdio.h>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -162,6 +162,27 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#check-allocations">
+                    <h3 id="check-allocations">
+                        check-allocations
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (check-allocations)
+                </pre>
+                <p class="doc">
+                    <p>will check the allocations made by the program
+immediately, raising a <code>SIGABRT</code> if it fails.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#leak-array">
                     <h3 id="leak-array">
                         leak-array

--- a/examples/check_malloc.carp
+++ b/examples/check_malloc.carp
@@ -1,0 +1,4 @@
+(Debug.check-allocations)
+
+(defn main []
+  (println* &(Array.repeat 10000000 &Int.zero)))

--- a/run_carp_tests.sh
+++ b/run_carp_tests.sh
@@ -45,6 +45,7 @@ done
 stack exec carp -- ./examples/mutual_recursion.carp -b
 stack exec carp -- ./examples/guessing.carp -b
 stack exec carp -- ./examples/no_core.carp --no-core -b
+stack exec carp -- ./examples/check_malloc.carp -b
 
 # Run tests which rely on SDL unless the `--no_sdl` argument was passed in
 if [[ ${NO_SDL} -eq 0 ]]; then


### PR DESCRIPTION
This PR introduces `Dynamic.check-allocations`, which sets a flag to check all calls to `malloc` and raise `SIGABRT` if they fail.

Built in response to #498.

Cheers