### PR TITLE
Add todo macro

### DIFF
--- a/core/Long.carp
+++ b/core/Long.carp
@@ -21,7 +21,9 @@
   (register dec (λ [Long] Long))
   (register to-int (λ [Long] Int))
   (register from-int (λ [Int] Long))
-  (register copy (λ [&Long] Long)) ;; TODO: Should not be needed when refs to value types are auto-converted to non-refs.
+  (todo copy "Should not be needed when refs to value types are auto-converted
+to non-refs.")
+  (register copy (λ [&Long] Long))
 
   (defn /= [x y]
     (not (Long.= x y)))

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -24,13 +24,19 @@
 (defmacro private [name]
   (list 'meta-set! name "private" true))
 
+(doc todo "sets the todo property for a binding.")
+(defmacro todo [name value]
+  (list 'meta-set! name "todo" value))
+
 (doc private? "Is this binding private?")
+(todo private? "This is buggy, will report true when meta is set to 'false'!")
 (defmacro private? [name]
-  (list 'not (list '= () (list 'meta name "private")))) ;; TODO: This is buggy, will report true when meta is set to 'false'!
+  (list 'not (list '= () (list 'meta name "private"))))
 
 (doc hidden? "Is this binding hidden?")
+(todo hidden? "This is buggy, will report true when meta is set to 'false'!")
 (defmacro hidden? [name]
-  (list 'not (list '= () (list 'meta name "hidden")))) ;; TODO: This is buggy, will report true when meta is set to 'false'!
+  (list 'not (list '= () (list 'meta name "hidden"))))
 
 (defndynamic annotate-helper [name annotation]
   (cons annotation (meta name "annotations")))


### PR DESCRIPTION
This PR adds the `todo` macro, which adds, well, TODOs to bindings. This gives a semantically clean place for adding TODOs, caveat emptors, nota benes, et al.

Cheers