### PR TITLE
Fix vector lerp.

### DIFF
--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -77,3 +77,6 @@
 
 (defn not-null? [p]
   (not (null? p)))
+
+(defn xlerp [from to amount]
+  (+ from (* (- to from) amount)))

--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -91,8 +91,8 @@
 
   (doc lerp "Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).")
   (defn lerp [a b amnt]
-    (init (* (- @(x b) @(x a)) amnt)
-          (* (- @(y b) @(y a)) amnt)))
+    (init (xlerp @(x a) @(x b) amnt)
+          (xlerp @(y a) @(y b) amnt)))
 )
 
 (deftype (Vector3 a) [x a, y a, z a])
@@ -185,9 +185,9 @@
 
   (doc lerp "Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).")
   (defn lerp [a b amnt]
-    (init (* (- @(x b) @(x a)) amnt)
-          (* (- @(y b) @(y a)) amnt)
-          (* (- @(z b) @(z a)) amnt)))
+    (init (xlerp @(x a) @(x b) amnt)
+          (xlerp @(y a) @(y b) amnt)
+          (xlerp @(z a) @(z b) amnt)))
 )
 
 (deftype (VectorN a) [n Int, v (Array a)])
@@ -283,7 +283,5 @@
 
   (doc lerp "Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).")
   (defn lerp [a b amnt]
-    (Maybe.apply (zip - b a)
-      (fn [x] (init @(n a) @(v &(zip- * &(Array.replicate @(n a) &amnt)
-                           (v &x)))))))
+    (zip (fn [from to] (xlerp from to amnt)) a b))
 )

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -75,6 +75,10 @@
                 "dot works")
   (assert-equal test
                 &(init 2.5 5.0)
-                &(lerp &(init 0.0 0.0) &(init 5.0 10.0) 0.5)
+                &(lerp &(zero) &(init 5.0 10.0) 0.5)
                 "lerp works")
+  (assert-equal test
+                &(init 1.5 15.0)
+                &(lerp &(init 1.0 10.0) &(init 2.0 20.0) 0.5)
+                "lerp works 2")
 )

--- a/test/vector3.carp
+++ b/test/vector3.carp
@@ -63,7 +63,11 @@
                 (dot &(init 10.0 2.0 3.0) &(init 2.0 12.0 3.0))
                 "dot works")
   (assert-equal test
-                &(init 2.5 5.0 0.75)
-                &(lerp &(init 0.0 0.0 0.5) &(init 5.0 10.0 2.0) 0.5)
+                &(init 2.5 5.0 1.0)
+                &(lerp &(zero) &(init 5.0 10.0 2.0) 0.5)
                 "lerp works")
+  (assert-equal test
+                &(init 1.5 15.0 150.0)
+                &(lerp &(init 1.0 10.0 100.0) &(init 2.0 20.0 200.0) 0.5)
+                "lerp works 2")
 )

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -81,4 +81,8 @@
                 &(init 1 [2.0])
                 &(Maybe.unsafe-from (lerp &(init 1 [0.0]) &(init 1 [5.0]) 0.4))
                 "lerp works")
+  (assert-equal test
+                &(init 1 [3.0])
+                &(Maybe.unsafe-from (lerp &(init 1 [1.0]) &(init 1 [5.0]) 0.5))
+                "lerp works 2")
 )


### PR DESCRIPTION
Looks like `lerp` for vectors is wrong. I named the plain number interpolator `xlerp` because if I named it `lerp` I got the following error:

```
I encountered an error when emitting code:

I found an unresolved generic type `(λ [(Ref (Vector2 r159)), (Ref (Vector2 Double)), Double] (Vector2 Double))` for the expression `XObj {obj = Sym Vector2.lerp (LookupGlobal CarpLand AFunction), info = Just (Info {infoLine = 78, infoColumn = 19, infoFile = "/Volumes/Data/carp/Carp/test/vector2.carp", infoDelete = fromList [], infoIdentifier = 452}), ty = Just (λ [(Ref (Vector2 r159)), (Ref (Vector2 Double)), Double] (Vector2 Double))}` at line 78, column 19 in '/Volumes/Data/carp/Carp/test/vector2.carp'

```