### PR TITLE
Macros: Add dynamic list to array transforms

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -92,21 +92,16 @@
         acc
         (list-to-array-internal (cdr xs) (append acc (array (car xs))))))
 
-  (doc list-to-array "Transforms a list dynamic data literal into an array dynamic data
-  literal, preserving order")
-  (defndynamic list-to-array [xs]
-    (list-to-array-internal xs (array)))
- 
-  (defndynamic array-to-list-internal [xs acc]
-    (if (= 0 (length xs)) 
-        acc 
-        (array-to-list-internal (cdr xs) (append acc (list (car xs))))))
-  
-  (doc array-to-list "Transforms an array dynamic data literal into a list dynamic data
-  literal, preserving order.")
-  (defndynamic array-to-list [xs]
+  (defndynamic collect-into-internal [xs acc f]
+    (if (= 0 (length xs))
+        acc
+        (collect-into-internal (cdr xs) (append acc (f (car xs))) f)))
+
+  (doc collect-into 
+    "Transforms a dynamic data literal into another, preserving order")
+  (defndynamic collect-into [xs f]
     (list 'quote
-      (array-to-list-internal xs (list))))
+      (collect-into-internal xs (f) f)))
   )
 
 (defndynamic cond-internal [xs]

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -105,8 +105,8 @@
   (doc array-to-list "Transforms an array dynamic data literal into a list dynamic data
   literal, preserving order.")
   (defndynamic array-to-list [xs]
-    (list-to-array-internal xs (list)))
-
+    (list 'quote
+      (array-to-list-internal xs (list))))
   )
 
 (defndynamic cond-internal [xs]

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -86,6 +86,26 @@
 
   (defmacro e [form]
     (eval-internal form))
+ 
+  (defndynamic list-to-array-internal [xs acc]
+    (if (= 0 (length xs))
+        acc
+        (list-to-array-internal (cdr xs) (append acc (array (car xs))))))
+
+  (doc list-to-array "Transforms a list dynamic data literal into an array dynamic data
+  literal, preserving order")
+  (defndynamic list-to-array [xs]
+    (list-to-array-internal xs (array)))
+ 
+  (defndynamic array-to-list-internal [xs acc]
+    (if (= 0 (length xs)) 
+        acc 
+        (array-to-list-internal (cdr xs) (append acc (list (car xs))))))
+  
+  (doc array-to-list "Transforms an array dynamic data literal into a list dynamic data
+  literal, preserving order.")
+  (defndynamic array-to-list [xs]
+    (list-to-array-internal xs (list)))
 
   )
 


### PR DESCRIPTION
This change adds two utility functions to the Dynamic module for
transforming list forms into arrays and array forms into lists.

Using this function, one can easily convert lists and arrays for
ease of symbol manipulation, for example:

```clojure
(Symbol.join (list-to-array (list 'a 'b 'c)))
```

This comes in handy, for instance, when defining macros, as certain
forms in Carp expect arrays in certain places while others expect
list--this enables the programmer to flexible convert between the two as
needed.