### PR TITLE
Streamline macro-log

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -479,12 +479,6 @@ commandProject args =
      liftIO (print (contextProj ctx))
      return dynamicNil
 
--- | Command for printing a message to the screen.
-commandPrint :: CommandCallback
-commandPrint args =
-  do liftIO $ mapM_ (putStrLn . pretty) args
-     return dynamicNil
-
 -- | Command for getting the name of the operating system you're on.
 commandOS :: CommandCallback
 commandOS _ =
@@ -594,12 +588,14 @@ commandMacroError [msg] =
     x                  -> return (Left (EvalError (pretty x) (info msg)))
 
 commandMacroLog :: CommandCallback
-commandMacroLog [msg] =
-  case msg of
-    XObj (Str msg) _ _ -> do liftIO (putStrLn msg)
-                             return dynamicNil
-    x                  -> do liftIO (putStrLn (pretty x))
-                             return dynamicNil
+commandMacroLog msgs = do
+  liftIO (mapM_ (putStr . logify) msgs)
+  liftIO (putStr "\n")
+  return dynamicNil
+  where logify msg =
+          case msg of
+            XObj (Str msg) _ _ -> msg
+            x                  -> pretty x
 
 commandEq :: CommandCallback
 commandEq [a, b] =

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -216,7 +216,7 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "cons-last" 2 commandConsLast
                     , addCommand "append" 2 commandAppend
                     , addCommand "macro-error" 1 commandMacroError
-                    , addCommand "macro-log" 1 commandMacroLog
+                    , addCommandConfigurable "macro-log" Nothing commandMacroLog
                     , addCommandConfigurable "str" Nothing commandStr
                     , addCommand "not" 1 commandNot
                     , addCommand "=" 2 commandEq
@@ -236,7 +236,6 @@ dynamicModule = Env { envBindings = bindings
                     , addCommandConfigurable "help" Nothing commandHelp
                     , addCommand "project" 0 commandProject
                     , addCommand "load" 1 commandLoad
-                    , addCommand "macro-log" 1 commandPrint
                     , addCommand "expand" 1 commandExpand
                     , addCommand "project-set!" 2 commandProjectSet
                     , addCommand "os" 0 commandOS


### PR DESCRIPTION
This PR fixes #528 by streamlining `macro-log` and removing the duplicate. Specifically, you can now write stuff like

```clojure
(macro-log "Hiya number " 2 "!")
```

In other words, it’s multi-arity and type-generic now!

Cheers