### PR TITLE
Remove local-include in favor of relative-include

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -296,13 +296,6 @@
 (defmacro ignore [form]
   (list 'let (array '_ form) (list)))
 
-;; Allows inclusion of C headers relative to the Carp file in which this macro is called.
-(defmacro relative-include [file]
-  (list 'local-include
-        (list 'Dynamic.String.join [(list 'Dynamic.String.directory (list 'file))
-                                    "/"
-                                    file])))
-
 (defmacro save-docs [:rest modules]
   ;; A trick to be able to send unquoted symbols to 'save-docs'
   (list 'save-docs-internal (list 'quote modules)))

--- a/core/SDL.carp
+++ b/core/SDL.carp
@@ -1,6 +1,6 @@
 (system-include "math.h")
 
-(local-include "../core/SDLHelper.h")
+(relative-include "SDLHelper.h")
 
 (not-on-windows
   (add-pkg "sdl2"))

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -1321,25 +1321,6 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#local-include">
-                    <h3 id="local-include">
-                        local-include
-                    </h3>
-                </a>
-                <div class="description">
-                    command
-                </div>
-                <p class="sig">
-                    Dynamic
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
                 <a class="anchor" href="#macro-error">
                     <h3 id="macro-error">
                         macro-error
@@ -1476,6 +1457,25 @@
                 <a class="anchor" href="#read-file">
                     <h3 id="read-file">
                         read-file
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#relative-include">
+                    <h3 id="relative-include">
+                        relative-include
                     </h3>
                 </a>
                 <div class="description">

--- a/examples/external_struct.carp
+++ b/examples/external_struct.carp
@@ -1,4 +1,4 @@
-(local-include "../examples/banana.h")
+(relative-include "banana.h")
 (Project.no-echo)
 
 (register-type Apple)

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -503,7 +503,17 @@ commandAddInclude includerConstructor [x] =
       return (Left (EvalError ("Argument to 'include' must be a string, but was `" ++ pretty x ++ "`") (info x)))
 
 commandAddSystemInclude = commandAddInclude SystemInclude
-commandAddLocalInclude  = commandAddInclude LocalInclude
+
+commandAddRelativeInclude :: CommandCallback
+commandAddRelativeInclude [x] =
+  case x of
+    XObj (Str file) i@(Just info) t ->
+        let compiledFile = infoFile info
+        in commandAddInclude RelativeInclude [
+          XObj (Str $ (takeDirectory compiledFile) ++ "/" ++ file) i t
+        ]
+    _ ->
+      return (Left (EvalError ("Argument to 'include' must be a string, but was `" ++ pretty x ++ "`") (info x)))
 
 commandIsList :: CommandCallback
 commandIsList [x] =

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -741,7 +741,7 @@ paramListToC xobjs = intercalate ", " (map getParam xobjs)
 projectIncludesToC :: Project -> String
 projectIncludesToC proj = intercalate "\n" (map includerToC (projectIncludes proj)) ++ "\n\n"
   where includerToC (SystemInclude file) = "#include <" ++ file ++ ">"
-        includerToC (LocalInclude file) = "#include \"" ++ file ++ "\""
+        includerToC (RelativeInclude file) = "#include \"" ++ file ++ "\""
 
 binderToC :: ToCMode -> Binder -> Either ToCError String
 binderToC toCMode binder =

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -586,12 +586,12 @@ instance Show Project where
 
 -- | Represent the inclusion of a C header file, either like <string.h> or "string.h"
 data Includer = SystemInclude String
-              | LocalInclude String
+              | RelativeInclude String
               deriving Eq
 
 instance Show Includer where
   show (SystemInclude file) = "<" ++ file ++ ">"
-  show (LocalInclude file) = "\"" ++ file ++ "\""
+  show (RelativeInclude file) = "\"" ++ file ++ "\""
 
 -- | Converts an S-expression to one of the Carp types.
 xobjToTy :: XObj -> Maybe Ty

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -242,7 +242,7 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "project-set!" 2 commandProjectSet
                     , addCommand "os" 0 commandOS
                     , addCommand "system-include" 1 commandAddSystemInclude
-                    , addCommand "local-include" 1 commandAddLocalInclude
+                    , addCommand "relative-include" 1 commandAddRelativeInclude
                     , addCommand "save-docs-internal" 1 commandSaveDocsInternal
                     , addCommand "read-file" 1 commandReadFile
                     ]

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -1,4 +1,4 @@
-(local-include "../test/fixture_foo.h")
+(relative-include "fixture_foo.h")
 (load "Test.carp")
 (load "Vector.carp")
 


### PR DESCRIPTION
This PR fixes #472 by removing `local-include` and prefering `relative-include` wherever possible.

It seems like, from [surveying Github](https://github.com/search?q=extension%3Acarp+local-include), the only people currently impacted by this are @timdeve (specifically his arduino project) and @titan (his palbox api client).

Cheers