### PR TITLE
Updates docs to reflect removal of local-include

### DIFF
--- a/docs/LanguageGuide.md
+++ b/docs/LanguageGuide.md
@@ -220,7 +220,7 @@ Sometimes, it's more convenient to bring a module's declarations into scope only
 ### C Interop
 ```clojure
 (system-include "math.h") ;; compiles to #include <math.h>
-(relative-include "math.h") ;; compiles to #include "/full/path/to/file/math.h"
+(relative-include "math.h") ;; compiles to #include "$carp_file_dir/math.h" where carp_file_dir is the absolute path to the folder containing the invoking .carp file
 
 (register blah (Fn [Int Int] String)) ;; Will register the function 'blah' that takes two Int:s and returns a String
 (register pi Double) ;; Will register the global variable 'pi' of type Double

--- a/docs/LanguageGuide.md
+++ b/docs/LanguageGuide.md
@@ -220,7 +220,7 @@ Sometimes, it's more convenient to bring a module's declarations into scope only
 ### C Interop
 ```clojure
 (system-include "math.h") ;; compiles to #include <math.h>
-(local-include "math.h") ;; compiles to #include "math.h"
+(relative-include "math.h") ;; compiles to #include "/full/path/to/file/math.h"
 
 (register blah (Fn [Int Int] String)) ;; Will register the function 'blah' that takes two Int:s and returns a String
 (register pi Double) ;; Will register the global variable 'pi' of type Double


### PR DESCRIPTION
Replaces reference to local-include with relative-include in the language guide

local-include was removed in #543 