### PR TITLE
[WIP] Update scoring of defalias

### DIFF
--- a/src/Scoring.hs
+++ b/src/Scoring.hs
@@ -19,7 +19,7 @@ scoreTypeBinder typeEnv b@(Binder _ (XObj (Lst (XObj x _ _ : XObj (Sym _ _) _ _ 
       -- we add 1 here because deftypes generate aliases that
       -- will at least have the same score as the type, but
       -- need to come after. the increment represents this dependency
-      in  (depthOfType typeEnv Set.empty selfName aliasedType + 1, b)
+      in (depthOfType typeEnv Set.empty selfName aliasedType + 2, b)
     Deftype s -> depthOfStruct s
     DefSumtype s -> depthOfStruct s
     _ -> (500, b)
@@ -69,13 +69,13 @@ depthOfType typeEnv visited selfName theType =
       maximum (visitType retTy : fmap visitType argTys)
     visitType (PointerTy p) = visitType p
     visitType (RefTy r) = visitType r
-    visitType _ = 1
+    visitType _ = 0
 
     depthOfStructType :: String -> [Ty] -> Int
-    depthOfStructType name varTys = 1 +
+    depthOfStructType name varTys =
       case name of
         "Array" -> depthOfVarTys
-        _ | name == selfName -> 1
+        _ | name == selfName -> 0
           | otherwise ->
               case lookupInEnv (SymPath [] name) (getTypeEnv typeEnv) of
                 Just (_, Binder _ typedef) -> depthOfDeftype typeEnv (Set.insert theType visited) typedef varTys
@@ -85,7 +85,7 @@ depthOfType typeEnv visited selfName theType =
                                          -- Instead, let's try the type vars.
       where depthOfVarTys =
               case fmap (depthOfType typeEnv visited name) varTys of
-                [] -> 1
+                [] -> 0
                 xs -> maximum xs + 1
 
 


### PR DESCRIPTION
(Duplicate of #574, but as a proper Draft)

This PR is a hack that updates the scoring of defalias by incrementing by more than 1. This is because somehow the scoring that `depthOfType` comes up with for the aliased type is lower (usually 1-2) than what the final score of that type is. The problem can be seen in [my queues repo](https://github.com/hellerve/queues.carp).

As this is just a hack, I’d rather investigate the reason for this more deeply and figure it out for real. I’m quite sure that the problem is related to some scoring discrepancy between wrapped and top-level types, but I can’t quite figure it out as of yet. Someone with more experience with the scoring might be able to illuminate more here.

Independent of all of this, I changed some baseline values from `1` to `0`, since there doesn’t seem to be a reason for `1` to be the baseline value (the outcome isn’t changed and the tests still run). This came out of some prior playing around with the module.

Cheers