### PR TITLE
Replace colon in git path

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -1132,6 +1132,8 @@ commandLoad [xobj@(XObj (Str path) i _)] =
             machineReadableInfoFromXObj (fppl ctx) xobj ++ " I can't find a file named: '" ++ path ++ "'"
           _ -> "I can't find a file named: '" ++ path ++ "'") ++
         "\n\nI tried interpreting the statement as a git import, but got: " ++ stderr) (info xobj)
+    replaceC c s [] = []
+    replaceC c s (a:b) = if a == c then s ++ replaceC c s b else a : replaceC c s b
     cantLoadSelf ctx path =
       case contextExecMode ctx of
         Check ->
@@ -1142,7 +1144,7 @@ commandLoad [xobj@(XObj (Str path) i _)] =
       let split = splitOn "@" path
       in tryInstallWithCheckout (joinWith "@" (init split)) (last split)
     fromURL url =
-      let split = splitOn "/" url
+      let split = splitOn "/" (replaceC ':' "_COLON_" url)
           fst = head split
       in if fst `elem` ["https:", "http:"]
         then joinWith "/" (tail split)


### PR DESCRIPTION
This PR fixes #571 by replacing the colon in a file path produced by a Git checkout by `_COLON_`. This should probably be generalized later on, but maybe it’s good enough for now?

@TimDeve Could you check that this fixes your problem?

Cheers