### PR TITLE
Fix regression when loading via git

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -1145,8 +1145,8 @@ commandLoad [xobj@(XObj (Str path) i _)] =
     fromURL url =
       let split = splitOn "/" (replaceC ':' "_COLON_" url)
           fst = head split
-      in if fst `elem` ["https:", "http:"]
-        then joinWith "/" $ tail $ tail split
+      in if fst `elem` ["https_COLON_", "http_COLON_"]
+        then joinWith "/" (tail (tail split))
         else
           if '@' `elem` fst
             then joinWith "/" (joinWith "@" (tail (splitOn "@" fst)) : tail split)

--- a/test/args.carp
+++ b/test/args.carp
@@ -13,6 +13,6 @@
                (System.get-args-len)
                "System.get-args-len works as expected")
   (assert-equal test
-                (make-exe-path "/Untitled")
+                (make-exe-path "Untitled")
                 (System.get-arg 0)
                 "System.get-arg works as expected"))


### PR DESCRIPTION
This PR fixes a regression that was introduced by #579: we check for `https:` and `http:` after having the colon replaced, meaning this will never work. We have to check for `https_COLON_` and `http_COLON_` instead.

Cheers