### PR TITLE
Add write-file

### DIFF
--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -1644,6 +1644,25 @@
                     
                 </p>
             </div>
+            <div class="binder">
+                <a class="anchor" href="#write-file">
+                    <h3 id="write-file">
+                        write-file
+                    </h3>
+                </a>
+                <div class="description">
+                    command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
         </div>
     </body>
 </html>

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -815,6 +815,22 @@ commandReadFile [filename] =
     _ ->
       return (Left (EvalError ("The argument to `read-file` must be a string, I got `" ++ pretty filename ++ "`") (info filename)))
 
+commandWriteFile :: CommandCallback
+commandWriteFile [filename, contents] =
+  case filename of
+    XObj (Str fname) _ _ -> do
+      case contents of
+        XObj (Str s) _ _ -> do
+         exceptional <- liftIO $ ((try $ writeFile fname s) :: (IO (Either IOException ())))
+         case exceptional of
+            Right () -> return dynamicNil
+            Left _ ->
+              return (Left (EvalError ("Cannot write to argument to `" ++ fname ++ "`, an argument to `write-file`") (info filename)))
+        _ ->
+          return (Left (EvalError ("The second argument to `write-file` must be a string, I got `" ++ pretty contents ++ "`") (info contents)))
+    _ ->
+      return (Left (EvalError ("The first argument to `write-file` must be a string, I got `" ++ pretty filename ++ "`") (info filename)))
+
 commandSaveDocsInternal :: CommandCallback
 commandSaveDocsInternal [modulePath] = do
      ctx <- get

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -244,6 +244,7 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "relative-include" 1 commandAddRelativeInclude
                     , addCommand "save-docs-internal" 1 commandSaveDocsInternal
                     , addCommand "read-file" 1 commandReadFile
+                    , addCommand "write-file" 2 commandWriteFile
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))


### PR DESCRIPTION
This PR adds the dynamic function `write-file`, which is the writing equivalent to `read-file`. It enables us to write code like this:

```clojure
(defdynamic *c-counter* 0)

(defndynamic inline-c [s]
  (let [f (String.join [(Project.get-config "output-directory")
                        "carp_inline_c_generated" (str *c-counter*) ".h"])]
    (do
      (write-file f s)
      (system-include f))))


(inline-c "int x() { return 1; }")
(register x (Fn [] Int))

(defn main [] (println* &(x)))
```

I hope this is useful enough to motivate why this is a good idea!

Cheers