### PR TITLE
core.h: Use pragma once for multi-include

### DIFF
--- a/core/core.h
+++ b/core/core.h
@@ -1,3 +1,4 @@
+#pragma once
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 #include <windows.h>
 #endif


### PR DESCRIPTION
This PR adds `#pragma once` to `core.h`, to make it possible for external C files to include `core.h` without nameclashes. It shouldn’t do anything else.

Cheers