### PR TITLE
Ensure directory paths have trailing slash in Project.config

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -108,9 +108,9 @@ commandProjectConfig [xobj@(XObj (Str key) _ _), value] =
                      "title" -> do title <- unwrapStringXObj value
                                    return (proj { projectTitle = title })
                      "output-directory" -> do outDir <- unwrapStringXObj value
-                                              return (proj { projectOutDir = outDir })
+                                              return (proj { projectOutDir = addTrailingPathSeparator outDir })
                      "docs-directory" -> do docsDir <- unwrapStringXObj value
-                                            return (proj { projectDocsDir = docsDir })
+                                            return (proj { projectDocsDir = addTrailingPathSeparator docsDir })
                      "docs-generate-index" ->
                        do docsGenerateIndex <- unwrapBoolXObj value
                           return (proj { projectDocsGenerateIndex = docsGenerateIndex })

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -46,3 +46,5 @@ toStandard = if platform == Windows then map (\x -> if x == '\\' then '/' else x
 
 xdgPath :: D.XdgDirectory -> FilePath -> IO FilePath
 xdgPath t = fmap toStandard . D.getXdgDirectory t . (</>) "carp" . toNative
+
+addTrailingPathSeparator = FP.addTrailingPathSeparator


### PR DESCRIPTION
This PR fixes the problem @eriksvedang encountered in #588 by ensuring that all paths fed into `Project.config` have a trailing slash.

Cheers