### PR TITLE
Ccleanup path in git load if we fail

### DIFF
--- a/src/Path.hs
+++ b/src/Path.hs
@@ -20,6 +20,12 @@ configPath = xdgPath D.XdgConfig
 createDirectoryIfMissing :: Bool -> FilePath -> IO ()
 createDirectoryIfMissing createParents = D.createDirectoryIfMissing createParents . toNative
 
+removeDirectoryRecursive :: FilePath -> IO ()
+removeDirectoryRecursive = D.removeDirectoryRecursive . toNative
+
+doesPathExist :: FilePath -> IO Bool
+doesPathExist = D.doesPathExist . toNative
+
 doesFileExist :: FilePath -> IO Bool
 doesFileExist = D.doesFileExist . toNative
 


### PR DESCRIPTION
This PR fixes #595 by ensuring that we remove the directory that we created for our Git load if we fail.

Cheers