### PR TITLE
Add a byte type

### DIFF
--- a/core/Byte.carp
+++ b/core/Byte.carp
@@ -1,0 +1,61 @@
+(system-include "carp_byte.h")
+
+(defmodule Byte
+  (register + (λ [Byte Byte] Byte))
+  (register - (λ [Byte Byte] Byte))
+  (register * (λ [Byte Byte] Byte))
+  (register / (λ [Byte Byte] Byte))
+  (register < (λ [Byte Byte] Bool))
+  (register > (λ [Byte Byte] Bool))
+  (register = (λ [Byte Byte] Bool))
+  (register mod (λ [Byte Byte] Byte))
+  (register bit-shift-left (λ [Byte Byte] Byte))
+  (register bit-shift-right (λ [Byte Byte] Byte))
+  (register bit-and (λ [Byte Byte] Byte))
+  (register bit-or (λ [Byte Byte] Byte))
+  (register bit-xor (λ [Byte Byte] Byte))
+  (register bit-not (λ [Byte] Byte))
+  (register inc (λ [Byte] Byte))
+  (register dec (λ [Byte] Byte))
+  (register copy (λ [&Byte] Byte))
+  (register to-int (λ [Byte] Int))
+  (register from-int (λ [Int] Byte))
+
+  (defn even? [a] (= (mod a 2b) 0b))
+  (defn odd? [a] (not (even? a)))
+
+  (defn zero [] 0b)
+
+  (defn add-ref [x y]
+    (Byte.+ @x @y))
+
+  ;; Move to generic math module?
+  (defn clamp [min, max, val]
+    (if (> val max)
+      max
+      (if (< val min)
+        min
+        val)))
+
+  (doc pow "Raise x to the power of y.")
+  (defn pow [x y]
+    (let-do [r 1b]
+      (while (/= y 0b)
+        (do
+          (when (/= (bit-and y 1b) 0b)
+            (set! r (* r x)))
+          (set! y (/ y 2b))
+          (set! x (* x x))))
+      r))
+)
+
+(defmodule ByteRef
+  (defn = [a b]
+    (Byte.= @a @b))
+
+  (defn < [a b]
+    (Byte.< @a @b))
+
+  (defn > [a b]
+    (Byte.> @a @b))
+)

--- a/core/Core.carp
+++ b/core/Core.carp
@@ -23,6 +23,7 @@
 (load "Result.carp")
 (load "Dynamic.carp")
 (load "Format.carp")
+(load "Byte.carp")
 (load "Int.carp")
 (load "Long.carp")
 (load "Double.carp")

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -29,6 +29,10 @@
   (defn hash [k] (to-int (the Char @k)))
 )
 
+(defmodule Byte
+  (defn hash [k] (to-int (the Byte @k)))
+)
+
 (defmodule Float
   (defn hash [k] (to-bytes @k))
 )

--- a/core/Random.carp
+++ b/core/Random.carp
@@ -76,3 +76,12 @@
   (defn random-sized [n]
     (from-chars &(Array.repeat n &Char.random)))
 )
+
+(defmodule Byte
+  (defn random-between [lower upper]
+    (Byte.from-int (Int.random-between (Byte.to-int lower) (Byte.to-int upper))))
+
+  (defn random []
+    (Byte.from-int (Int.random)))
+)
+

--- a/core/String.carp
+++ b/core/String.carp
@@ -179,6 +179,12 @@
   (register from-string (λ [&String] Int))
 )
 
+(defmodule Byte
+  (register str (Fn [Byte] String))
+  (register format (Fn [&String Byte] String))
+  (register from-string (λ [&String] Byte))
+)
+
 (defmodule Float
   (register str (Fn [Float] String))
   (register format (Fn [&String Float] String))

--- a/core/String.carp
+++ b/core/String.carp
@@ -208,6 +208,7 @@
 )
 
 (defmodule Int (defn prn [x] (Int.str x)))
+(defmodule Byte (defn prn [x] (Byte.str x)))
 (defmodule IntRef
   (defn prn [x] (Int.str @x))
   (defn str [x] (Int.str @x))
@@ -216,6 +217,11 @@
 (defmodule BoolRef
   (defn prn [x] (Bool.str @x))
   (defn str [x] (Bool.str @x)))
+
+(defmodule ByteRef
+  (defn prn [x] (Byte.str @x))
+  (defn str [x] (Byte.str @x))
+  )
 
 (defmodule Long (defn prn [x] (Long.str x)))
 (defmodule Float (defn prn [x] (Float.str x)))

--- a/core/carp_byte.h
+++ b/core/carp_byte.h
@@ -1,0 +1,36 @@
+typedef uint8_t byte;
+
+uint8_t Byte__PLUS_(uint8_t x, uint8_t y)   { return x + y; }
+uint8_t Byte__MINUS_(uint8_t x, uint8_t y)  { return x - y; }
+uint8_t Byte__MUL_(uint8_t x, uint8_t y)    { return x * y; }
+uint8_t Byte__DIV_(uint8_t x, uint8_t y)    { return x / y; }
+bool Byte__EQ_(uint8_t x, uint8_t y)    { return x == y; }
+bool Byte__LT_(uint8_t x, uint8_t y)    { return x < y; }
+bool Byte__GT_(uint8_t x, uint8_t y)    { return x > y; }
+
+uint8_t Byte_inc(uint8_t x) { return x + 1; }
+uint8_t Byte_dec(uint8_t x) { return x - 1; }
+uint8_t Byte_bit_MINUS_shift_MINUS_left(uint8_t x, uint8_t y) { return x << y; }
+uint8_t Byte_bit_MINUS_shift_MINUS_right(uint8_t x, uint8_t y) { return x >> y; }
+uint8_t Byte_bit_MINUS_and(uint8_t x, uint8_t y) { return x & y; }
+uint8_t Byte_bit_MINUS_or(uint8_t x, uint8_t y) { return x | y; }
+uint8_t Byte_bit_MINUS_xor(uint8_t x, uint8_t y) { return x ^ y; }
+uint8_t Byte_bit_MINUS_not(uint8_t x) { return ~x; }
+
+uint8_t Byte_copy(const uint8_t *x) { return *x; }
+
+uint8_t Byte_mod(uint8_t x, uint8_t divider) {
+    return x % divider;
+}
+
+bool Byte_mask(uint8_t a, uint8_t b) {
+    return a & b;
+}
+
+int Byte_to_MINUS_int(uint8_t a) {
+    return a;
+}
+
+uint8_t Byte_from_MINUS_int(int a) {
+    return a;
+}

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -243,6 +243,24 @@ long Long_from_MINUS_string(const String *s) {
     return atol(*s);
 }
 
+String Byte_str(uint8_t x) {
+    int size = snprintf(NULL, 0, "%ub", x)+1;
+    String buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "%ub", x);
+    return buffer;
+}
+
+String Byte_format(const String* str, uint8_t x) {
+    int size = snprintf(NULL, 0, *str, x)+1;
+    String buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, *str, x);
+    return buffer;
+}
+
+uint8_t Byte_from_MINUS_string(const String *s) {
+    return atoi(*s);
+}
+
 int String_index_MINUS_of_MINUS_from(const String *s, char c, int i) {
     /* Return index of first occurrence of `c` in `s` AFTER index i
      * Returns -1 if not found

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -546,6 +546,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#hash">
+                    <h3 id="hash">
+                        hash
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [&amp;Byte] Int)
+                </p>
+                <pre class="args">
+                    (hash k)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#inc">
                     <h3 id="inc">
                         inc

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -141,10 +141,105 @@
                 </div>
             </div>
             <h1>
-                Vector2
+                Byte
             </h1>
             <div class="module-description">
                 
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#*">
+                    <h3 id="*">
+                        *
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#+">
+                    <h3 id="+">
+                        +
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#-">
+                    <h3 id="-">
+                        -
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#/">
+                    <h3 id="/">
+                        /
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&lt;">
+                    <h3 id="&lt;">
+                        &lt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
             </div>
             <div class="binder">
                 <a class="anchor" href="#=">
@@ -153,75 +248,187 @@
                     </h3>
                 </a>
                 <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#&gt;">
+                    <h3 id="&gt;">
+                        &gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Bool)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#add-ref">
+                    <h3 id="add-ref">
+                        add-ref
+                    </h3>
+                </a>
+                <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] Bool)
+                    (λ [&amp;Byte, &amp;Byte] Byte)
                 </p>
                 <pre class="args">
-                    (= a b)
+                    (add-ref x y)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#add">
-                    <h3 id="add">
-                        add
+                <a class="anchor" href="#bit-and">
+                    <h3 id="bit-and">
+                        bit-and
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] (Vector2 a))
+                    (λ [Byte, Byte] Byte)
                 </p>
-                <pre class="args">
-                    (add a b)
-                </pre>
+                <span>
+                    
+                </span>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#angle-between">
-                    <h3 id="angle-between">
-                        angle-between
+                <a class="anchor" href="#bit-not">
+                    <h3 id="bit-not">
+                        bit-not
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] a)
+                    (λ [Byte] Byte)
                 </p>
-                <pre class="args">
-                    (angle-between a b)
-                </pre>
+                <span>
+                    
+                </span>
                 <p class="doc">
-                    <p>Get the angle between two vectors a and b.</p>
-
+                    
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#anti-parallel?">
-                    <h3 id="anti-parallel?">
-                        anti-parallel?
+                <a class="anchor" href="#bit-or">
+                    <h3 id="bit-or">
+                        bit-or
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-shift-left">
+                    <h3 id="bit-shift-left">
+                        bit-shift-left
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-shift-right">
+                    <h3 id="bit-shift-right">
+                        bit-shift-right
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#bit-xor">
+                    <h3 id="bit-xor">
+                        bit-xor
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#clamp">
+                    <h3 id="clamp">
+                        clamp
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] Bool)
+                    (λ [a, a, a] a)
                 </p>
                 <pre class="args">
-                    (anti-parallel? a b)
+                    (clamp min max val)
                 </pre>
                 <p class="doc">
-                    <p>Check whether the two vectors a and b are anti-parallel.</p>
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -231,412 +438,187 @@
                     </h3>
                 </a>
                 <div class="description">
-                    template
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 f))] (Vector2 f))
+                    (λ [&amp;Byte] Byte)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>copies the <code>Vector2</code>.</p>
-
+                    
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#delete">
-                    <h3 id="delete">
-                        delete
+                <a class="anchor" href="#dec">
+                    <h3 id="dec">
+                        dec
                     </h3>
                 </a>
                 <div class="description">
-                    template
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Vector2 f)] ())
+                    (λ [Byte] Byte)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>deletes a <code>Vector2</code>. Should usually not be called manually.</p>
-
+                    
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dist">
-                    <h3 id="dist">
-                        dist
+                <a class="anchor" href="#even?">
+                    <h3 id="even?">
+                        even?
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] a)
+                    (λ [Byte] Bool)
                 </p>
                 <pre class="args">
-                    (dist a b)
-                </pre>
-                <p class="doc">
-                    <p>Get the distance between the vectors a and b.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#div">
-                    <h3 id="div">
-                        div
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a)), a] (Vector2 a))
-                </p>
-                <pre class="args">
-                    (div a n)
+                    (even? a)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dot">
-                    <h3 id="dot">
-                        dot
+                <a class="anchor" href="#format">
+                    <h3 id="format">
+                        format
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] a)
-                </p>
-                <pre class="args">
-                    (dot a b)
-                </pre>
-                <p class="doc">
-                    <p>Get the dot product of the two vectors x and y.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#heading">
-                    <h3 id="heading">
-                        heading
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a))] a)
-                </p>
-                <pre class="args">
-                    (heading a)
-                </pre>
-                <p class="doc">
-                    <p>Get the heading of the vector a.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#init">
-                    <h3 id="init">
-                        init
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (λ [f, f] (Vector2 f))
+                    (λ [&amp;String, Byte] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>creates a <code>Vector2</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#mag">
-                    <h3 id="mag">
-                        mag
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a))] a)
-                </p>
-                <pre class="args">
-                    (mag o)
-                </pre>
-                <p class="doc">
-                    <p>Get the magnitude of a vector.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#mag-sq">
-                    <h3 id="mag-sq">
-                        mag-sq
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a))] a)
-                </p>
-                <pre class="args">
-                    (mag-sq o)
-                </pre>
-                <p class="doc">
-                    <p>Get the squared magnitude of a vector.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#map">
-                    <h3 id="map">
-                        map
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(λ [a] b), (Ref (Vector2 a))] (Vector2 b))
-                </p>
-                <pre class="args">
-                    (map f v)
-                </pre>
-                <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#mul">
-                    <h3 id="mul">
-                        mul
+                <a class="anchor" href="#from-int">
+                    <h3 id="from-int">
+                        from-int
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), a] (Vector2 a))
-                </p>
-                <pre class="args">
-                    (mul a n)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#normalize">
-                    <h3 id="normalize">
-                        normalize
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a))] (Vector2 a))
-                </p>
-                <pre class="args">
-                    (normalize o)
-                </pre>
-                <p class="doc">
-                    <p>Normalize a vector.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#parallel?">
-                    <h3 id="parallel?">
-                        parallel?
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] Bool)
-                </p>
-                <pre class="args">
-                    (parallel? a b)
-                </pre>
-                <p class="doc">
-                    <p>Check whether the two vectors a and b are parallel.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#perpendicular?">
-                    <h3 id="perpendicular?">
-                        perpendicular?
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] Bool)
-                </p>
-                <pre class="args">
-                    (perpendicular? a b)
-                </pre>
-                <p class="doc">
-                    <p>Check whether the two vectors a and b are perpendicular.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#prn">
-                    <h3 id="prn">
-                        prn
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 f))] String)
+                    (λ [Int] Byte)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>converts a <code>Vector2</code> to a string.</p>
-
+                    
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#random">
-                    <h3 id="random">
-                        random
+                <a class="anchor" href="#from-string">
+                    <h3 id="from-string">
+                        from-string
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [&amp;String] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#inc">
+                    <h3 id="inc">
+                        inc
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#mod">
+                    <h3 id="mod">
+                        mod
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#odd?">
+                    <h3 id="odd?">
+                        odd?
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Vector2 a))
+                    (λ [Byte] Bool)
                 </p>
                 <pre class="args">
-                    (random)
+                    (odd? a)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#rotate">
-                    <h3 id="rotate">
-                        rotate
+                <a class="anchor" href="#pow">
+                    <h3 id="pow">
+                        pow
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a)), a] (Vector2 a))
+                    (λ [Byte, Byte] Byte)
                 </p>
                 <pre class="args">
-                    (rotate a n)
+                    (pow x y)
                 </pre>
                 <p class="doc">
-                    <p>Rotate the vector a by the radians n.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-x">
-                    <h3 id="set-x">
-                        set-x
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (λ [(Vector2 f), f] (Vector2 f))
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>x</code> property of a <code>Vector2</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-x!">
-                    <h3 id="set-x!">
-                        set-x!
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 f)), f] ())
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>x</code> property of a <code>Vector2</code> in place.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-y">
-                    <h3 id="set-y">
-                        set-y
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (λ [(Vector2 f), f] (Vector2 f))
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>y</code> property of a <code>Vector2</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#set-y!">
-                    <h3 id="set-y!">
-                        set-y!
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 f)), f] ())
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>sets the <code>y</code> property of a <code>Vector2</code> in place.</p>
+                    <p>Raise x to the power of y.</p>
 
                 </p>
             </div>
@@ -647,194 +629,35 @@
                     </h3>
                 </a>
                 <div class="description">
-                    template
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 f))] String)
+                    (λ [Byte] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>converts a <code>Vector2</code> to a string.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#sub">
-                    <h3 id="sub">
-                        sub
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] (Vector2 a))
-                </p>
-                <pre class="args">
-                    (sub a b)
-                </pre>
-                <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#sum">
-                    <h3 id="sum">
-                        sum
+                <a class="anchor" href="#to-int">
+                    <h3 id="to-int">
+                        to-int
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a))] a)
-                </p>
-                <pre class="args">
-                    (sum o)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#update-x">
-                    <h3 id="update-x">
-                        update-x
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Vector2 f), (Ref (λ [f] f))] (Vector2 f))
+                    (λ [Byte] Int)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>updates the <code>x</code> property of a <code>Vector2</code> using a function <code>f</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#update-y">
-                    <h3 id="update-y">
-                        update-y
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Vector2 f), (Ref (λ [f] f))] (Vector2 f))
-                </p>
-                <span>
                     
-                </span>
-                <p class="doc">
-                    <p>updates the <code>y</code> property of a <code>Vector2</code> using a function <code>f</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#vapprox">
-                    <h3 id="vapprox">
-                        vapprox
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a))] Bool)
-                </p>
-                <pre class="args">
-                    (vapprox a b)
-                </pre>
-                <p class="doc">
-                    <p>Check whether the vectors a and b are approximately equal.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#vlerp">
-                    <h3 id="vlerp">
-                        vlerp
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 a)), (Ref (Vector2 a)), a] (Vector2 a))
-                </p>
-                <pre class="args">
-                    (vlerp a b amnt)
-                </pre>
-                <p class="doc">
-                    <p>Linearly interpolate between the two vectors a and b by amnt (between 0 and 1).</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#vreduce">
-                    <h3 id="vreduce">
-                        vreduce
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(λ [a, b] a), a, (Ref (Vector2 b))] a)
-                </p>
-                <pre class="args">
-                    (vreduce f i v)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#x">
-                    <h3 id="x">
-                        x
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 f))] &amp;f)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>gets the <code>x</code> property of a <code>Vector2</code>.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#y">
-                    <h3 id="y">
-                        y
-                    </h3>
-                </a>
-                <div class="description">
-                    instantiate
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Vector2 f))] &amp;f)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>gets the <code>y</code> property of a <code>Vector2</code>.</p>
-
                 </p>
             </div>
             <div class="binder">
@@ -847,29 +670,10 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Vector2 a))
+                    (λ [] Byte)
                 </p>
                 <pre class="args">
                     (zero)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#zip">
-                    <h3 id="zip">
-                        zip
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(λ [a, b] c), (Ref (Vector2 a)), (Ref (Vector2 b))] (Vector2 c))
-                </p>
-                <pre class="args">
-                    (zip f a b)
                 </pre>
                 <p class="doc">
                     

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -623,6 +623,63 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Byte] String)
+                </p>
+                <pre class="args">
+                    (prn x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random">
+                    <h3 id="random">
+                        random
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [] Byte)
+                </p>
+                <pre class="args">
+                    (random)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#random-between">
+                    <h3 id="random-between">
+                        random-between
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [Byte, Byte] Byte)
+                </p>
+                <pre class="args">
+                    (random-between lower upper)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#str">
                     <h3 id="str">
                         str

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -28,6 +28,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Byte.html">
+                                Byte
+                            </a>
+                        </li>
+                        <li>
                             <a href="Long.html">
                                 Long
                             </a>

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -24,6 +24,11 @@
                                 </a>
                             </li>
                             <li>
+                                <a href="Byte.html">
+                                    Byte
+                                </a>
+                            </li>
+                            <li>
                                 <a href="Long.html">
                                     Long
                                 </a>

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -13,6 +13,7 @@
 
 (save-docs Dynamic
            Int
+           Byte
            Long
            Bool
            Float

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -98,6 +98,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             Arr _   -> visitArray indent xobj
             Num IntTy num -> return (show (round num :: Int))
             Num LongTy num -> return (show (round num :: Int) ++ "l")
+            Num ByteTy num -> return (show (round num :: Int))
             Num FloatTy num -> return (show num ++ "f")
             Num DoubleTy num -> return (show num)
             Num _ _ -> error "Can't emit invalid number type."

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -257,6 +257,7 @@ pretty = visit 0
             Dict dict -> "{" ++ joinWithSpace (map (visit indent) (concatMap (\(a, b) -> [a, b]) (Map.toList dict))) ++ "}"
             Num IntTy num -> show (round num :: Int)
             Num LongTy num -> show num ++ "l"
+            Num ByteTy num -> show num
             Num FloatTy num -> show num ++ "f"
             Num DoubleTy num -> show num
             Num _ _ -> error "Invalid number type."
@@ -600,6 +601,7 @@ xobjToTy (XObj (Sym (SymPath _ "Int") _) _ _) = Just IntTy
 xobjToTy (XObj (Sym (SymPath _ "Float") _) _ _) = Just FloatTy
 xobjToTy (XObj (Sym (SymPath _ "Double") _) _ _) = Just DoubleTy
 xobjToTy (XObj (Sym (SymPath _ "Long") _) _ _) = Just LongTy
+xobjToTy (XObj (Sym (SymPath _ "Byte") _) _ _) = Just ByteTy
 xobjToTy (XObj (Sym (SymPath _ "String") _) _ _) = Just StringTy
 xobjToTy (XObj (Sym (SymPath _ "Pattern") _) _ _) = Just PatternTy
 xobjToTy (XObj (Sym (SymPath _ "Char") _) _ _) = Just CharTy

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -58,6 +58,12 @@ integer :: Parsec.Parsec String ParseState XObj
 integer = do (i, num) <- maybeSigned
              return (XObj (Num IntTy (read num)) i Nothing)
 
+byte :: Parsec.Parsec String ParseState XObj
+byte = do (i, num) <- maybeSigned
+          _ <- Parsec.char 'b'
+          incColumn 1
+          return (XObj (Num ByteTy (read num)) i Nothing)
+
 long :: Parsec.Parsec String ParseState XObj
 long = do (i, num) <- maybeSigned
           _ <- Parsec.char 'l'
@@ -67,6 +73,7 @@ long = do (i, num) <- maybeSigned
 number :: Parsec.Parsec String ParseState XObj
 number = Parsec.try float <|>
          Parsec.try floatNoPeriod <|>
+         Parsec.try byte <|>
          Parsec.try double <|>
          Parsec.try long <|>
          Parsec.try integer

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -27,6 +27,7 @@ import Util
 -- | Carp types.
 data Ty = IntTy
         | LongTy
+        | ByteTy
         | BoolTy
         | FloatTy
         | DoubleTy
@@ -60,6 +61,7 @@ instance Show Ty where
   show FloatTy               = "Float"
   show DoubleTy              = "Double"
   show LongTy                = "Long"
+  show ByteTy                = "Byte"
   show BoolTy                = "Bool"
   show StringTy              = "String"
   show PatternTy             = "Pattern"
@@ -107,6 +109,7 @@ tyToCManglePtr _ BoolTy                  = "bool"
 tyToCManglePtr _ FloatTy                 = "float"
 tyToCManglePtr _ DoubleTy                = "double"
 tyToCManglePtr _ LongTy                  = "long"
+tyToCManglePtr _ ByteTy                  = "uint8_t"
 tyToCManglePtr _ StringTy                = "String"
 tyToCManglePtr _ PatternTy               = "Pattern"
 tyToCManglePtr _ CharTy                  = "char"

--- a/src/Validate.hs
+++ b/src/Validate.hs
@@ -38,6 +38,7 @@ canBeUsedAsMemberType typeEnv typeVariables t xobj =
     IntTy     -> return ()
     FloatTy   -> return ()
     DoubleTy  -> return ()
+    ByteTy    -> return ()
     LongTy    -> return ()
     BoolTy    -> return ()
     StringTy  -> return ()

--- a/test/byte_math.carp
+++ b/test/byte_math.carp
@@ -1,0 +1,50 @@
+(load "Test.carp")
+
+(use-all Byte Test)
+
+(deftest test
+  (assert-equal test
+                1b
+                (min 1b 2b)
+                "min works as expected")
+  (assert-equal test
+                2b
+                (max 1b 2b)
+                "max works as expected")
+  (assert-equal test
+                false
+                (even? 3b)
+                "even? works as expected")
+  (assert-equal test
+                true
+                (odd? 3b)
+                "odd? works as expected")
+  (assert-equal test
+                1b
+                (bit-and 3b 5b)
+                "bit-and works as expected")
+  (assert-equal test
+                5b
+                (bit-or 1b 4b)
+                "bit-or works as expected")
+  (assert-equal test
+                4b
+                (bit-xor 1b 5b)
+                "bit-xor works as expected")
+  (assert-equal test
+                1b
+                (bit-not 254b)
+                "bit-not works as expected")
+  (assert-equal test
+                8b
+                (bit-shift-left 2b 2b)
+                "bit-shift-left works as expected")
+  (assert-equal test
+                2b
+                (bit-shift-right 16b 3b)
+                "bit-shift-right works as expected")
+  (assert-equal test
+                1
+                (/ 3 2)
+                "integer division truncates as expected")
+)


### PR DESCRIPTION
This PR adds the type `Byte` to the core types (which desugars to `uint8_t`). It mostly works like the other numerical types, except that it’s unsigned, and so `neg`, `abs`, and `positive-mod` don’t really make sense.

Test cases are included. I suspect that this clashes quite a bit with #581, and I’m happy to backport that work into this (or the other way around, whichever is easier).

Cheers