### PR TITLE
Fix pattern escaping

### DIFF
--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -104,7 +104,7 @@ parseInternalPattern = do maybeAnchor <- Parsec.optionMaybe (Parsec.char '^')
             c <- Parsec.oneOf ['1', '2', '3', '4', '5', '6', '7', '8', '9',
                                'a', 'c', 'd', 'g', 'l', 'p', 's', 'u', 'w',
                                'x', 'n', 't', 'b', 'f', '[', ']', '\\', '$',
-                               '(', ')', '^', '"', '*', '.']
+                               '(', ')', '^', '"', '*', '.', '-']
             case c of
               'b' -> do c1 <- Parsec.noneOf ['"']
                         c2 <- Parsec.noneOf ['"']


### PR DESCRIPTION
This PR adds `-` to the list of characters that we can escape. This is because `-` means `Match the previous character (or class) zero or more times, as few times as possible` in Carp patterns (as taken over from Lua patterns).

Cheers