### PR TITLE
Actually register error

### DIFF
--- a/core/IO.carp
+++ b/core/IO.carp
@@ -13,7 +13,7 @@
   (doc errorln "prints a string ref to stderr, appends a newline.")
   (register errorln (Fn [(Ref String)] ()))
   (doc error "prints a string ref to stderr, does not append a newline.")
-  (register print (Fn [(Ref String)] ()))
+  (register error (Fn [(Ref String)] ()))
   (doc get-line "gets a line from stdin.")
   (register get-line (Fn [] String))
   (doc get-char "gets a character from stdin.")

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -265,10 +265,10 @@
                     </h3>
                 </a>
                 <div class="description">
-                    doc-stub
+                    external
                 </div>
                 <p class="sig">
-                    a
+                    (λ [&amp;String] ())
                 </p>
                 <span>
                     


### PR DESCRIPTION
This PR makes sure we actually register  `error` inside `IO`.

Thanks for @hugurp for looking at the docs with me and pointing out the `doc-stub`. :)

Cheers