### PR TITLE
into lifetimes: unsafe-first and unsafe-last return references

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -69,7 +69,7 @@ If it doesn’t find an index, `Nothing` will be returned.")
 
 Generates a runtime error if the array is empty.")
   (defn unsafe-first [a]
-    @(Array.nth a 0))
+    (Array.nth a 0))
 
   (doc first "takes the first element of an array and returns a `Just`.
 
@@ -83,7 +83,7 @@ Returns `Nothing` if the array is empty.")
 
 Generates a runtime error if the array is empty.")
   (defn unsafe-last [a]
-    @(Array.nth a (Int.dec (Array.length a))))
+    (Array.nth a (Int.dec (Array.length a))))
 
 
   (doc last "takes the last element of an array and returns a `Just`.

--- a/core/Filepath.carp
+++ b/core/Filepath.carp
@@ -14,5 +14,5 @@
     (let [segments (split-by path &[\/])]
       ; this is actually safe here, because split by will return an array of
       ; length > 0
-      (unsafe-last &segments)))
+      @(unsafe-last &segments)))
   )

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -1325,7 +1325,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] a)
+                    (λ [(Ref (Array a) b)] (Ref a b))
                 </p>
                 <pre class="args">
                     (unsafe-first a)
@@ -1346,7 +1346,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] a)
+                    (λ [(Ref (Array a) b)] (Ref a b))
                 </p>
                 <pre class="args">
                     (unsafe-last a)

--- a/examples/reptile.carp
+++ b/examples/reptile.carp
@@ -110,7 +110,7 @@
 (defn grow [snake]
   (let [new-snake (Snake.update-freeze snake &inc2)
         b (Snake.body &new-snake)
-        new-b (push-back @b (unsafe-last b))]
+        new-b (push-back @b @(unsafe-last b))]
     (Snake.set-body new-snake new-b)))
 
 (defn update-after-kill [world]
@@ -123,7 +123,7 @@
   (let [s (World.snake world)
         h (World.human world)
         b (Snake.body s)
-        head &(unsafe-first b)]
+        head (unsafe-first b)]
     (if (= head h)
       (update-after-kill @world)
       @world)))
@@ -131,7 +131,7 @@
 (defn check-world [world]
   (let [snake (World.snake world)
         b (Snake.body snake)
-        head &(unsafe-first b)
+        head (unsafe-first b)
         x @(Vector2.x head)
         y @(Vector2.y head)]
     (World.set-dead @world (or (< x 0.0)

--- a/test/array.carp
+++ b/test/array.carp
@@ -49,7 +49,7 @@
                 "repeat-indexed works as expected")
   (assert-equal test
                 1
-                (unsafe-first &[1 2 3])
+                @(unsafe-first &[1 2 3])
                 "unsafe-first works as expected")
   (assert-equal test
                 &(Maybe.Just 1)
@@ -61,7 +61,7 @@
                 "first works as expected on empty array")
   (assert-equal test
                 \c
-                (unsafe-last &[\a \b \c])
+                @(unsafe-last &[\a \b \c])
                 "unsafe-last works as expected")
   (assert-equal test
                 &(Maybe.Just \c)

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -212,12 +212,12 @@
 (defn array-first []
   (let [xs [@"a" @"b" @"c"]
         result (Array.unsafe-first &xs)]
-    (assert (= @"a" result))))
+    (assert (= "a" result))))
 
 (defn array-last []
   (let [xs [@"a" @"b" @"c"]
         result (Array.unsafe-last &xs)]
-    (assert (= @"c" result))))
+    (assert (= "c" result))))
 
 (defn array-eq-1 []
   (let [xs [@"a" @"b" @"c"]


### PR DESCRIPTION
This PR changes the unsafe array functions to returns references directly. According to GitHub search, only Carp internally uses those functions, so they should be safe for change.

Cheers