### PR TITLE
Filter out unit types from call

### DIFF
--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -733,10 +733,12 @@ toDeclaration (Binder meta xobj@(XObj (Lst xobjs) _ t)) =
 toDeclaration _ = error "Missing case."
 
 paramListToC :: [XObj] -> String
-paramListToC xobjs = intercalate ", " (map getParam xobjs)
+paramListToC xobjs = intercalate ", " (map getParam (filter notUnit xobjs))
   where getParam :: XObj -> String
         getParam (XObj (Sym (SymPath _ name) _) _ (Just t)) = tyToCLambdaFix t ++ " " ++ mangle name
         getParam invalid = error (show (InvalidParameter invalid))
+        notUnit (XObj _ _ (Just UnitTy)) = False
+        notUnit _ = True
 
 projectIncludesToC :: Project -> String
 projectIncludesToC proj = intercalate "\n" (map includerToC includes) ++ "\n\n"


### PR DESCRIPTION
This PR fixes #557 by removing unit types from calling forms. It makes programs like this work:

```
(defn f [x] x)

(defn main [] (f ()))
```

Which before errored by trying to emit a parameter of type `void` in the argument list.

Cheers