### PR TITLE
Add 2 missing includes on core/Core.carp

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -12,6 +12,8 @@
 (system-include "carp_stdbool.h")
 (system-include "core.h")
 (system-include "carp_memory.h")
+(system-include "sys/wait.h")
+(system-include "unistd.h")
 
 (load "Interfaces.carp")
 (load "Bool.carp")


### PR DESCRIPTION
Looks like there was 2 missing includes on the Core.carp file, making compilation fail on systems that those are not imported by default