### PR TITLE
macros: add enum form

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -342,3 +342,12 @@ The expression must be evaluable at compile time.")
 (doc gensym "generates symbols dynamically as needed.")
 (defndynamic gensym []
   (gensym-with 'gensym-generated))
+
+(defndynamic make-enum-constructors [constructors]
+  (if (= (length constructors) 0)
+    ()
+    (cons (list (car constructors) [])
+          (make-enum-constructors (cdr constructors)))))
+
+(defmacro enum [name :rest constructors]
+  (cons 'deftype (cons name (make-enum-constructors constructors))))


### PR DESCRIPTION
This PR adds the `enum` macro form. It is basically a convenience form around `deftype` with sumtypes without arguments. That means that this

```clojure
(enum TwoState
  First
  Second
)
```

desugars to this

```clojure
(deftype TwoState
  (First [])
  (Second [])
)
```

It is thus purely a vehicle for convenience and clarity, and not for functionality. Therefore it is subject to all concerns for style that anyone might have. If you think the name needs to change, or the form needs to change, let me know!

Cheers