### PR TITLE
macros: add cxr, nthcar, and nthcdr

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -73,6 +73,25 @@
   (defndynamic cdddar [pair] (cdr (cdr (cdr (car pair)))))
   (defndynamic cddddr [pair] (cdr (cdr (cdr (cdr pair)))))
 
+  (defndynamic cxr [x pair]
+    (if (= (length x) 0)
+      (list 'quote pair)
+      (list
+        (if (= 'a (cadr x))
+          'car
+          (if (= 'd (cadr x))
+            'cdr
+            (macro-error "`cxr` expects either `a` or `d` symbols, got " (cadr x))))
+        (if (= 1 (car x))
+          (cxr (cddr x) pair)
+          (cxr (cons (- (car x) 1) (cdr x)) pair)))))
+
+  (defndynamic nthcdr [n pair]
+    (cxr (list n 'd) pair))
+
+  (defndynamic nthcar [n pair]
+    (cxr (list 1 'a n 'd) pair))
+
   (defndynamic eval-internal [form]
     (list 'do
           (list 'defn 'main [] (list 'IO.println* form))


### PR DESCRIPTION
This PR adds the dynamic functions `cxr`, `nthcar`, and `nthcdr`. They build on top of `car` and `cdr` to allow arbitrary accesses, like so:

```clojure
(defdynamic x '(1 2 ((3) 4) 5))
(cxr '(3 a 2 d) x) ; => 3, equivalent to caaaddr
(nthcdr 2 x) ; => (((3) 4) 5)
(nthcar 2 x) ; => ((3) 4)
```

I’m not quite sure about the naming of `nthcar`, because it suggests `n` `car` operations, when in fact it’s `n` `cdr`s followed by one `car`. In Common Lisp, this is just called `nth`, but since we already use that name, I’d like to avoid that. Any alternative suggestions are welcome!

Cheers