### PR TITLE
RFC: Add Array.unreduce

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -257,17 +257,17 @@ This function copies the array. If you don’t want that, use [`endo-map`](#endo
         (aset-uninitialized! &na i (~f (unsafe-nth a i))))
       na))
 
-  (doc map-> "creates an array by producing values using `step` until they no
-longer satisfy `test`. The initial value is `start`.
+  (doc unreduce "creates an array by producing values using `step` until they
+no longer satisfy `test`. The initial value is `start`.
 
 Example:
 ```
 ; if we didn’t have Array.range, we could define it like this:
 (defn range [start end step]
-  (map-> start &(fn [x] (< x (+ step end))) &(fn [x] (+ x step)))
+  (unreduce start &(fn [x] (< x (+ step end))) &(fn [x] (+ x step)))
 )
 ```")
-  (defn map-> [start test step]
+  (defn unreduce [start test step]
     (let-do [elem start
              acc []]
       (while-do (~test elem)

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -257,6 +257,24 @@ This function copies the array. If you don’t want that, use [`endo-map`](#endo
         (aset-uninitialized! &na i (~f (unsafe-nth a i))))
       na))
 
+  (doc map-> "creates an array by producing values using `step` until they no
+longer satisfy `test`. The initial value is `start`.
+
+Example:
+```
+; if we didn’t have Array.range, we could define it like this:
+(defn range [start end step]
+  (map-> start &(fn [x] (< x (+ step end))) &(fn [x] (+ x step)))
+)
+```")
+  (defn map-> [start test step]
+    (let-do [elem start
+             acc []]
+      (while-do (~test elem)
+        (push-back! &acc elem)
+        (set! elem (~step elem)))
+      acc))
+
   (doc zip "maps over two arrays using a function `f` that takes two arguments. It will produces a new array with the length of the shorter input.
 
 The trailing elements of the longer array will be discarded.")

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -669,33 +669,6 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#map-&gt;">
-                    <h3 id="map-&gt;">
-                        map-&gt;
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [a, (Ref (λ [a] Bool)), (Ref (λ [a] a))] (Array a))
-                </p>
-                <pre class="args">
-                    (map-&gt; start test step)
-                </pre>
-                <p class="doc">
-                    <p>creates an array by producing values using <code>step</code> until they no
-longer satisfy <code>test</code>. The initial value is <code>start</code>.</p>
-<p>Example:</p>
-<pre><code>; if we didn’t have Array.range, we could define it like this:
-(defn range [start end step]
-  (map-&gt; start &amp;(fn [x] (&lt; x (+ step end))) &amp;(fn [x] (+ x step)))
-)
-</code></pre>
-
-                </p>
-            </div>
-            <div class="binder">
                 <a class="anchor" href="#maximum">
                     <h3 id="maximum">
                         maximum
@@ -1340,6 +1313,33 @@ longer satisfy <code>test</code>. The initial value is <code>start</code>.</p>
                 </pre>
                 <p class="doc">
                     <p>swaps the indices <code>i</code> and <code>j</code> of an array <code>a</code> in place.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#unreduce">
+                    <h3 id="unreduce">
+                        unreduce
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, (Ref (λ [a] Bool)), (Ref (λ [a] a))] (Array a))
+                </p>
+                <pre class="args">
+                    (unreduce start test step)
+                </pre>
+                <p class="doc">
+                    <p>creates an array by producing values using <code>step</code> until they
+no longer satisfy <code>test</code>. The initial value is <code>start</code>.</p>
+<p>Example:</p>
+<pre><code>; if we didn’t have Array.range, we could define it like this:
+(defn range [start end step]
+  (unreduce start &amp;(fn [x] (&lt; x (+ step end))) &amp;(fn [x] (+ x step)))
+)
+</code></pre>
 
                 </p>
             </div>

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -669,6 +669,33 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#map-&gt;">
+                    <h3 id="map-&gt;">
+                        map-&gt;
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [a, (Ref (λ [a] Bool)), (Ref (λ [a] a))] (Array a))
+                </p>
+                <pre class="args">
+                    (map-&gt; start test step)
+                </pre>
+                <p class="doc">
+                    <p>creates an array by producing values using <code>step</code> until they no
+longer satisfy <code>test</code>. The initial value is <code>start</code>.</p>
+<p>Example:</p>
+<pre><code>; if we didn’t have Array.range, we could define it like this:
+(defn range [start end step]
+  (map-&gt; start &amp;(fn [x] (&lt; x (+ step end))) &amp;(fn [x] (+ x step)))
+)
+</code></pre>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#maximum">
                     <h3 id="maximum">
                         maximum
@@ -717,16 +744,17 @@
                     </h3>
                 </a>
                 <div class="description">
-                    template
+                    defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array t)), Int] &amp;t)
+                    (λ [(Ref (Array a)), Int] (Maybe a))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (nth xs index)
+                </pre>
                 <p class="doc">
-                    <p>gets a reference to the <code>n</code>th element from an array <code>a</code>.</p>
+                    <p>gets a reference to the <code>n</code>th element from an array <code>arr</code> wrapped on a <code>Maybe</code>.</p>
+<p>If the <code>index</code> is out of bounds, return <code>Maybe.Nothing</code></p>
 
                 </p>
             </div>
@@ -1354,6 +1382,26 @@
                 <p class="doc">
                     <p>takes the last element of an array.</p>
 <p>Generates a runtime error if the array is empty.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#unsafe-nth">
+                    <h3 id="unsafe-nth">
+                        unsafe-nth
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Array t)), Int] &amp;t)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>gets a reference to the <code>n</code>th element from an array <code>a</code>.</p>
 
                 </p>
             </div>

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -406,27 +406,6 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#ptr">
-                    <h3 id="ptr">
-                        ptr
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (λ [(Ref (Maybe a))] (Ptr a))
-                </p>
-                <pre class="args">
-                    (ptr a)
-                </pre>
-                <p class="doc">
-                    <p>Creates a <code>(Ptr a)</code> from a <code>(Maybe a)</code>. If the <code>Maybe</code> was
-<code>Nothing</code>, this function will return a <code>NULL</code> value.</p>
-
-                </p>
-            </div>
-            <div class="binder">
                 <a class="anchor" href="#str">
                     <h3 id="str">
                         str
@@ -484,6 +463,27 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                 </pre>
                 <p class="doc">
                     <p>is an unsafe unwrapper that will get the value from a <code>Just</code>. If <code>a</code> is <code>Nothing</code>, a runtime error will be generated.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#unsafe-ptr">
+                    <h3 id="unsafe-ptr">
+                        unsafe-ptr
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Maybe a))] (Ptr a))
+                </p>
+                <pre class="args">
+                    (unsafe-ptr a)
+                </pre>
+                <p class="doc">
+                    <p>Creates a <code>(Ptr a)</code> from a <code>(Maybe a)</code>. If the <code>Maybe</code> was
+<code>Nothing</code>, this function will return a <code>NULL</code> value.</p>
 
                 </p>
             </div>

--- a/test/array.carp
+++ b/test/array.carp
@@ -293,4 +293,9 @@
   (assert-equal test
                 &[1 3]
                 &(remove-nth 1 [1 2 3])
-                "remove-nth works"))
+                "remove-nth works")
+  (assert-equal test
+                &[1.0 1.5 2.0 2.5]
+                &(map-> 1.0 &(fn [x] (< x 3.0)) &(fn [x] (+ x 0.5)))
+                "map-> works")
+)

--- a/test/array.carp
+++ b/test/array.carp
@@ -296,6 +296,6 @@
                 "remove-nth works")
   (assert-equal test
                 &[1.0 1.5 2.0 2.5]
-                &(map-> 1.0 &(fn [x] (< x 3.0)) &(fn [x] (+ x 0.5)))
-                "map-> works")
+                &(unreduce 1.0 &(fn [x] (< x 3.0)) &(fn [x] (+ x 0.5)))
+                "unreduce works")
 )


### PR DESCRIPTION
This PR adds `Array.map->`. This seems like a very useful function to me, but I may be alone with that judgement, so please tell me if you’d rather not have this in the standard library.

`map->` represents a functional generalization of looping in a `map`-like interface. To quote from its docstring:

`map->` creates an array by producing values using `step` until they no longer satisfy `test`. The initial value is `start`.

Example:
```clojure
; if we didn’t have Array.range, we could define it like this:
(defn range [start end step]
  (map-> start &(fn [x] (< x (+ step end))) &(fn [x] (+ x step)))
)
```

It is thus a little hard to understand, but once you do it is fairly powerful.

Cheers