### PR TITLE
[win] attempt to fix windows compilation

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -12,8 +12,12 @@
 (system-include "carp_stdbool.h")
 (system-include "core.h")
 (system-include "carp_memory.h")
-(system-include "sys/wait.h")
-(system-include "unistd.h")
+
+(if (not (Dynamic.or (= "windows" (os)) (= "mingw32" (os))))
+  (do
+    (system-include "sys/wait.h")
+    (system-include "unistd.h"))
+  ())
 
 (load "Interfaces.carp")
 (load "Bool.carp")

--- a/core/core.h
+++ b/core/core.h
@@ -1,6 +1,8 @@
 #if defined(WIN32) || defined(_WIN32) || \
     defined(__WIN32) && !defined(__CYGWIN__)
 #include <windows.h>
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #endif
 #ifndef _WIN32
 #include <unistd.h>


### PR DESCRIPTION
Can Dynamic.or be used in Core.carp like this? or will this never evaluate true on non-win systems? This could be hacky in some way, but it's small and fixed compilation on my system.