### PR TITLE
core: make result functions take refs

### DIFF
--- a/core/Result.carp
+++ b/core/Result.carp
@@ -6,13 +6,13 @@
   (doc apply "takes a `Result` `a` and applies functions to them, one in the case that it is an `Error`, one in the case that it is a `Success`.")
   (defn apply [a success-f error-f]
     (match a
-      (Success x) (Success (success-f x))
-      (Error x) (Error (error-f x))))
+      (Success x) (Success (~success-f x))
+      (Error x) (Error (~error-f x))))
 
   (doc map "takes a `Result` and applies a function `f` to it if it is a `Success` type, and wraps it back up. In the case that it is an `Error`, it is returned as is.")
   (defn map [a f]
     (match a
-      (Success x) (Success (f x))
+      (Success x) (Success (~f x))
       (Error x) (Error x)))
 
   (doc and-then "takes a `Result` and applies a function `f` to it if it is a `Success` type. In the case that it is an `Error`, it is returned as is.
@@ -20,7 +20,7 @@
 It is thus quite similar to [`map`](#map), but it will unwrap the value.")
   (defn and-then [a f]
     (match a
-      (Success x) (f x)
+      (Success x) (~f x)
       (Error x) (Error x)))
 
   (doc unwrap-or-zero "takes a `Result` and either unwraps it if it is a `Success`, or calls `zero`. `zero` must be defined on the `Success` type.")
@@ -35,13 +35,13 @@ It is the inverse of [`and-then`](#and-then).")
   (defn or-else [a f]
     (match a
       (Success x) (Success x)
-      (Error x) (f x)))
+      (Error x) (~f x)))
 
   (doc unwrap-or-else "takes a `Result` and either unwraps it if it is a `Success`, or calls a function `f` on the value contained in the `Error`.")
   (defn unwrap-or-else [a f]
     (match a
       (Success x) x
-      (Error x) (f x)))
+      (Error x) (~f x)))
 
   (doc unsafe-from-success "is an unsafe unwrapper that will get the value from a `Success`. If `a` is an `Error`, a runtime error will be generated.")
   (defn unsafe-from-success [a]

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -216,7 +216,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (λ [a] (Result c b))] (Result c b))
+                    (λ [(Result a b), (Ref (λ [a] (Result c b)))] (Result c b))
                 </p>
                 <pre class="args">
                     (and-then a f)
@@ -237,7 +237,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (λ [a] c), (λ [b] d)] (Result c d))
+                    (λ [(Result a b), (Ref (λ [a] c)), (Ref (λ [b] d))] (Result c d))
                 </p>
                 <pre class="args">
                     (apply a success-f error-f)
@@ -376,7 +376,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (λ [a] c)] (Result c b))
+                    (λ [(Result a b), (Ref (λ [a] c))] (Result c b))
                 </p>
                 <pre class="args">
                     (map a f)
@@ -396,7 +396,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (λ [b] (Result a c))] (Result a c))
+                    (λ [(Result a b), (Ref (λ [b] (Result a c)))] (Result a c))
                 </p>
                 <pre class="args">
                     (or-else a f)
@@ -539,7 +539,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (λ [b] a)] a)
+                    (λ [(Result a b), (Ref (λ [b] a))] a)
                 </p>
                 <pre class="args">
                     (unwrap-or-else a f)

--- a/test/result.carp
+++ b/test/result.carp
@@ -21,31 +21,31 @@
   )
   (assert-equal test
                 &(Success 1)
-                &(apply (Success 0) Int.inc Int.dec)
+                &(apply (Success 0) &Int.inc &Int.dec)
                 "apply works with Success"
   )
   (assert-equal test
                 &(Error -1)
-                &(apply (Error 0) Int.inc Int.dec)
+                &(apply (Error 0) &Int.inc &Int.dec)
                 "apply works with Error"
   )
   (assert-true test
-               (error? &(map (Error @"hi") Int.inc))
+               (error? &(map (Error @"hi") &Int.inc))
                "map works with Error"
   )
   (assert-equal test
                 &(Success 2)
-                &(map (the (Result Int String) (Success 1)) Int.inc)
+                &(map (the (Result Int String) (Success 1)) &Int.inc)
                 "map works with Success"
   )
   (assert-true test
-               (error? &(and-then (Error @"hi") (fn [x] (Success (Int.inc x)))))
+               (error? &(and-then (Error @"hi") &(fn [x] (Success (Int.inc x)))))
                "and-then works with Error"
   )
   (assert-equal test
                 &(Success 2)
                 &(and-then (the (Result Int String) (Success 1))
-                           (fn [x] (Success (Int.inc x))))
+                           &(fn [x] (Success (Int.inc x))))
                 "and-then works with Success"
   )
   (assert-equal test
@@ -61,23 +61,23 @@
   (assert-equal test
                 &(Error 5)
                 &(or-else (the (Result Int String) (Error @"error"))
-                          (fn [x] (Error (String.length &x))))
+                          &(fn [x] (Error (String.length &x))))
                 "or-else works with Error"
   )
   (assert-equal test
                 &(Success 1)
-                &(or-else (Success 1) (fn [x] (Error (String.length &x))))
+                &(or-else (Success 1) &(fn [x] (Error (String.length &x))))
                 "or-else works with Success"
   )
   (assert-equal test
                 5
                 (unwrap-or-else (the (Result Int String) (Error @"error"))
-                                (fn [s] (String.length &s)))
+                                &(fn [s] (String.length &s)))
                 "unwrap-or-else works with Error"
   )
   (assert-equal test
                 1
-                (unwrap-or-else (Success 1) (fn [s] (String.length &s)))
+                (unwrap-or-else (Success 1) &(fn [s] (String.length &s)))
                 "unwrap-or-else works with Success"
   )
   (assert-equal test


### PR DESCRIPTION
This PR makes sure that `Result` functions take refs. Before, they would take ownership over the function, which we generally do not want.

Cheers