### PR TITLE
core: add String.from-cstr

### DIFF
--- a/core/String.carp
+++ b/core/String.carp
@@ -10,6 +10,7 @@
   (register copy       (Fn [&String] String))
   (register length     (Fn [&String] Int))
   (register cstr       (Fn [&String] (Ptr Char)))
+  (register from-cstr  (Fn [(Ptr Char)] String))
   (register str        (Fn [&String] String))
   (register prn        (Fn [&String] String))
   (register index-of   (Fn [&String Char] Int))

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -93,7 +93,7 @@ char *String_cstr(const String *s) {
 }
 
 String String_from_MINUS_cstr(char *s) {
-    return s;
+    return String_copy(&s);
 }
 
 String String_str(const String *s) {

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -92,6 +92,10 @@ char *String_cstr(const String *s) {
     return *s;
 }
 
+String String_from_MINUS_cstr(char *s) {
+    return s;
+}
+
 String String_str(const String *s) {
     return String_copy(s);
 }

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -517,6 +517,25 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#from-cstr">
+                    <h3 id="from-cstr">
+                        from-cstr
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (λ [(Ptr Char)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#hash">
                     <h3 id="hash">
                         hash


### PR DESCRIPTION
This PR adds `String.from-cstr`. It’s a noop function that only appeases the typechecker.

Cheers