### PR TITLE
Check index in char-at

### DIFF
--- a/core/Format.carp
+++ b/core/Format.carp
@@ -5,32 +5,34 @@
         len (String.length s)]
     (if (= idx -1)
       (list 'copy s) ; no more splits found, just return string
-      (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
-        (list 'ref
-          (list 'String.append
-                "%"
-                (fmt-internal (String.substring s (+ idx 2) len) args)))
-        (if (= 0 (length args)) ; we need to insert something, but have nothing
-          (macro-error
-            (str "error in format string: not enough arguments to format string (missing argument for '%"
-                 (String.substring s (inc idx) (inc (inc idx)))
-                 "')"))
-          ; okay, this is the meat:
-          ; get the next % after our escaper
-          (let [next (String.index-of (String.substring s (inc idx) len) \%)]
-            (if (= -1 next)
-              (if (< 1 (length args))
-                (macro-error
-                  (str "error in format string: too many arguments to format string (missing directive for '"
-                       (cadr args)
-                       "')"))
-                (list 'ref (list 'format s (car args))))
-              (let [slice (String.substring s 0 (+ (inc idx) next))]
-                (list 'ref
-                  (list 'String.append
-                    (list 'ref (list 'format slice (car args)))
-                    (fmt-internal (String.substring s (+ (inc idx) next) len)
-                                      (cdr args))))))))))))
+      (if (= len 1)
+        (macro-error "error in format string: expected expression after last %")
+        (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
+          (list 'ref
+            (list 'String.append
+                  "%"
+                  (fmt-internal (String.substring s (+ idx 2) len) args)))
+          (if (= 0 (length args)) ; we need to insert something, but have nothing
+            (macro-error
+              (str "error in format string: not enough arguments to format string (missing argument for '%"
+                   (String.substring s (inc idx) (inc (inc idx)))
+                   "')"))
+            ; okay, this is the meat:
+            ; get the next % after our escaper
+            (let [next (String.index-of (String.substring s (inc idx) len) \%)]
+              (if (= -1 next)
+                (if (< 1 (length args))
+                  (macro-error
+                    (str "error in format string: too many arguments to format string (missing directive for '"
+                         (cadr args)
+                         "')"))
+                  (list 'ref (list 'format s (car args))))
+                (let [slice (String.substring s 0 (+ (inc idx) next))]
+                  (list 'ref
+                    (list 'String.append
+                      (list 'ref (list 'format slice (car args)))
+                      (fmt-internal (String.substring s (+ (inc idx) next) len)
+                                        (cdr args)))))))))))))
 
 (doc fmt "formats a string. It supports all of the string interpolations defined in format of the type that should be interpolated (e.g. %d and %x on integers).")
 (defmacro fmt [s :rest args]

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -656,7 +656,10 @@ commandCharAt :: CommandCallback
 commandCharAt [a, b] =
   return $ case (a, b) of
     (XObj (Str s) _ _, XObj (Num IntTy n) _ _) ->
-      Right (XObj (Chr (s !! (round n :: Int))) (Just dummyInfo) (Just IntTy))
+      let i = (round n :: Int)
+      in if length s > i
+         then Right (XObj (Chr (s !! i)) (Just dummyInfo) (Just IntTy))
+         else Left (EvalError ("Can't call char-at with " ++ pretty a ++ " and " ++ show i ++ ", index too large") (info a))
     _ ->
       Left (EvalError ("Can't call char-at with " ++ pretty a ++ " and " ++ pretty b) (info a))
 

--- a/test-for-errors/char_at_index.carp
+++ b/test-for-errors/char_at_index.carp
@@ -1,0 +1,2 @@
+(Project.config "file-path-print-length" "short")
+(String.char-at "" 1)

--- a/test/output/test-for-errors/char_at_index.carp.output.expected
+++ b/test/output/test-for-errors/char_at_index.carp.output.expected
@@ -1,0 +1,1 @@
+Can't call char-at with "" and 1, index too large at char_at_index.carp:2:17.


### PR DESCRIPTION
This PR fixes #636 by checking the index of `char-at`. It also makes the same error in `fmt` more informative.

A test case is included.

Cheers