### PR TITLE
README > Update the example for macOS Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Carp REPL has built-in documentation, run ```(help)``` to access it!
     (SDLApp.run-with-callbacks &app SDLApp.quit-on-esc tick draw state)))
 ```
 
-To build this example, save it to a file called 'example.carp' and load it with ```(load "example.carp")```, then execute ```(build)``` to build an executable, and ```(run)``` to start. The external dependencies are SDL2 and pkg-config.
+To build this example, save it to a file called 'example.carp' and load it with ```(load "example.carp")```, then execute ```(build)``` to build an executable, and ```(run)``` to start. The external dependencies are SDL2 and pkg-config. On macOS Catalina libiconv is also required.
 
 ### Language Designer & Lead Developer
 [Erik Svedäng](http://www.eriksvedang.com) ([@e_svedang](https://twitter.com/e_svedang))


### PR DESCRIPTION
I updated the README's example to note the additional dependency required for macOS Catalina as per issue #638. 