### PR TITLE
Add Result.map-error

### DIFF
--- a/core/Result.carp
+++ b/core/Result.carp
@@ -15,6 +15,12 @@
       (Success x) (Success (~f x))
       (Error x) (Error x)))
 
+  (doc map-error "takes a `Result` and applies a function `f` to it if it is an `Error` type, and wraps it back up. In the case that it is a `Success`, it is returned as is.")
+  (defn map-error [a f]
+    (match a
+      (Success x) (Success x)
+      (Error x) (Error (~f x))))
+
   (doc and-then "takes a `Result` and applies a function `f` to it if it is a `Success` type. In the case that it is an `Error`, it is returned as is.
 
 It is thus quite similar to [`map`](#map), but it will unwrap the value.")

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -387,6 +387,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#map-error">
+                    <h3 id="map-error">
+                        map-error
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Result a b), (Ref (λ [b] c))] (Result a c))
+                </p>
+                <pre class="args">
+                    (map-error a f)
+                </pre>
+                <p class="doc">
+                    <p>takes a <code>Result</code> and applies a function <code>f</code> to it if it is an <code>Error</code> type, and wraps it back up. In the case that it is a <code>Success</code>, it is returned as is.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#or-else">
                     <h3 id="or-else">
                         or-else

--- a/test/result.carp
+++ b/test/result.carp
@@ -39,6 +39,15 @@
                 "map works with Success"
   )
   (assert-true test
+               (success? &(map-error (Success @"hi") &Int.inc))
+               "map-error works with Success"
+  )
+  (assert-equal test
+                &(Error 2)
+                &(map-error (the (Result String Int) (Error 1)) &Int.inc)
+                "map-error works with Error"
+  )
+  (assert-true test
                (error? &(and-then (Error @"hi") &(fn [x] (Success (Int.inc x)))))
                "and-then works with Error"
   )


### PR DESCRIPTION
This PR adds `Result.map-error`, which was missing before and fills a hole that is opened by `map` on the `Success` constructor. Since `Error` and `Success` should generally have the same functionality attached to them, that’s what I settled on.

Test cases are included.

Cheers