### PR TITLE
Better performance in Map./Set.put!

### DIFF
--- a/core/Map.carp
+++ b/core/Map.carp
@@ -73,9 +73,15 @@
     (do (Array.aupdate! (entries &b) i &(fn [p] (Pair.set-b @p @val)))
         b))
 
+  (defn set-idx! [b i val]
+    (Array.aupdate! (entries b) i &(fn [p] (Pair.set-b @p @val))))
+
   (defn push-back [b k v]
     (do (Array.push-back! (entries &b) (Pair.init-from-refs k v))
         b))
+
+  (defn push-back! [b k v]
+    (Array.push-back! (entries b) (Pair.init-from-refs k v)))
 
   (defn get [b k default-value]
     (let [i (find b k)]
@@ -95,6 +101,12 @@
       (if (<= 0 i)
         (set-idx b i v)
         (push-back b k v))))
+
+  (defn put! [b k v]
+    (let [i (find b k)]
+      (if (<= 0 i)
+        (set-idx! b i v)
+        (push-back! b k v))))
 
   (defn contains? [b k]
     (<= 0 (find b k)))
@@ -140,7 +152,7 @@
     (let [idx (Int.positive-mod (hash k) @(n-buckets m))
           b (buckets m)
           n (Array.unsafe-nth b idx)]
-      (Array.aset! b idx (Bucket.put @n k v))))
+      (Bucket.put! n k v)))
 
   (doc get-with-default "Get the value for the key k from map m. If it isn’t found, the default is returned.")
   (defn get-with-default [m k default-value]
@@ -321,6 +333,9 @@
              (set! nentries (Array.push-back nentries @e)))))
       nentries))
 
+  (defn push-back! [b k]
+    (Array.push-back! (entries b) k))
+
   (defn shrink [b k]
     (if (contains? b k)
       (set-entries @b (remove (entries b) k))
@@ -356,7 +371,7 @@
           b (buckets s)
           n (Array.unsafe-nth b idx)]
       (when (not (SetBucket.contains? n k))
-        (Array.aset! b idx (SetBucket.grow n @k)))))
+        (SetBucket.push-back! n @k))))
 
   (doc length "Get the length of set s.")
   (defn length [s]


### PR DESCRIPTION
This PR increases the performance of `put!` for `Map` and `Set` in the presence of collisions by reducing indirection and allocation.

The peformance can be tested with, for instance, this program:

```clojure
(load "Bench.carp")

(add-cflag "-O3 -flto -march=native -fomit-frame-pointer")

(defn main []
  (let-do [m (Set.create-with-len 16777216)
           x (Bench.get-time-elapsed)]
    (for [i 0 16777216] (Set.put! &m &(Int.random)))
    (Bench.print "Time: " (- (Bench.get-time-elapsed) x))))
```

On my machine (a recent MacBook Pro), this prints around 7.5 seconds versus around 13 seconds before, so it’s pretty substantial.

Cheers