### PR TITLE
Move get-time-elapsed into Bench module

### DIFF
--- a/core/Bench.carp
+++ b/core/Bench.carp
@@ -1,12 +1,15 @@
 (load "Statistics.carp")
 
 (system-include "carp_bench.h")
-(register get-time-elapsed (Fn [] Double))
 
 (defmodule Bench
   (def min-runs 50)
   (private min-runs)
   (hidden min-runs)
+
+  (private get-time-elapsed)
+  (hidden get-time-elapsed)
+  (register get-time-elapsed (Fn [] Double) "get_time_elapsed")
 
   (doc set-min-runs! "sets the minimum number of runs to `n`.
 
@@ -106,15 +109,15 @@ If your functions takes a large amount of time, experimenting with this might ma
 
 
 (defmacro benchn [n form]
-  (list 'let ['before (get-time-elapsed)
+  (list 'let ['before (Bench.get-time-elapsed)
               'times []]
     (list 'do
       (list 'for ['i 0 n]
-        (list 'let ['before-once (get-time-elapsed)]
+        (list 'let ['before-once (Bench.get-time-elapsed)]
           (list 'do
             form
-            (list 'set! &times (Array.push-back (Array.copy &times) (Double.- (get-time-elapsed) before-once))))))
-      (list 'let ['total (Double.- (get-time-elapsed) before)
+            (list 'set! &times (Array.push-back (Array.copy &times) (Double.- (Bench.get-time-elapsed) before-once))))))
+      (list 'let ['total (Double.- (Bench.get-time-elapsed) before)
                   'per (list 'Double./ 'total (list 'Double.from-int n))]
         (do
           (Bench.print "Total time elapsed: " total)

--- a/core/carp_bench.h
+++ b/core/carp_bench.h
@@ -1,4 +1,4 @@
-double get_MINUS_time_MINUS_elapsed() {
+double get_time_elapsed() {
     struct timespec tv;
     clock_gettime(CLOCK_REALTIME, &tv);
     return 1000000000 * tv.tv_sec + tv.tv_nsec;


### PR DESCRIPTION
This PR cleans up the Bench module by moving `get-time-elapsed` into the module and cleaning up the name in C.

Cheers