### PR TITLE
Use snprintf only when checking length

### DIFF
--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -670,13 +670,13 @@ Array Pattern_global_MINUS_match(Pattern *p, String *s) {
 String Pattern_internal_add_char(String a, char b) {
     if (!a) {
         String buffer = CARP_MALLOC(2);
-        snprintf(buffer, 2, "%c", b);
+        sprintf(buffer, "%c", b);
         return buffer;
     }
 
     int len = strlen(a) + 2;
     String buffer = CARP_MALLOC(len);
-    snprintf(buffer, len, "%s%c", a, b);
+    sprintf(buffer, "%s%c", a, b);
     CARP_FREE(a);
     return buffer;
 }
@@ -747,7 +747,7 @@ String Pattern_substitute(Pattern *p, String *s, String *t, int ns) {
 
     int l = strlen(res) + strlen(str) + 1;
     String buffer = CARP_MALLOC(l);
-    snprintf(buffer, l, "%s%s", res, str);
+    sprintf(buffer, "%s%s", res, str);
     CARP_FREE(res);
     return buffer;
 }
@@ -773,7 +773,7 @@ String Pattern_str(Pattern *p) {
 String Pattern_prn(Pattern *p) {
     int n = strlen(*p) + 4;
     String buffer = CARP_MALLOC(n);
-    snprintf(buffer, n, "#\"%s\"", *p);
+    sprintf(buffer, "#\"%s\"", *p);
     return buffer;
 }
 

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -80,7 +80,7 @@ String String_append(const String *a, const String *b) {
     int lb = strlen(*b);
     int total = la + lb + 1;
     String buffer = CARP_MALLOC(total);
-    snprintf(buffer, total, "%s%s", *a, *b);
+    sprintf(buffer, "%s%s", *a, *b);
     return buffer;
 }
 
@@ -103,7 +103,7 @@ String String_str(const String *s) {
 String String_prn(const String *s) {
     int n = strlen(*s) + 4;
     String buffer = CARP_MALLOC(n);
-    snprintf(buffer, n, "@\"%s\"", *s);
+    sprintf(buffer, "@\"%s\"", *s);
     return buffer;
 }
 
@@ -114,7 +114,7 @@ char String_char_MINUS_at(const String *s, int i) {
 String String_format(const String *str, const String *s) {
     int size = snprintf(NULL, 0, *str, *s) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *str, *s);
+    sprintf(buffer, *str, *s);
     return buffer;
 }
 
@@ -160,68 +160,68 @@ String Bool_str(bool b) {
 String Bool_format(const String *str, bool b) {
     int size = snprintf(NULL, 0, *str, b) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *str, b);
+    sprintf(buffer, *str, b);
     return buffer;
 }
 
 String Char_str(char c) {
     String buffer = CARP_MALLOC(2);
-    snprintf(buffer, 2, "%c", c);
+    sprintf(buffer, "%c", c);
     return buffer;
 }
 
 String Char_prn(char c) {
     String buffer = CARP_MALLOC(3);
-    snprintf(buffer, 3, "\\%c", c);
+    sprintf(buffer, "\\%c", c);
     return buffer;
 }
 
 String Char_format(const String *str, char b) {
     int size = snprintf(NULL, 0, *str, b) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *str, b);
+    sprintf(buffer, *str, b);
     return buffer;
 }
 
 String Double_str(double x) {
     int size = snprintf(NULL, 0, "%g", x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, "%g", x);
+    sprintf(buffer, "%g", x);
     return buffer;
 }
 
 String Double_format(const String *s, double x) {
     int size = snprintf(NULL, 0, *s, x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *s, x);
+    sprintf(buffer, *s, x);
     return buffer;
 }
 
 String Float_str(float x) {
     int size = snprintf(NULL, 0, "%gf", x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, "%gf", x);
+    sprintf(buffer, "%gf", x);
     return buffer;
 }
 
 String Float_format(const String *str, float x) {
     int size = snprintf(NULL, 0, *str, x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *str, x);
+    sprintf(buffer, *str, x);
     return buffer;
 }
 
 String Int_str(int x) {
     int size = snprintf(NULL, 0, "%d", x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, "%d", x);
+    sprintf(buffer, "%d", x);
     return buffer;
 }
 
 String Int_format(const String *str, int x) {
     int size = snprintf(NULL, 0, *str, x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *str, x);
+    sprintf(buffer, *str, x);
     return buffer;
 }
 
@@ -232,14 +232,14 @@ int Int_from_MINUS_string(const String *s) {
 String Long_str(long x) {
     int size = snprintf(NULL, 0, "%ldl", x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, "%ldl", x);
+    sprintf(buffer, "%ldl", x);
     return buffer;
 }
 
 String Long_format(const String *str, long x) {
     int size = snprintf(NULL, 0, *str, x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *str, x);
+    sprintf(buffer, *str, x);
     return buffer;
 }
 
@@ -248,16 +248,16 @@ long Long_from_MINUS_string(const String *s) {
 }
 
 String Byte_str(uint8_t x) {
-    int size = snprintf(NULL, 0, "%ub", x)+1;
+    int size = snprintf(NULL, 0, "%ub", x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, "%ub", x);
+    sprintf(buffer, "%ub", x);
     return buffer;
 }
 
-String Byte_format(const String* str, uint8_t x) {
-    int size = snprintf(NULL, 0, *str, x)+1;
+String Byte_format(const String *str, uint8_t x) {
+    int size = snprintf(NULL, 0, *str, x) + 1;
     String buffer = CARP_MALLOC(size);
-    snprintf(buffer, size, *str, x);
+    sprintf(buffer, *str, x);
     return buffer;
 }
 

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -80,7 +80,9 @@ String String_append(const String *a, const String *b) {
     int lb = strlen(*b);
     int total = la + lb + 1;
     String buffer = CARP_MALLOC(total);
-    sprintf(buffer, "%s%s", *a, *b);
+    memcpy(buffer, *a, la);
+    memcpy(buffer+la, *b, lb);
+    buffer[la+lb] = '\0';
     return buffer;
 }
 

--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -428,7 +428,7 @@ strTy typeEnv env (StructTy "Array" [innerType]) =
   , TokC   "  String buffer = CARP_MALLOC(size);\n"
   , TokC   "  String bufferPtr = buffer;\n"
   , TokC   "\n"
-  , TokC   "  snprintf(buffer, size, \"[\");\n"
+  , TokC   "  sprintf(buffer, \"[\");\n"
   , TokC   "  bufferPtr += 1;\n"
   , TokC   "\n"
   , TokC   "  for(int i = 0; i < a->len; i++) {\n"
@@ -436,7 +436,7 @@ strTy typeEnv env (StructTy "Array" [innerType]) =
   , TokC   "  }\n"
   , TokC   "\n"
   , TokC   "  if(a->len > 0) { bufferPtr -= 1; }\n"
-  , TokC   "  snprintf(bufferPtr, size, \"]\");\n"
+  , TokC   "  sprintf(bufferPtr, \"]\");\n"
   , TokC   "  return buffer;\n"
   ]
 strTy _ _ _ = []
@@ -469,7 +469,7 @@ insideArrayStr typeEnv env t =
     FunctionFound functionFullName ->
       let takeAddressOrNot = if isManaged typeEnv t then "&" else ""
       in  unlines [ "  temp = " ++ functionFullName ++ "(" ++ takeAddressOrNot ++ "((" ++ tyToC t ++ "*)a->data)[i]);"
-                  , "    snprintf(bufferPtr, size, \"%s \", temp);"
+                  , "    sprintf(bufferPtr, \"%s \", temp);"
                   , "    bufferPtr += strlen(temp) + 1;"
                   , "    if(temp) {"
                   , "      CARP_FREE(temp);"

--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -311,11 +311,11 @@ tokensForStr typeEnv env typeName memberPairs concreteStructTy  =
                         , "  String buffer = CARP_MALLOC(size);"
                         , "  String bufferPtr = buffer;"
                         , ""
-                        , "  snprintf(bufferPtr, size, \"(%s \", \"" ++ typeName ++ "\");"
+                        , "  sprintf(bufferPtr, \"(%s \", \"" ++ typeName ++ "\");"
                         , "  bufferPtr += strlen(\"" ++ typeName ++ "\") + 2;\n"
                         , joinWith "\n" (map (memberPrn typeEnv env) memberPairs)
                         , "  bufferPtr--;"
-                        , "  snprintf(bufferPtr, size, \")\");"
+                        , "  sprintf(bufferPtr, \")\");"
                         , "  return buffer;"
                         , "}"]
 

--- a/src/StructUtils.hs
+++ b/src/StructUtils.hs
@@ -17,15 +17,15 @@ memberPrn typeEnv env (memberName, memberTy) =
    in case nameOfPolymorphicFunction typeEnv env strFuncType "prn" of
         Just strFunctionPath ->
           unlines ["  temp = " ++ pathToC strFunctionPath ++ "(" ++ maybeTakeAddress ++ "p->" ++ memberName ++ ");"
-                  , "  snprintf(bufferPtr, size, \"%s \", temp);"
+                  , "  sprintf(bufferPtr, \"%s \", temp);"
                   , "  bufferPtr += strlen(temp) + 1;"
                   , "  if(temp) { CARP_FREE(temp); temp = NULL; }"
                   ]
         Nothing ->
           if isExternalType typeEnv memberTy
           then unlines [ "  temp = malloc(11);"
-                       , "  snprintf(temp, 11, \"<external>\");"
-                       , "  snprintf(bufferPtr, size, \"%s \", temp);"
+                       , "  sprintf(temp, \"<external>\");"
+                       , "  sprintf(bufferPtr, \"%s \", temp);"
                        , "  bufferPtr += strlen(temp) + 1;"
                        , "  if(temp) { CARP_FREE(temp); temp = NULL; }"
                        ]

--- a/src/Sumtypes.hs
+++ b/src/Sumtypes.hs
@@ -200,12 +200,12 @@ strCase typeEnv env concreteStructTy@(StructTy _ typeVariables) theCase =
   let (name, tys, correctedTagName) = namesFromCase theCase concreteStructTy
   in unlines
      [ "  if(p->_tag == " ++ correctedTagName ++ ") {"
-     , "    snprintf(bufferPtr, size, \"(%s \", \"" ++ name ++ "\");"
+     , "    sprintf(bufferPtr, \"(%s \", \"" ++ name ++ "\");"
      , "    bufferPtr += strlen(\"" ++ name ++ "\") + 2;\n"
      , joinWith "\n" (map (memberPrn typeEnv env) (zip (map (\anon -> name ++ "." ++ anon)
                                                        anonMemberNames) tys))
      , "    bufferPtr--;"
-     , "    snprintf(bufferPtr, size, \")\");"
+     , "    sprintf(bufferPtr, \")\");"
      , "  }"
      ]
 


### PR DESCRIPTION
This PR is basically the vanilla version of #650. We’re removing the length checks with `snprintf` when we know the size already. This avoids a few extra checks.

Cheers