### PR TITLE
Add Float.from-string and Double.from-string

### DIFF
--- a/core/String.carp
+++ b/core/String.carp
@@ -189,6 +189,7 @@
 (defmodule Float
   (register str (Fn [Float] String))
   (register format (Fn [&String Float] String))
+  (register from-string (λ [&String] Float))
 )
 
 (defmodule Long
@@ -200,6 +201,7 @@
 (defmodule Double
   (register str (Fn [Double] String))
   (register format (Fn [&String Double] String))
+  (register from-string (λ [&String] Double))
 )
 
 (defmodule Char

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -199,6 +199,10 @@ String Double_format(const String *s, double x) {
     return buffer;
 }
 
+double Double_from_MINUS_string(const String *s) {
+    return strtod(*s, NULL);
+}
+
 String Float_str(float x) {
     int size = snprintf(NULL, 0, "%gf", x) + 1;
     String buffer = CARP_MALLOC(size);
@@ -211,6 +215,10 @@ String Float_format(const String *str, float x) {
     String buffer = CARP_MALLOC(size);
     sprintf(buffer, *str, x);
     return buffer;
+}
+
+float Float_from_MINUS_string(const String *s) {
+    return strtof(*s, NULL);
 }
 
 String Int_str(int x) {

--- a/test/double_math.carp
+++ b/test/double_math.carp
@@ -101,4 +101,10 @@
                 0l
                 (to-bytes 0.0)
                 "to-bytes works as expected II"
-  ))
+  )
+  (assert-equal test
+                10.3
+                (from-string "10.3")
+                "from-string works as expected"
+  )
+)

--- a/test/float_math.carp
+++ b/test/float_math.carp
@@ -107,4 +107,10 @@
                 0
                 (to-bytes 0.0f)
                 "to-bytes works as expected II"
-  ))
+  )
+  (assert-equal test
+                10.3f
+                (from-string "10.3")
+                "from-string works as expected"
+  )
+)


### PR DESCRIPTION
This PR adds `Float.from-string` and `Double.from-string`. Because of how the underlying C functions work, they both return `0` if the number could not be parsed (similar to `Int.from-string` and `Long.from-string`). We should probably fix that at some point.

Test cases are included.

Cheers