### PR TITLE
More useful error message on too many vars

### DIFF
--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -1097,7 +1097,7 @@ manageMemory typeEnv globalEnv root =
                      case deletersMatchingXObj xobj deleters of
                        [] ->  return (Left (GettingReferenceToUnownedValue xobj))
                        [_] -> return (return ())
-                       _ -> error "Too many variables with the same name in set."
+                       _ -> error $ "Too many variables with the same name in set (was looking for " ++ pretty xobj ++ " at " ++ prettyInfoFromXObj xobj ++ ")"
              else return (return ())
 
         transferOwnership :: XObj -> XObj -> State MemState (Either TypeError ())


### PR DESCRIPTION
This PR makes the error message on duplicate symbols in `Concretize` more useful. This is just a band-aid, because we should introduce more principled error handling in the long run, but this is a first attempt.

Cheers