### PR TITLE
core: fix type of Char.zero

### DIFF
--- a/core/Char.carp
+++ b/core/Char.carp
@@ -44,8 +44,7 @@
   (defn alphanum? [c]
     (or (alpha? c) (num? c)))
 
-  (defn zero []
-    (from-int 0))
+  (defn zero [] (the Char (from-int 0)))
 )
 
 (defmodule CharRef


### PR DESCRIPTION
This PR fixes the type of `Char.zero`, which was too permissive (using the generic function `from-int` without annotation).

Cheers