### PR TITLE
Make foreach (almost) hygienic

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -170,11 +170,13 @@
 ;;         (list f (list 'Array.nth (list 'ref xs) 'i))))
 
 (defndynamic foreach-internal [var xs expr]
-  (list 'let ['xs xs
-              'len (list 'Array.length 'xs)]
-        (list 'for ['i 0 'len]
-              (list 'let [var (list 'Array.unsafe-nth 'xs 'i)]
-                    expr))))
+  (let [xsym (gensym-with 'xs)
+        len (gensym-with 'len)]
+    (list 'let [xsym xs
+                len (list 'Array.length xsym)]
+          (list 'for ['i 0 len]
+                (list 'let [var (list 'Array.unsafe-nth xsym 'i)]
+                      expr)))))
 
 (defmacro foreach [binding expr]
   (if (array? binding)

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -171,11 +171,12 @@
 
 (defndynamic foreach-internal [var xs expr]
   (let [xsym (gensym-with 'xs)
-        len (gensym-with 'len)]
+        len (gensym-with 'len)
+        i (gensym-with 'i)]
     (list 'let [xsym xs
                 len (list 'Array.length xsym)]
-          (list 'for ['i 0 len]
-                (list 'let [var (list 'Array.unsafe-nth xsym 'i)]
+          (list 'for [i 0 len]
+                (list 'let [var (list 'Array.unsafe-nth xsym i)]
                       expr)))))
 
 (defmacro foreach [binding expr]


### PR DESCRIPTION
This PR changes `foreach` to be more hygienic. I changed the variables `len` and `xs` to `gensym`s to make sure that we don’t introduce unwanted captures. The variable `i` I deliberately left unhygienic, because it’s often useful to know the iteration number we’re on (though arguably, that’s what `for` is designed to do). I’d be happy to introduce a gensym for that as well.

Cheers