### PR TITLE
Add missing #include <stdint.h> to carp_byte.h

### DIFF
--- a/core/carp_byte.h
+++ b/core/carp_byte.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 typedef uint8_t byte;
 
 uint8_t Byte__PLUS_(uint8_t x, uint8_t y) {


### PR DESCRIPTION
On my system, Carp programs fail to compile with error messages like this:
```
In file included from out/main.c:18:
./core/carp_byte.h:1:9: error: unknown type name 'uint8_t'
typedef uint8_t byte;
```

Adding the correct include directive fixes the issue.

Additional info:
+ Compile command: `clang -fPIC -lm -g out/main.c -o "out/Untitled"  -I./core/ `
+ Clang version: 
   ``` 
   clang version 9.0.1 
   Target: x86_64-unknown-linux-gnu
   Thread model: posix
   InstalledDir: /usr/bin
   ```
+ OS: `openSUSE Tumbleweed 20200122`

