### PR TITLE
Use memcpy if members aren’t managed

### DIFF
--- a/test/execute.sh
+++ b/test/execute.sh
@@ -2,6 +2,7 @@
 
 # Runs the executable and compares its output to the .expected file
 
+echo $1
 ./carp.sh $1 --log-memory -x > test/output/$1.output.actual 2>&1
 
 if ! diff test/output/$1.output.actual test/output/$1.output.expected; then


### PR DESCRIPTION
This PR makes `Array.copy` use `memcpy` if the member type isn’t managed instead of copying all the members on their own. It’s not necessarily a huge performance boost, but it leads to tighter code (and is just good practice I think).

Cheers