### PR TITLE
Fix multiple things in pattern

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -39,6 +39,30 @@ If you want to replace all occurrences of the pattern, use `-1`.")
   (doc from-chars "creates a pattern that matches a group of characters from a list of those characters.")
   (defn from-chars [chars]
     (Pattern.init &(str* @"[" (String.from-chars chars) @"]")))
+
+  (defn global-match-str [p s]
+    (Array.copy-map &Array.unsafe-first &(global-match p s)))
+
+  (doc split "splits a string by a pattern.")
+  (defn split [p s]
+    (let-do [idx (find-all p s)
+             strs (global-match-str p s)
+             lidx (Array.length &idx)
+             result (Array.allocate (Int.inc lidx))]
+      (Array.aset-uninitialized! &result 0
+        (substring s 0 (if (> lidx 0) @(Array.unsafe-nth &idx 0) (length s))))
+      (for [i 0 (Int.dec (Array.length &idx))]
+        (let [plen (length (Array.unsafe-nth &strs i))]
+          (Array.aset-uninitialized! &result (Int.inc i)
+            (substring s (+ @(Array.unsafe-nth &idx i) plen)
+                         @(Array.unsafe-nth &idx (Int.inc i))))))
+      (when (> lidx 0)
+        (let [plen (length (Array.unsafe-nth &strs (Int.dec lidx)))]
+          (Array.aset-uninitialized! &result lidx
+            (suffix-string s (+ @(Array.unsafe-nth &idx (Int.dec lidx))
+                                plen)))))
+      result))
+
 )
 
 (defmodule String
@@ -84,7 +108,7 @@ If you want to replace all occurrences of the pattern, use `-1`.")
 
   (doc chomp "trims a newline from the end of a string.")
   (defn chomp [s]
-    (Pattern.substitute #"\n$" s "" 1))
+    (Pattern.substitute #"\r$" &(Pattern.substitute #"\n$" s "" 1) "" 1))
 
   (doc collapse-whitespace "collapses groups of whitespace into single spaces.")
   (defn collapse-whitespace [s]

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -304,20 +304,16 @@ init:                     /* using goto's to optimize tail recursion */
                         s = NULL; /* match failed */
                         break;
                     }
-                    case 'n': { /* newline? */
-                        if (*s == '\r') {
-                            if (*(++s) == '\n') s++;
-                        } else if (*s == '\n')
-                            s++;
-                        else
-                            s = NULL;
-                        break;
-                    }
+                    case 'r':   /* carriage return? */
+                    case 'n':   /* newline? */
                     case 't': { /* tab? */
-                        if (*s == '\t')
-                            s++;
-                        else
-                            s = NULL;
+                        char h = *(p + 1);
+                        p += 2;
+                        if (  (*s == '\r' && h == 'r')
+                           || (*s == '\n' && h == 'n')
+                           || (*s == '\t' && h == 't')
+                           ) { s++; goto init; }
+                        else s = NULL;
                         break;
                     }
                     case '0':

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -309,11 +309,13 @@ init:                     /* using goto's to optimize tail recursion */
                     case 't': { /* tab? */
                         char h = *(p + 1);
                         p += 2;
-                        if (  (*s == '\r' && h == 'r')
-                           || (*s == '\n' && h == 'n')
-                           || (*s == '\t' && h == 't')
-                           ) { s++; goto init; }
-                        else s = NULL;
+                        if ((*s == '\r' && h == 'r') ||
+                            (*s == '\n' && h == 'n') ||
+                            (*s == '\t' && h == 't')) {
+                            s++;
+                            goto init;
+                        } else
+                            s = NULL;
                         break;
                     }
                     case '0':
@@ -424,7 +426,7 @@ Array Pattern_internal_push_onecapture(PatternMatchState *ms, int i, String s,
     if (i >= ms->level) {
         if (!i)
             return Array_push_String(captures, s, i,
-                                     ms->capture[i].len); /* add whole match */
+                                     e - s); /* add whole match */
         else
             carp_regerror("invalid capture index %cd", C_ESC, i + 1);
     } else {

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -110,8 +110,8 @@ parseInternalPattern = do maybeAnchor <- Parsec.optionMaybe (Parsec.char '^')
             _ <- Parsec.char '\\'
             c <- Parsec.oneOf ['1', '2', '3', '4', '5', '6', '7', '8', '9',
                                'a', 'c', 'd', 'g', 'l', 'p', 's', 'u', 'w',
-                               'x', 'n', 't', 'b', 'f', '[', ']', '\\', '$',
-                               '(', ')', '^', '"', '*', '.', '-']
+                               'x', 'n', 'r', 't', 'b', 'f', '[', ']', '\\',
+                               '$', '(', ')', '^', '"', '*', '.', '-']
             case c of
               'b' -> do c1 <- Parsec.noneOf ['"']
                         c2 <- Parsec.noneOf ['"']

--- a/test/pattern.carp
+++ b/test/pattern.carp
@@ -61,8 +61,7 @@
                 "matches? works as exptected II")
   (assert-equal test
                 true
-                (and* (matches? #"\n" "\n") (matches? #"\n" "\r")
-                      (matches? #"\n" "\r\n"))
+                (and (matches? #"\n" "\n") (matches? #"\r" "\r"))
                 "matches? works as exptected on newlines special case")
   (assert-equal test
                 true
@@ -84,6 +83,10 @@
                 "sub 2-3 3-4"
                 &(substitute #"(\d)-(\d)" "1-2 2-3 3-4" "sub" 1)
                 "substitute works as expected")
+  (assert-equal test
+                &[@"" @"1" @"2" @"3" @""]
+                &(split #"\-\-" "--1--2--3--")
+                "split works as expected")
   (assert-equal test
                 "sub sub sub"
                 &(substitute #"(\d)-(\d)" "1-2 2-3 3-4" "sub" -1)


### PR DESCRIPTION
This PR fixes multiple things in `Pattern`:

### Newlines & Tabs

Firstly, this PR fixes how newlines and tabs are treated in patterns and adds carriage returns. Previously, the match was aborted on the first match of a newline due to a bug (`goto init;` wasn’t called). This PR simplifies their handler also.

### Captures

Secondly, this PR fixes capture groups; there was the possibility for memory corruption if capture groups weren’t initialized, but the length calculation for the strings doesn’t need to depend on those capture groups in the first place. We also introduce `Pattern.split` and `Pattern.global-match-str`, which first triggered that bug.

Cheers