### PR TITLE
core: add check in starts-with?/ends-with? for string length

### DIFF
--- a/core/String.carp
+++ b/core/String.carp
@@ -76,9 +76,15 @@
 
   (doc starts-with? "Check if the string `s` begins with the string `sub`.")
   (defn starts-with? [s sub]
-    (= sub &(prefix s (length sub))))
+    (let [ls (length sub)]
+      (and (>= (length s) ls) (= sub &(prefix s ls)))))
 
   (doc ends-with? "Check if the string `s` ends with the string `sub`.")
+  (defn ends-with? [s sub]
+    (let [ls (length s)
+          lsub (length sub)]
+      (and (>= ls lsub) (= sub &(suffix s (- ls lsub))))))
+
   (defn ends-with? [s sub]
     (= sub &(suffix s (- (length s) (length sub)))))
 

--- a/core/String.carp
+++ b/core/String.carp
@@ -85,9 +85,6 @@
           lsub (length sub)]
       (and (>= ls lsub) (= sub &(suffix s (- ls lsub))))))
 
-  (defn ends-with? [s sub]
-    (= sub &(suffix s (- (length s) (length sub)))))
-
   (doc zero "The empty string.")
   (defn zero [] @"")
 


### PR DESCRIPTION
This PR fixes a problem in `starts-with?` and `ends-with?`, namely they didn’t check whether the substrings were actually shorter than the strings to test against, which is a requirement.

Cheers