### PR TITLE
Add additional custom comparator to for

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -143,12 +143,15 @@
     (let [variable (car settings)
           from (cadr settings)
           to (caddr settings)
-          step (if (= (length settings) 4) (cadddr settings) 1)
+          step (if (> (length settings) 3) (cadddr settings) 1)
+          comp (if (> (length settings) 4)
+                 (cadddr (cdr settings))
+                 (if (< step (- step step)) '> '<))
           ]
       (list
        'let (array variable from)
        (list
-        'while (list (if (< step (- step step)) '> '<) variable to)
+        'while (list comp variable to)
         (list
          'do
          (if (= (length body) 0)


### PR DESCRIPTION
This PR adds custom comparators to `for`. This is necessary especially when using expressions as steps. We can implement a generic `for` loop with arbitrary numerical types like so, for instance:

```clojure
(for [(zero) n (one) <] (IO.println &(str n))
```

`n` is the only thing that determines which numerical type to use here, which is pretty cool.

But we can also use more advanced comparators, if we really want to.

Cheers