### PR TITLE
Readd old foreach as doall

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -164,10 +164,9 @@
   (list 'ref
         (list 'str x)))
 
-;; Old foreach, what's a better name for this? (it's just 'map' with side effects)
-;; (defmacro foreach [f xs]
-;;   (list 'for ['i 0 (list 'Array.length (list 'ref xs))]
-;;         (list f (list 'Array.nth (list 'ref xs) 'i))))
+(defmacro doall [f xs]
+  (list 'for ['i 0 (list 'Array.length (list 'ref xs))]
+        (list f (list 'Array.unsafe-nth (list 'ref xs) 'i))))
 
 (defndynamic foreach-internal [var xs expr]
   (let [xsym (gensym-with 'xs)


### PR DESCRIPTION
This PR readds the old implementation of `foreach` as `doall`, a kind of side-effecting version of `map`.

Cheers