### PR TITLE
Add Binary module

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -355,4 +355,40 @@ It will create a copy. If you want to avoid that, consider using [`endo-filter`]
             (set! result true)
             (break))))
       result))
+
+  (doc partition
+    "Partitions an array `arr` into an array of arrays of length `n`
+    sequentially filled with the `arr`'s original values.
+
+    This function will fill partitions until `arr` is exhuasted.
+
+    If `n` is greater than or equal to the length of `arr`, the result of this
+    function is an array containing a single array of length `n`.
+
+    For example:
+
+    ```clojure
+    (Array.partition &[1 2 3 4] 2)
+    => [[1 2] [3 4]]
+    (Array.partition &[1 2 3 4] 3)
+    => [[1 2 3] [4]]
+    (Array.partition &[1 2 3 4] 6)
+    => [[1 2 3 4]]
+    ```")
+  (sig partition (Fn [(Ref (Array a) b) Int] (Array (Array a))))
+  (defn partition [arr n] 
+    (let [len (+ (mod (Array.length arr) n) (/ (Array.length arr) n))]
+      (let-do [x 0
+               y 0
+               a []]
+        ;; We use while since we're doing custom incrementation of x
+        ;; dealing with the extra increment implicitly called by for is messier
+        (while (< x (Array.length arr))
+          (do
+            (set! y (+ x n))
+            (when (> y (Array.length arr))
+              (set! y (Array.length arr)))
+            (set! a (push-back a (Array.slice arr x y)))
+            (set! x y)))
+        a)))
 )

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -377,7 +377,6 @@ It will create a copy. If you want to avoid that, consider using [`endo-filter`]
     ```")
   (sig partition (Fn [(Ref (Array a) b) Int] (Array (Array a))))
   (defn partition [arr n] 
-    (let [len (+ (mod (Array.length arr) n) (/ (Array.length arr) n))]
       (let-do [x 0
                y 0
                a []]
@@ -390,5 +389,5 @@ It will create a copy. If you want to avoid that, consider using [`endo-filter`]
               (set! y (Array.length arr)))
             (set! a (push-back a (Array.slice arr x y)))
             (set! x y)))
-        a)))
+        a))
 )

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -68,6 +68,9 @@
   (register to-int16 (λ [Byte Byte] Uint16))
   (register to-int32 (λ [Byte Byte Byte Byte] Uint32))
   (register to-int64 (λ [Byte Byte Byte Byte Byte Byte Byte Byte] Uint64))
+  (register int16-to-byte  (λ [(Ref Uint16)] Byte))
+  (register int32-to-byte  (λ [(Ref Uint32)] Byte))
+  (register int64-to-byte  (λ [(Ref Uint64)] Byte))
   (register system-endianness-internal (λ [] Int))
 
   (doc system-endianness
@@ -102,6 +105,16 @@
       (Order.BigEndian)
         (Maybe.zip &to-int16 (Array.nth bytes 1) (Array.nth bytes 0))))
 
+  (doc int16->bytes
+    "Converts a Uint16 to a sequence of bytes representing the value using the provided `order`")
+  (sig int16->bytes (Fn [Order Uint16] (Array Byte)))
+  (defn int16->bytes [order i]
+    (match order
+      (Order.LittleEndian)
+        (Array.copy-map &int16-to-byte &[i (Uint16.bit-shift-right i (Uint16.from-long 8l))])
+      (Order.BigEndian)
+        (Array.copy-map &int16-to-byte &[(Uint16.bit-shift-right i (Uint16.from-long 8l)) i])))
+
   (doc bytes->int32-unsafe
     "Interprets the first four bytes in a byte sequence as an Uint32 value.
      **This operation is unsafe.**")
@@ -129,6 +142,19 @@
       (Order.BigEndian)
         (Maybe.zip4 &to-int32 (Array.nth bs 3) (Array.nth bs 2)
                               (Array.nth bs 1) (Array.nth bs 0))))
+
+  (doc int32->bytes
+    "Converts a Uint32 to a sequence of bytes representing the value using the provided `order`")
+  (sig int32->bytes (Fn [Order Uint32] (Array Byte)))
+  (defn int32->bytes [order i]
+    (let [shift (fn [lng] (Uint32.bit-shift-right i (Uint32.from-long lng)))]
+      (match order
+        (Order.LittleEndian)
+          (Array.copy-map &int32-to-byte
+            &[i (shift 8l) (shift 16l) (shift 24l)])
+        (Order.BigEndian)
+          (Array.copy-map &int32-to-byte
+            &[(shift 24l) (shift 16l) (shift 8l) i]))))
 
   (doc bytes->int64-unsafe
     "Interprets the first eight bytes in a byte sequence as an Uint64 value.
@@ -165,6 +191,22 @@
                               (Array.nth bs 5) (Array.nth bs 4)
                               (Array.nth bs 3) (Array.nth bs 2)
                               (Array.nth bs 1) (Array.nth bs 0))))
+  (doc int64->bytes
+    "Converts a Uint64 to a sequence of bytes representing the value using the provided `order`")
+  (sig int64->bytes (Fn [Order Uint64] (Array Byte)))
+  (defn int64->bytes [order i]
+    (let [shift (fn [lng] (Uint64.bit-shift-right i (Uint64.from-long lng)))]
+      (match order
+        (Order.LittleEndian)
+          (Array.copy-map &int64-to-byte
+            &[i (shift 8l) (shift 16l)
+                (shift 24l) (shift 32l)
+                (shift 40l) (shift 48l) (shift 56l)])
+        (Order.BigEndian)
+          (Array.copy-map &int64-to-byte
+            &[(shift 56l) (shift 48l)
+              (shift 40l) (shift 32l)
+              (shift 24l) (shift 16l) (shift 8l) i]))))
 
   (doc bytes->int16-seq-unsafe
     "Interprets a sequence of bytes as a sequence of Uint16 values.

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -14,6 +14,14 @@
   (register to-int16 (λ [Byte Byte] Int))
   (register to-int32 (λ [Byte Byte Byte Byte] Int))
   (register to-int64 (λ [Byte Byte Byte Byte Byte Byte Byte Byte] Int))
+  (register system-endianness-internal (λ [] Int))
+
+  (doc system-endianness "Returns the endianness of the host system.")
+  (sig system-endianness (λ [] Order))
+  (defn system-endianness [] 
+    (if (= (system-endianness-internal) 1)
+        (Order.LittleEndian)
+        (Order.BigEndian)))
 
   (doc bytes->int16-unsafe
     "Interprets the first two bytes in a byte sequence as an int16 value.

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -2,8 +2,8 @@
 (load "StdInt.carp")
 
 (defmodule Binary
-  (doc Order 
-    "The type of byte orders. 
+  (doc Order
+    "The type of byte orders.
 
     LittleEndian designates the little endian ordering, and indicates the least
     significant byte appears first in a given byte sequence.
@@ -17,10 +17,10 @@
   (register to-int64 (λ [Byte Byte Byte Byte Byte Byte Byte Byte] Uint64))
   (register system-endianness-internal (λ [] Int))
 
-  (doc system-endianness 
+  (doc system-endianness
     "Returns the endianness of the host system.")
   (sig system-endianness (λ [] Order))
-  (defn system-endianness [] 
+  (defn system-endianness []
     (if (= (system-endianness-internal) 1)
         (Order.LittleEndian)
         (Order.BigEndian)))
@@ -30,7 +30,7 @@
      **This operation is unsafe.**")
   (sig bytes->int16-unsafe (Fn [Order (Ref (Array Byte) a)] Uint16))
   (defn bytes->int16-unsafe [order bs]
-    (match order 
+    (match order
       (Order.LittleEndian)
         (to-int16 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1))
       (Order.BigEndian)
@@ -41,11 +41,11 @@
      **This operation is unsafe.**")
   (sig bytes->int32-unsafe (Fn [Order (Ref (Array Byte))] Uint32))
   (defn bytes->int32-unsafe [order bs]
-    (match order 
-      (Order.LittleEndian) 
-        (to-int32 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1) 
-                  @(Array.unsafe-nth bs 2) @(Array.unsafe-nth bs 3)) 
-      (Order.BigEndian) 
+    (match order
+      (Order.LittleEndian)
+        (to-int32 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)
+                  @(Array.unsafe-nth bs 2) @(Array.unsafe-nth bs 3))
+      (Order.BigEndian)
         (to-int32 @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
@@ -54,50 +54,43 @@
      **This operation is unsafe.**")
   (sig bytes->int64-unsafe (Fn [Order (Ref (Array Byte) a)] Uint64))
   (defn bytes->int64-unsafe [order bs]
-    (match order 
-      (Order.LittleEndian) 
-        (to-int64 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1) 
+    (match order
+      (Order.LittleEndian)
+        (to-int64 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)
                   @(Array.unsafe-nth bs 2) @(Array.unsafe-nth bs 3)
                   @(Array.unsafe-nth bs 4) @(Array.unsafe-nth bs 5)
                   @(Array.unsafe-nth bs 6) @(Array.unsafe-nth bs 7))
-      (Order.BigEndian) 
+      (Order.BigEndian)
         (to-int64 @(Array.unsafe-nth bs 7) @(Array.unsafe-nth bs 6)
                   @(Array.unsafe-nth bs 5) @(Array.unsafe-nth bs 4)
                   @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
- 
-  (doc byte-seq->int16-seq-unsafe
+
+(doc byte-seq->int16-seq-unsafe
     "Interprets a sequence of bytes as a sequence of int16 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
-  (defn byte-seq->int16-seq [order bs]
-    ;; This is way less efficient than it could be.
-    ;; Instead of allocating about 4 extra arrays, we can express this
-    ;; as a fold.
-    (let [enum (Array.enumerated bs)] 
-      (let [evens (Array.copy-filter &(fn [p] (Int.even? @(Pair.a p))) &enum)
-            odds (Array.copy-filter &(fn [p] (Int.odd? @(Pair.a p))) &enum)
-            intf (fn [r1 r2] (to-int16 @(Pair.b r1) @(Pair.b r2)))]
-        (match order 
-          (Order.LittleEndian) (Array.zip &intf &evens &odds)
-          (Order.BigEndian) (Array.zip &intf &odds &evens)))))
+  (sig byte-seq->int16-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
+  (defn byte-seq->int16-seq-unsafe [order bs]
+    (let [partitions (Array.partition bs 2)
+          f (fn [b] (bytes->int16-unsafe order b))]
+      (Array.copy-map &f &partitions)))
 
-  (doc byte-seq->int32-seq-unsafe 
+  (doc byte-seq->int32-seq-unsafe
     "Interprets a sequence of bytes as a sequence of int32 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
-  (defn byte-seq->int32-seq [order bs] 
+  (sig byte-seq->int32-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
+  (defn byte-seq->int32-seq-unsafe [order bs]
     (let [partitions (Array.partition bs 4)
-          f (fn [b] (bytes->int32-unsafe order b))] 
+          f (fn [b] (bytes->int32-unsafe order b))]
       (Array.copy-map &f &partitions)))
 
-  (doc byte-seq->int64-seq-unsafe 
-    "Interprets a sequence of bytes as a sequence of int32 values.
+  (doc byte-seq->int64-seq-unsafe
+    "Interprets a sequence of bytes as a sequence of int64 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
-  (defn byte-seq->int64-seq [order bs] 
+  (sig byte-seq->int64-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
+  (defn byte-seq->int64-seq-unsafe [order bs]
     (let [partitions (Array.partition bs 8)
-          f (fn [b] (bytes->int64-unsafe order b))] 
+          f (fn [b] (bytes->int64-unsafe order b))]
       (Array.copy-map &f &partitions)))
- 
+
 )

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -1,6 +1,59 @@
 (system-include "carp_binary.h")
 (load "StdInt.carp")
 
+;; Helper functions for making working with Maybe easier
+;; TODO: Replace all of these with a single type-generic
+;; zip-n macro.
+(defmodule Maybe
+  (defn zip [f a b]
+    (match a
+    (Maybe.Nothing) (Maybe.Nothing)
+    (Just x)
+      (match b
+      (Maybe.Nothing) (Maybe.Nothing)
+      (Just y) (Just (~f x y)))))
+
+  (defn zip4 [f a b c d]
+    (match a
+    (Maybe.Nothing) (Maybe.Nothing)
+    (Just x)
+      (match b
+      (Maybe.Nothing) (Maybe.Nothing)
+      (Just y)
+        (match c
+        (Maybe.Nothing) (Maybe.Nothing)
+        (Just z)
+          (match d
+          (Maybe.Nothing) (Maybe.Nothing)
+          (Just x2) (Just (~f x y z x2)))))))
+
+  (defn zip8 [f a b c d e a1 b1 c1]
+   (match a
+   (Maybe.Nothing) (Maybe.Nothing)
+   (Just x)
+     (match b
+     (Maybe.Nothing) (Maybe.Nothing)
+     (Just y)
+       (match c
+       (Maybe.Nothing) (Maybe.Nothing)
+       (Just z)
+         (match d
+         (Maybe.Nothing) (Maybe.Nothing)
+         (Just x2)
+           (match e
+           (Maybe.Nothing) (Maybe.Nothing)
+           (Just y2)
+             (match a1
+             (Maybe.Nothing) (Maybe.Nothing)
+             (Just z2)
+               (match b1
+               (Maybe.Nothing) (Maybe.Nothing)
+               (Just x3)
+                 (match c1
+                 (Maybe.Nothing) (Maybe.Nothing)
+                 (Just y3) (Just (~f x y z x2 y2 z2 x3 y3)))))))))))
+)
+
 (defmodule Binary
   (doc Order
     "The type of byte orders.
@@ -36,6 +89,19 @@
       (Order.BigEndian)
         (to-int16 @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
+  (doc bytes->int16
+    "Interprets the first two bytes in a byte sequence as an int16 value.
+
+     If the first two bytes are inaccessible, or the given array contains less
+     than two bytes, returns Maybe.Nothing.")
+  (sig bytes->int16 (Fn [Order (Ref (Array Byte) a)] (Maybe Uint16)))
+  (defn bytes->int16 [order bytes]
+    (match order
+      (Order.LittleEndian)
+        (Maybe.zip &to-int16 (Array.nth bytes 0) (Array.nth bytes 1))
+      (Order.BigEndian)
+        (Maybe.zip &to-int16 (Array.nth bytes 1) (Array.nth bytes 0))))
+
   (doc bytes->int32-unsafe
     "Interprets the first four bytes in a byte sequence as an int32 value.
      **This operation is unsafe.**")
@@ -48,6 +114,21 @@
       (Order.BigEndian)
         (to-int32 @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
+
+  (doc bytes->int32
+    "Interprets the first four bytes in a byte sequence as an int32 value.
+
+     If the first four bytes are inaccessible, or the given array contains less
+     than four bytes, returns Maybe.Nothing.")
+  (sig bytes->int32 (Fn [Order (Ref (Array Byte))] (Maybe Uint32)))
+  (defn bytes->int32 [order bs]
+    (match order
+      (Order.LittleEndian)
+        (Maybe.zip4 &to-int32 (Array.nth bs 0) (Array.nth bs 1)
+                              (Array.nth bs 2) (Array.nth bs 3))
+      (Order.BigEndian)
+        (Maybe.zip4 &to-int32 (Array.nth bs 3) (Array.nth bs 2)
+                              (Array.nth bs 1) (Array.nth bs 0))))
 
   (doc bytes->int64-unsafe
     "Interprets the first eight bytes in a byte sequence as an int64 value.
@@ -66,13 +147,42 @@
                   @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
-(doc byte-seq->int16-seq-unsafe
+  (doc bytes->int64
+    "Interprets the first eight bytes in a byte sequence as an int64 value.
+
+     If the first eight bytes are inaccessible, or the given array contains less
+     than eight bytes, returns Maybe.Nothing.")
+  (sig bytes->int64 (Fn [Order (Ref (Array Byte) a)] (Maybe Uint64)))
+  (defn bytes->int64 [order bs]
+    (match order
+      (Order.LittleEndian)
+        (Maybe.zip8 &to-int64 (Array.nth bs 0) (Array.nth bs 1)
+                              (Array.nth bs 2) (Array.nth bs 3)
+                              (Array.nth bs 4) (Array.nth bs 5)
+                              (Array.nth bs 6) (Array.nth bs 7))
+      (Order.BigEndian)
+        (Maybe.zip8 &to-int64 (Array.nth bs 7) (Array.nth bs 6)
+                              (Array.nth bs 5) (Array.nth bs 4)
+                              (Array.nth bs 3) (Array.nth bs 2)
+                              (Array.nth bs 1) (Array.nth bs 0))))
+
+  (doc byte-seq->int16-seq-unsafe
     "Interprets a sequence of bytes as a sequence of int16 values.
      **This operation is unsafe.**")
   (sig byte-seq->int16-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
   (defn byte-seq->int16-seq-unsafe [order bs]
     (let [partitions (Array.partition bs 2)
           f (fn [b] (bytes->int16-unsafe order b))]
+      (Array.copy-map &f &partitions)))
+
+  (doc bytes->int16-seq
+    "Interprets a sequence of bytes as a sequence of Uint16 values.
+
+     If a segment of bytes cannot be interpreted as an Uint16, returns Maybe.Nothing.")
+  (sig bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint16))))
+  (defn bytes->int16-seq [order bs]
+    (let [partitions (Array.partition bs 2)
+          f (fn [b] (bytes->int16 order b))]
       (Array.copy-map &f &partitions)))
 
   (doc byte-seq->int32-seq-unsafe
@@ -84,6 +194,16 @@
           f (fn [b] (bytes->int32-unsafe order b))]
       (Array.copy-map &f &partitions)))
 
+  (doc bytes->int32-seq
+    "Interprets a sequence of bytes as a sequence of Uint32 values.
+
+     If a segment of bytes cannot be interpreted as an Uint32, returns Maybe.Nothing.")
+  (sig bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint32))))
+  (defn bytes->int32-seq [order bs]
+    (let [partitions (Array.partition bs 4)
+          f (fn [b] (bytes->int32 order b))]
+      (Array.copy-map &f &partitions)))
+
   (doc byte-seq->int64-seq-unsafe
     "Interprets a sequence of bytes as a sequence of int64 values.
      **This operation is unsafe.**")
@@ -93,4 +213,13 @@
           f (fn [b] (bytes->int64-unsafe order b))]
       (Array.copy-map &f &partitions)))
 
+  (doc bytes->int64-seq
+    "Interprets a sequence of bytes as a sequence of Uint64 values.
+
+     If a segment of bytes cannot be interpreted as an Uint64, returns Maybe.Nothing.")
+  (sig bytes->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint64))))
+  (defn bytes->int64-seq [order bs]
+    (let [partitions (Array.partition bs 8)
+          f (fn [b] (bytes->int64 order b))]
+      (Array.copy-map &f &partitions)))
 )

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -73,6 +73,45 @@
   (register int64-to-byte  (λ [(Ref Uint64)] Byte))
   (register system-endianness-internal (λ [] Int))
 
+  (defn unwrap-success [x]
+    (Result.unwrap-or-zero @x))
+
+  (defn unwrap-error [x]
+    (Result.from-error @x (zero)))
+
+  (doc byte-converter
+    "Returns a function that, when called, attempts to convert an array of bytes using `f` and `order`
+
+     If the conversion is successful, returns a `Result.Success` containing the converted value.
+
+     If the conversion fails, returns a `Result.Error` containing the byte array passed as an argument.")
+  (defn byte-converter [f order]
+     (fn [bs]
+       (match (~f order bs)
+              (Maybe.Nothing) (Result.Error @bs)
+              (Maybe.Just i)  (Result.Success i))))
+  (doc interpreted
+    "Returns the interpreted value from a sequence of byte-converion results")
+  (private interpreted)
+  (defn interpreted [results]
+    (==> results
+         (Array.copy-filter &Result.success?)
+         (ref)
+         (Array.copy-map &unwrap-success)))
+
+  (doc remaining-bytes
+    "Returns the number of uninterpreted bytes from a seuqence of byte-conversion results")
+  (private remaining-bytes)
+  (defn remaining-bytes [results]
+    (==> results
+         (Array.copy-filter &Result.error?)
+         (ref)
+         (Array.copy-map &unwrap-error)
+         (ref)
+         (Array.copy-map &Array.length)
+         (ref)
+         (Array.reduce &(fn [x y] (+ x @y)) 0)))
+
   (doc system-endianness
     "Returns the endianness of the host system.")
   (sig system-endianness (λ [] Order))
@@ -127,12 +166,24 @@
   (doc bytes->int16-seq
     "Interprets a sequence of bytes as a sequence of Uint16 values.
 
-     If a segment of bytes cannot be interpreted as an Uint16, returns Maybe.Nothing.")
-  (sig bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint16))))
+     Returns a pair containing interpreted values and the number of bytes that were not interpreted.")
+  (sig bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Pair (Array Uint16) Int)))
   (defn bytes->int16-seq [order bs]
     (let [partitions (Array.partition bs 2)
-          f (fn [b] (bytes->int16 order b))]
-      (Array.copy-map &f &partitions)))
+          f (byte-converter &bytes->int16 order)]
+      (let [results (Array.copy-map &f &partitions)]
+        (Pair.init (interpreted &results) (remaining-bytes &results)))))
+
+  (doc bytes->int16-seq-exact
+    "Attempts to interpret a given byte sequence as an exact sequence of Uint16 values.
+
+     If successful, returns the interpreted values. If unsuccessful, returns the number of excess bytes.")
+  (sig bytes->int16-seq-exact (Fn [Order (Ref (Array Byte) a)] (Result (Array Uint16) Int)))
+  (defn bytes->int16-seq-exact [order bs]
+    (let [r (bytes->int16-seq order bs)]
+      (if (= 0 @(Pair.b &r))
+          (Result.Success @(Pair.a &r))
+          (Result.Error @(Pair.b &r)))))
 
   (doc int16-seq->bytes
     "Converts an array of Uint16 values into byte sequences.")
@@ -194,12 +245,24 @@
   (doc bytes->int32-seq
     "Interprets a sequence of bytes as a sequence of Uint32 values.
 
-     If a segment of bytes cannot be interpreted as an Uint32, returns Maybe.Nothing.")
-  (sig bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint32))))
+     Returns a pair containing interpreted values and the number of bytes that were not interpreted.")
+  (sig bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Pair (Array Uint32) Int)))
   (defn bytes->int32-seq [order bs]
     (let [partitions (Array.partition bs 4)
-          f (fn [b] (bytes->int32 order b))]
-      (Array.copy-map &f &partitions)))
+          f (byte-converter &bytes->int32 order)]
+      (let [results (Array.copy-map &f &partitions)]
+        (Pair.init (interpreted &results) (remaining-bytes &results)))))
+
+  (doc bytes->int32-seq-exact
+    "Attempts to interpret a given byte sequence as an exact sequence of Uint32 values.
+
+     If successful, returns the interpreted values. If unsuccessful, returns the number of excess bytes.")
+  (sig bytes->int32-seq-exact (Fn [Order (Ref (Array Byte) a)] (Result (Array Uint32) Int)))
+  (defn bytes->int32-seq-exact [order bs]
+    (let [r (bytes->int32-seq order bs)]
+      (if (= 0 @(Pair.b &r))
+          (Result.Success @(Pair.a &r))
+          (Result.Error @(Pair.b &r)))))
 
   (doc int32-seq->bytes
     "Converts an array of Uint32 values into byte sequences.")
@@ -272,12 +335,24 @@
   (doc bytes->int64-seq
     "Interprets a sequence of bytes as a sequence of Uint64 values.
 
-     If a segment of bytes cannot be interpreted as an Uint64, returns Maybe.Nothing.")
-  (sig bytes->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint64))))
+     Returns a pair containing interpreted values and the number of bytes that were not interpreted.")
+  (sig bytes->int64-seq (Fn [Order (Ref (Array Byte) a)] (Pair (Array Uint64) Int)))
   (defn bytes->int64-seq [order bs]
     (let [partitions (Array.partition bs 8)
-          f (fn [b] (bytes->int64 order b))]
-      (Array.copy-map &f &partitions)))
+          f (byte-converter &bytes->int64 order)]
+      (let [results (Array.copy-map &f &partitions)]
+        (Pair.init (interpreted &results) (remaining-bytes &results)))))
+
+  (doc bytes->int64-seq-exact
+    "Attempts to interpret a given byte sequence as an exact sequence of Uint64 values.
+
+     If successful, returns the interpreted values. If unsuccessful, returns the number of excess bytes.")
+  (sig bytes->int64-seq-exact (Fn [Order (Ref (Array Byte) a)] (Result (Array Uint64) Int)))
+  (defn bytes->int64-seq-exact [order bs]
+    (let [r (bytes->int64-seq order bs)]
+      (if (= 0 @(Pair.b &r))
+          (Result.Success @(Pair.a &r))
+          (Result.Error @(Pair.b &r)))))
 
   (doc int64-seq->bytes
     "Converts an array of Uint64 values into byte sequences.")

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -81,11 +81,11 @@
         (Order.LittleEndian)
         (Order.BigEndian)))
 
-  (doc bytes->int16-unsafe
+  (doc unsafe-bytes->int16
     "Interprets the first two bytes in a byte sequence as an Uint16 value.
      **This operation is unsafe.**")
-  (sig bytes->int16-unsafe (Fn [Order (Ref (Array Byte) a)] Uint16))
-  (defn bytes->int16-unsafe [order bs]
+  (sig unsafe-bytes->int16 (Fn [Order (Ref (Array Byte) a)] Uint16))
+  (defn unsafe-bytes->int16 [order bs]
     (match order
       (Order.LittleEndian)
         (to-int16 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1))
@@ -115,13 +115,13 @@
       (Order.BigEndian)
         (Array.copy-map &int16-to-byte &[(Uint16.bit-shift-right i (Uint16.from-long 8l)) i])))
 
-  (doc bytes->int16-seq-unsafe
+  (doc unsafe-bytes->int16-seq
     "Interprets a sequence of bytes as a sequence of Uint16 values.
      **This operation is unsafe.**")
-  (sig bytes->int16-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
-  (defn bytes->int16-seq-unsafe [order bs]
+  (sig unsafe-bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
+  (defn unsafe-bytes->int16-seq [order bs]
     (let [partitions (Array.partition bs 2)
-          f (fn [b] (bytes->int16-unsafe order b))]
+          f (fn [b] (unsafe-bytes->int16 order b))]
       (Array.copy-map &f &partitions)))
 
   (doc bytes->int16-seq
@@ -141,11 +141,11 @@
     (let [f (fn [i] (int16->bytes order @i))]
       (Array.copy-map &f is)))
 
-  (doc bytes->int32-unsafe
+  (doc unsafe-bytes->int32
     "Interprets the first four bytes in a byte sequence as an Uint32 value.
      **This operation is unsafe.**")
-  (sig bytes->int32-unsafe (Fn [Order (Ref (Array Byte))] Uint32))
-  (defn bytes->int32-unsafe [order bs]
+  (sig unsafe-bytes->int32 (Fn [Order (Ref (Array Byte))] Uint32))
+  (defn unsafe-bytes->int32 [order bs]
     (match order
       (Order.LittleEndian)
         (to-int32 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)
@@ -182,13 +182,13 @@
           (Array.copy-map &int32-to-byte
             &[(shift 24l) (shift 16l) (shift 8l) i]))))
 
-  (doc bytes->int32-seq-unsafe
+  (doc unsafe-bytes->int32-seq
     "Interprets a sequence of bytes as a sequence of Uint32 values.
      **This operation is unsafe.**")
-  (sig bytes->int32-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
-  (defn bytes->int32-seq-unsafe [order bs]
+  (sig unsafe-bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
+  (defn unsafe-bytes->int32-seq [order bs]
     (let [partitions (Array.partition bs 4)
-          f (fn [b] (bytes->int32-unsafe order b))]
+          f (fn [b] (unsafe-bytes->int32 order b))]
       (Array.copy-map &f &partitions)))
 
   (doc bytes->int32-seq
@@ -208,11 +208,11 @@
     (let [f (fn [i] (int32->bytes order @i))]
       (Array.copy-map &f is)))
 
-  (doc bytes->int64-unsafe
+  (doc unsafe-bytes->int64
     "Interprets the first eight bytes in a byte sequence as an Uint64 value.
      **This operation is unsafe.**")
-  (sig bytes->int64-unsafe (Fn [Order (Ref (Array Byte) a)] Uint64))
-  (defn bytes->int64-unsafe [order bs]
+  (sig unsafe-bytes->int64 (Fn [Order (Ref (Array Byte) a)] Uint64))
+  (defn unsafe-bytes->int64 [order bs]
     (match order
       (Order.LittleEndian)
         (to-int64 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)
@@ -260,13 +260,13 @@
               (shift 40l) (shift 32l)
               (shift 24l) (shift 16l) (shift 8l) i]))))
 
-  (doc bytes->int64-seq-unsafe
+  (doc unsafe-bytes->int64-seq
     "Interprets a sequence of bytes as a sequence of Uint64 values.
      **This operation is unsafe.**")
-  (sig bytes->int64-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
-  (defn bytes->int64-seq-unsafe [order bs]
+  (sig unsafe-bytes->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
+  (defn unsafe-bytes->int64-seq [order bs]
     (let [partitions (Array.partition bs 8)
-          f (fn [b] (bytes->int64-unsafe order b))]
+          f (fn [b] (unsafe-bytes->int64 order b))]
       (Array.copy-map &f &partitions)))
 
   (doc bytes->int64-seq

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -227,6 +227,13 @@
           f (fn [b] (bytes->int16 order b))]
       (Array.copy-map &f &partitions)))
 
+  (doc int16-seq->bytes
+    "Converts an array of Uint16 values into byte sequences.")
+  (sig int16-seq->bytes (Fn [Order (Ref (Array Uint16) a)] (Array (Array Byte))))
+  (defn int16-seq->bytes [order is]
+    (let [f (fn [i] (int16->bytes order @i))]
+      (Array.copy-map &f is)))
+
   (doc bytes->int32-seq-unsafe
     "Interprets a sequence of bytes as a sequence of Uint32 values.
      **This operation is unsafe.**")
@@ -246,6 +253,13 @@
           f (fn [b] (bytes->int32 order b))]
       (Array.copy-map &f &partitions)))
 
+  (doc int32-seq->bytes
+    "Converts an array of Uint32 values into byte sequences.")
+  (sig int32-seq->bytes (Fn [Order (Ref (Array Uint32) a)] (Array (Array Byte))))
+  (defn int32-seq->bytes [order is]
+    (let [f (fn [i] (int32->bytes order @i))]
+      (Array.copy-map &f is)))
+
   (doc bytes->int64-seq-unsafe
     "Interprets a sequence of bytes as a sequence of Uint64 values.
      **This operation is unsafe.**")
@@ -264,4 +278,11 @@
     (let [partitions (Array.partition bs 8)
           f (fn [b] (bytes->int64 order b))]
       (Array.copy-map &f &partitions)))
+
+  (doc int64-seq->bytes
+    "Converts an array of Uint64 values into byte sequences.")
+  (sig int64-seq->bytes (Fn [Order (Ref (Array Uint64) a)] (Array (Array Byte))))
+  (defn int64-seq->bytes [order is]
+    (let [f (fn [i] (int64->bytes order @i))]
+      (Array.copy-map &f is)))
 )

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -66,14 +66,6 @@
                   @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
  
-  (doc byte-seq->int8-seq-unsafe 
-    "Interprets a sequence of bytes as a sequence of int8 values.
-     **This operation is unsafe.**")
-  (sig byte-seq->int8-seq (Fn [(Ref (Array Byte) a)] (Array Int)))
-  (defn byte-seq->int8-seq [bs]
-    (let [f (fn [b] (Byte.to-int @b))]
-    (Array.copy-map &f bs)))
-
   (doc byte-seq->int16-seq-unsafe
     "Interprets a sequence of bytes as a sequence of int16 values.
      **This operation is unsafe.**")

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -1,4 +1,5 @@
 (system-include "carp_binary.h")
+(load "StdInt.carp")
 
 (defmodule Binary
   (doc Order 
@@ -11,12 +12,13 @@
     significant byte occurs first in a given byte sequence.")
   (deftype Order LittleEndian BigEndian)
 
-  (register to-int16 (λ [Byte Byte] Int))
-  (register to-int32 (λ [Byte Byte Byte Byte] Int))
-  (register to-int64 (λ [Byte Byte Byte Byte Byte Byte Byte Byte] Int))
+  (register to-int16 (λ [Byte Byte] Uint16))
+  (register to-int32 (λ [Byte Byte Byte Byte] Uint32))
+  (register to-int64 (λ [Byte Byte Byte Byte Byte Byte Byte Byte] Uint64))
   (register system-endianness-internal (λ [] Int))
 
-  (doc system-endianness "Returns the endianness of the host system.")
+  (doc system-endianness 
+    "Returns the endianness of the host system.")
   (sig system-endianness (λ [] Order))
   (defn system-endianness [] 
     (if (= (system-endianness-internal) 1)
@@ -26,18 +28,18 @@
   (doc bytes->int16-unsafe
     "Interprets the first two bytes in a byte sequence as an int16 value.
      **This operation is unsafe.**")
-  (sig bytes->int16-unsafe (Fn [Order (Ref (Array Byte) a)] Int))
+  (sig bytes->int16-unsafe (Fn [Order (Ref (Array Byte) a)] Uint16))
   (defn bytes->int16-unsafe [order bs]
     (match order 
-      (Order.LittleEndian) 
-        (to-int16 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)) 
-      (Order.BigEndian) 
+      (Order.LittleEndian)
+        (to-int16 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1))
+      (Order.BigEndian)
         (to-int16 @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
   (doc bytes->int32-unsafe
     "Interprets the first four bytes in a byte sequence as an int32 value.
      **This operation is unsafe.**")
-  (sig bytes->int32-unsafe (Fn [Order (Ref (Array Byte))] Int))
+  (sig bytes->int32-unsafe (Fn [Order (Ref (Array Byte))] Uint32))
   (defn bytes->int32-unsafe [order bs]
     (match order 
       (Order.LittleEndian) 
@@ -50,7 +52,7 @@
   (doc bytes->int64-unsafe
     "Interprets the first eight bytes in a byte sequence as an int64 value.
      **This operation is unsafe.**")
-  (sig bytes->int64-unsafe (Fn [Order (Ref (Array Byte) a)] Int))
+  (sig bytes->int64-unsafe (Fn [Order (Ref (Array Byte) a)] Uint64))
   (defn bytes->int64-unsafe [order bs]
     (match order 
       (Order.LittleEndian) 
@@ -75,7 +77,7 @@
   (doc byte-seq->int16-seq-unsafe
     "Interprets a sequence of bytes as a sequence of int16 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
+  (sig byte-seq->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
   (defn byte-seq->int16-seq [order bs]
     ;; This is way less efficient than it could be.
     ;; Instead of allocating about 4 extra arrays, we can express this
@@ -91,7 +93,7 @@
   (doc byte-seq->int32-seq-unsafe 
     "Interprets a sequence of bytes as a sequence of int32 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
+  (sig byte-seq->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
   (defn byte-seq->int32-seq [order bs] 
     (let [partitions (Array.partition bs 4)
           f (fn [b] (bytes->int32-unsafe order b))] 
@@ -100,10 +102,10 @@
   (doc byte-seq->int64-seq-unsafe 
     "Interprets a sequence of bytes as a sequence of int32 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
+  (sig byte-seq->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
   (defn byte-seq->int64-seq [order bs] 
     (let [partitions (Array.partition bs 8)
           f (fn [b] (bytes->int64-unsafe order b))] 
       (Array.copy-map &f &partitions)))
-      
+ 
 )

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -56,22 +56,6 @@
                   @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
  
-  (sig partition (Fn [(Ref (Array a) b) Int] (Array (Array a))))
-  (defn partition [arr partition-len] 
-    (let [len (+ (mod (Array.length arr) partition-len) (/ (Array.length arr)
-    partition-len))]
-      (let-do [x 0
-               y 0
-               a (Array.allocate len)]
-        (for [i 0 len]
-          (do
-            (set! y (+ x partition-len))
-            (when (> y (Array.length arr))
-              (set! y (Array.length arr)))
-            (Array.aset-uninitialized! &a i (Array.slice arr x y))
-            (set! x y)))
-        a)))
-
   (doc byte-seq->int8-seq-unsafe 
     "Interprets a sequence of bytes as a sequence of int8 values.
      **This operation is unsafe.**")
@@ -101,7 +85,7 @@
      **This operation is unsafe.**")
   (sig byte-seq->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
   (defn byte-seq->int32-seq [order bs] 
-    (let [partitions (partition bs 4)
+    (let [partitions (Array.partition bs 4)
           f (fn [b] (bytes->int32-unsafe order b))] 
       (Array.copy-map &f &partitions)))
 
@@ -110,7 +94,7 @@
      **This operation is unsafe.**")
   (sig byte-seq->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
   (defn byte-seq->int64-seq [order bs] 
-    (let [partitions (partition bs 8)
+    (let [partitions (Array.partition bs 8)
           f (fn [b] (bytes->int64-unsafe order b))] 
       (Array.copy-map &f &partitions)))
       

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -79,7 +79,7 @@
         (Order.BigEndian)))
 
   (doc bytes->int16-unsafe
-    "Interprets the first two bytes in a byte sequence as an int16 value.
+    "Interprets the first two bytes in a byte sequence as an Uint16 value.
      **This operation is unsafe.**")
   (sig bytes->int16-unsafe (Fn [Order (Ref (Array Byte) a)] Uint16))
   (defn bytes->int16-unsafe [order bs]
@@ -90,7 +90,7 @@
         (to-int16 @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
   (doc bytes->int16
-    "Interprets the first two bytes in a byte sequence as an int16 value.
+    "Interprets the first two bytes in a byte sequence as an Uint16 value.
 
      If the first two bytes are inaccessible, or the given array contains less
      than two bytes, returns Maybe.Nothing.")
@@ -103,7 +103,7 @@
         (Maybe.zip &to-int16 (Array.nth bytes 1) (Array.nth bytes 0))))
 
   (doc bytes->int32-unsafe
-    "Interprets the first four bytes in a byte sequence as an int32 value.
+    "Interprets the first four bytes in a byte sequence as an Uint32 value.
      **This operation is unsafe.**")
   (sig bytes->int32-unsafe (Fn [Order (Ref (Array Byte))] Uint32))
   (defn bytes->int32-unsafe [order bs]
@@ -116,7 +116,7 @@
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
   (doc bytes->int32
-    "Interprets the first four bytes in a byte sequence as an int32 value.
+    "Interprets the first four bytes in a byte sequence as an Uint32 value.
 
      If the first four bytes are inaccessible, or the given array contains less
      than four bytes, returns Maybe.Nothing.")
@@ -131,7 +131,7 @@
                               (Array.nth bs 1) (Array.nth bs 0))))
 
   (doc bytes->int64-unsafe
-    "Interprets the first eight bytes in a byte sequence as an int64 value.
+    "Interprets the first eight bytes in a byte sequence as an Uint64 value.
      **This operation is unsafe.**")
   (sig bytes->int64-unsafe (Fn [Order (Ref (Array Byte) a)] Uint64))
   (defn bytes->int64-unsafe [order bs]
@@ -148,7 +148,7 @@
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
   (doc bytes->int64
-    "Interprets the first eight bytes in a byte sequence as an int64 value.
+    "Interprets the first eight bytes in a byte sequence as an Uint64 value.
 
      If the first eight bytes are inaccessible, or the given array contains less
      than eight bytes, returns Maybe.Nothing.")
@@ -166,11 +166,11 @@
                               (Array.nth bs 3) (Array.nth bs 2)
                               (Array.nth bs 1) (Array.nth bs 0))))
 
-  (doc byte-seq->int16-seq-unsafe
-    "Interprets a sequence of bytes as a sequence of int16 values.
+  (doc bytes->int16-seq-unsafe
+    "Interprets a sequence of bytes as a sequence of Uint16 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int16-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
-  (defn byte-seq->int16-seq-unsafe [order bs]
+  (sig bytes->int16-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
+  (defn bytes->int16-seq-unsafe [order bs]
     (let [partitions (Array.partition bs 2)
           f (fn [b] (bytes->int16-unsafe order b))]
       (Array.copy-map &f &partitions)))
@@ -185,11 +185,11 @@
           f (fn [b] (bytes->int16 order b))]
       (Array.copy-map &f &partitions)))
 
-  (doc byte-seq->int32-seq-unsafe
-    "Interprets a sequence of bytes as a sequence of int32 values.
+  (doc bytes->int32-seq-unsafe
+    "Interprets a sequence of bytes as a sequence of Uint32 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int32-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
-  (defn byte-seq->int32-seq-unsafe [order bs]
+  (sig bytes->int32-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
+  (defn bytes->int32-seq-unsafe [order bs]
     (let [partitions (Array.partition bs 4)
           f (fn [b] (bytes->int32-unsafe order b))]
       (Array.copy-map &f &partitions)))
@@ -204,11 +204,11 @@
           f (fn [b] (bytes->int32 order b))]
       (Array.copy-map &f &partitions)))
 
-  (doc byte-seq->int64-seq-unsafe
-    "Interprets a sequence of bytes as a sequence of int64 values.
+  (doc bytes->int64-seq-unsafe
+    "Interprets a sequence of bytes as a sequence of Uint64 values.
      **This operation is unsafe.**")
-  (sig byte-seq->int64-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
-  (defn byte-seq->int64-seq-unsafe [order bs]
+  (sig bytes->int64-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
+  (defn bytes->int64-seq-unsafe [order bs]
     (let [partitions (Array.partition bs 8)
           f (fn [b] (bytes->int64-unsafe order b))]
       (Array.copy-map &f &partitions)))

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -1,0 +1,117 @@
+(system-include "carp_binary.h")
+
+(defmodule Binary
+  (doc Order 
+    "The type of byte orders. 
+
+    LittleEndian designates the little endian ordering, and indicates the least
+    significant byte appears first in a given byte sequence.
+
+    BigEndian designates the big endian ordering, and indicates the most
+    significant byte occurs first in a given byte sequence.")
+  (deftype Order LittleEndian BigEndian)
+
+  (register to-int16 (λ [Byte Byte] Int))
+  (register to-int32 (λ [Byte Byte Byte Byte] Int))
+  (register to-int64 (λ [Byte Byte Byte Byte Byte Byte Byte Byte] Int))
+
+  (doc bytes->int16-unsafe
+    "Interprets the first two bytes in a byte sequence as an int16 value.
+     **This operation is unsafe.**")
+  (sig bytes->int16-unsafe (Fn [Order (Ref (Array Byte) a)] Int))
+  (defn bytes->int16-unsafe [order bs]
+    (match order 
+      (Order.LittleEndian) 
+        (to-int16 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)) 
+      (Order.BigEndian) 
+        (to-int16 @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
+
+  (doc bytes->int32-unsafe
+    "Interprets the first four bytes in a byte sequence as an int32 value.
+     **This operation is unsafe.**")
+  (sig bytes->int32-unsafe (Fn [Order (Ref (Array Byte))] Int))
+  (defn bytes->int32-unsafe [order bs]
+    (match order 
+      (Order.LittleEndian) 
+        (to-int32 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1) 
+                  @(Array.unsafe-nth bs 2) @(Array.unsafe-nth bs 3)) 
+      (Order.BigEndian) 
+        (to-int32 @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
+                  @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
+
+  (doc bytes->int64-unsafe
+    "Interprets the first eight bytes in a byte sequence as an int64 value.
+     **This operation is unsafe.**")
+  (sig bytes->int64-unsafe (Fn [Order (Ref (Array Byte) a)] Int))
+  (defn bytes->int64-unsafe [order bs]
+    (match order 
+      (Order.LittleEndian) 
+        (to-int64 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1) 
+                  @(Array.unsafe-nth bs 2) @(Array.unsafe-nth bs 3)
+                  @(Array.unsafe-nth bs 4) @(Array.unsafe-nth bs 5)
+                  @(Array.unsafe-nth bs 6) @(Array.unsafe-nth bs 7))
+      (Order.BigEndian) 
+        (to-int64 @(Array.unsafe-nth bs 7) @(Array.unsafe-nth bs 6)
+                  @(Array.unsafe-nth bs 5) @(Array.unsafe-nth bs 4)
+                  @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
+                  @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
+ 
+  (sig partition (Fn [(Ref (Array a) b) Int] (Array (Array a))))
+  (defn partition [arr partition-len] 
+    (let [len (+ (mod (Array.length arr) partition-len) (/ (Array.length arr)
+    partition-len))]
+      (let-do [x 0
+               y 0
+               a (Array.allocate len)]
+        (for [i 0 len]
+          (do
+            (set! y (+ x partition-len))
+            (when (> y (Array.length arr))
+              (set! y (Array.length arr)))
+            (Array.aset-uninitialized! &a i (Array.slice arr x y))
+            (set! x y)))
+        a)))
+
+  (doc byte-seq->int8-seq-unsafe 
+    "Interprets a sequence of bytes as a sequence of int8 values.
+     **This operation is unsafe.**")
+  (sig byte-seq->int8-seq (Fn [(Ref (Array Byte) a)] (Array Int)))
+  (defn byte-seq->int8-seq [bs]
+    (let [f (fn [b] (Byte.to-int @b))]
+    (Array.copy-map &f bs)))
+
+  (doc byte-seq->int16-seq-unsafe
+    "Interprets a sequence of bytes as a sequence of int16 values.
+     **This operation is unsafe.**")
+  (sig byte-seq->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
+  (defn byte-seq->int16-seq [order bs]
+    ;; This is way less efficient than it could be.
+    ;; Instead of allocating about 4 extra arrays, we can express this
+    ;; as a fold.
+    (let [enum (Array.enumerated bs)] 
+      (let [evens (Array.copy-filter &(fn [p] (Int.even? @(Pair.a p))) &enum)
+            odds (Array.copy-filter &(fn [p] (Int.odd? @(Pair.a p))) &enum)
+            intf (fn [r1 r2] (to-int16 @(Pair.b r1) @(Pair.b r2)))]
+        (match order 
+          (Order.LittleEndian) (Array.zip &intf &evens &odds)
+          (Order.BigEndian) (Array.zip &intf &odds &evens)))))
+
+  (doc byte-seq->int32-seq-unsafe 
+    "Interprets a sequence of bytes as a sequence of int32 values.
+     **This operation is unsafe.**")
+  (sig byte-seq->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
+  (defn byte-seq->int32-seq [order bs] 
+    (let [partitions (partition bs 4)
+          f (fn [b] (bytes->int32-unsafe order b))] 
+      (Array.copy-map &f &partitions)))
+
+  (doc byte-seq->int64-seq-unsafe 
+    "Interprets a sequence of bytes as a sequence of int32 values.
+     **This operation is unsafe.**")
+  (sig byte-seq->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array Int)))
+  (defn byte-seq->int64-seq [order bs] 
+    (let [partitions (partition bs 8)
+          f (fn [b] (bytes->int64-unsafe order b))] 
+      (Array.copy-map &f &partitions)))
+      
+)

--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -115,6 +115,32 @@
       (Order.BigEndian)
         (Array.copy-map &int16-to-byte &[(Uint16.bit-shift-right i (Uint16.from-long 8l)) i])))
 
+  (doc bytes->int16-seq-unsafe
+    "Interprets a sequence of bytes as a sequence of Uint16 values.
+     **This operation is unsafe.**")
+  (sig bytes->int16-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
+  (defn bytes->int16-seq-unsafe [order bs]
+    (let [partitions (Array.partition bs 2)
+          f (fn [b] (bytes->int16-unsafe order b))]
+      (Array.copy-map &f &partitions)))
+
+  (doc bytes->int16-seq
+    "Interprets a sequence of bytes as a sequence of Uint16 values.
+
+     If a segment of bytes cannot be interpreted as an Uint16, returns Maybe.Nothing.")
+  (sig bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint16))))
+  (defn bytes->int16-seq [order bs]
+    (let [partitions (Array.partition bs 2)
+          f (fn [b] (bytes->int16 order b))]
+      (Array.copy-map &f &partitions)))
+
+  (doc int16-seq->bytes
+    "Converts an array of Uint16 values into byte sequences.")
+  (sig int16-seq->bytes (Fn [Order (Ref (Array Uint16) a)] (Array (Array Byte))))
+  (defn int16-seq->bytes [order is]
+    (let [f (fn [i] (int16->bytes order @i))]
+      (Array.copy-map &f is)))
+
   (doc bytes->int32-unsafe
     "Interprets the first four bytes in a byte sequence as an Uint32 value.
      **This operation is unsafe.**")
@@ -155,6 +181,32 @@
         (Order.BigEndian)
           (Array.copy-map &int32-to-byte
             &[(shift 24l) (shift 16l) (shift 8l) i]))))
+
+  (doc bytes->int32-seq-unsafe
+    "Interprets a sequence of bytes as a sequence of Uint32 values.
+     **This operation is unsafe.**")
+  (sig bytes->int32-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
+  (defn bytes->int32-seq-unsafe [order bs]
+    (let [partitions (Array.partition bs 4)
+          f (fn [b] (bytes->int32-unsafe order b))]
+      (Array.copy-map &f &partitions)))
+
+  (doc bytes->int32-seq
+    "Interprets a sequence of bytes as a sequence of Uint32 values.
+
+     If a segment of bytes cannot be interpreted as an Uint32, returns Maybe.Nothing.")
+  (sig bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint32))))
+  (defn bytes->int32-seq [order bs]
+    (let [partitions (Array.partition bs 4)
+          f (fn [b] (bytes->int32 order b))]
+      (Array.copy-map &f &partitions)))
+
+  (doc int32-seq->bytes
+    "Converts an array of Uint32 values into byte sequences.")
+  (sig int32-seq->bytes (Fn [Order (Ref (Array Uint32) a)] (Array (Array Byte))))
+  (defn int32-seq->bytes [order is]
+    (let [f (fn [i] (int32->bytes order @i))]
+      (Array.copy-map &f is)))
 
   (doc bytes->int64-unsafe
     "Interprets the first eight bytes in a byte sequence as an Uint64 value.
@@ -207,58 +259,6 @@
             &[(shift 56l) (shift 48l)
               (shift 40l) (shift 32l)
               (shift 24l) (shift 16l) (shift 8l) i]))))
-
-  (doc bytes->int16-seq-unsafe
-    "Interprets a sequence of bytes as a sequence of Uint16 values.
-     **This operation is unsafe.**")
-  (sig bytes->int16-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
-  (defn bytes->int16-seq-unsafe [order bs]
-    (let [partitions (Array.partition bs 2)
-          f (fn [b] (bytes->int16-unsafe order b))]
-      (Array.copy-map &f &partitions)))
-
-  (doc bytes->int16-seq
-    "Interprets a sequence of bytes as a sequence of Uint16 values.
-
-     If a segment of bytes cannot be interpreted as an Uint16, returns Maybe.Nothing.")
-  (sig bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint16))))
-  (defn bytes->int16-seq [order bs]
-    (let [partitions (Array.partition bs 2)
-          f (fn [b] (bytes->int16 order b))]
-      (Array.copy-map &f &partitions)))
-
-  (doc int16-seq->bytes
-    "Converts an array of Uint16 values into byte sequences.")
-  (sig int16-seq->bytes (Fn [Order (Ref (Array Uint16) a)] (Array (Array Byte))))
-  (defn int16-seq->bytes [order is]
-    (let [f (fn [i] (int16->bytes order @i))]
-      (Array.copy-map &f is)))
-
-  (doc bytes->int32-seq-unsafe
-    "Interprets a sequence of bytes as a sequence of Uint32 values.
-     **This operation is unsafe.**")
-  (sig bytes->int32-seq-unsafe (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
-  (defn bytes->int32-seq-unsafe [order bs]
-    (let [partitions (Array.partition bs 4)
-          f (fn [b] (bytes->int32-unsafe order b))]
-      (Array.copy-map &f &partitions)))
-
-  (doc bytes->int32-seq
-    "Interprets a sequence of bytes as a sequence of Uint32 values.
-
-     If a segment of bytes cannot be interpreted as an Uint32, returns Maybe.Nothing.")
-  (sig bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array (Maybe Uint32))))
-  (defn bytes->int32-seq [order bs]
-    (let [partitions (Array.partition bs 4)
-          f (fn [b] (bytes->int32 order b))]
-      (Array.copy-map &f &partitions)))
-
-  (doc int32-seq->bytes
-    "Converts an array of Uint32 values into byte sequences.")
-  (sig int32-seq->bytes (Fn [Order (Ref (Array Uint32) a)] (Array (Array Byte))))
-  (defn int32-seq->bytes [order is]
-    (let [f (fn [i] (int32->bytes order @i))]
-      (Array.copy-map &f is)))
 
   (doc bytes->int64-seq-unsafe
     "Interprets a sequence of bytes as a sequence of Uint64 values.

--- a/core/Core.carp
+++ b/core/Core.carp
@@ -47,3 +47,4 @@
 (load "Map.carp")
 (load "Heap.carp")
 (load "Sort.carp")
+(load "Binary.carp")

--- a/core/StdInt.carp
+++ b/core/StdInt.carp
@@ -179,6 +179,7 @@
   (register copy (Fn [&Uint16] Uint16))
 
   (defn prn [a] (Uint16.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Uint16)))
 )
@@ -209,6 +210,7 @@
   (register copy (Fn [&Uint32] Uint32))
 
   (defn prn [a] (Uint32.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Uint32)))
 )
@@ -239,6 +241,7 @@
   (register copy (Fn [&Uint64] Uint64))
 
   (defn prn [a] (Uint64.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Uint64)))
 )

--- a/core/StdInt.carp
+++ b/core/StdInt.carp
@@ -29,6 +29,7 @@
   (register copy (Fn [&Int8] Int8))
 
   (defn prn [a] (Int8.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Int8)))
 )
@@ -59,6 +60,7 @@
   (register copy (Fn [&Int16] Int16))
 
   (defn prn [a] (Int16.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Int16)))
 )
@@ -89,6 +91,7 @@
   (register copy (Fn [&Int32] Int32))
 
   (defn prn [a] (Int32.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Int32)))
 )
@@ -119,6 +122,7 @@
   (register copy (Fn [&Int64] Int64))
 
   (defn prn [a] (Int64.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Int64)))
 )
@@ -149,6 +153,7 @@
   (register copy (Fn [&Uint8] Uint8))
 
   (defn prn [a] (Uint8.str a))
+  (defn zero [] (from-long 0l))
 
   (register from-bytes (Fn [&(Array Byte)] (Array Uint8)))
 )

--- a/core/carp_binary.h
+++ b/core/carp_binary.h
@@ -13,6 +13,18 @@ uint64_t Binary_to_MINUS_int64(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, u
     ((uint64_t)b6 << 40) | ((uint64_t)b7 << 48) | ((uint64_t)b8 << 56);
 }
 
+uint8_t Binary_int16_MINUS_to_MINUS_byte(uint16_t *x) {
+  return *x & 0xff;
+}
+
+uint8_t Binary_int32_MINUS_to_MINUS_byte(uint32_t *x) {
+  return *x & 0xff;
+}
+
+uint8_t Binary_int64_MINUS_to_MINUS_byte(uint64_t *x) {
+  return *x & 0xff;
+}
+
 int Binary_system_MINUS_endianness_MINUS_internal() {
   // The int type is always >= 16 bits, two bytes, according to The C
   // Programming Language, Second Edition. Contrarily, char is always a single

--- a/core/carp_binary.h
+++ b/core/carp_binary.h
@@ -12,3 +12,17 @@ uint64_t Binary_to_MINUS_int64(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, u
   return (uint64_t) b1 | (b2 << 8) | (b3 << 16) | (b4 << 24) | ((uint64_t)b5 << 32) | 
     ((uint64_t)b6 << 40) | ((uint64_t)b7 << 48) | ((uint64_t)b8 << 56);
 }
+
+int Binary_system_MINUS_endianness_MINUS_internal() {
+  // The int type is always >= 16 bits, two bytes, according to The C
+  // Programming Language, Second Edition. Contrarily, char is always a single
+  // byte. 
+  //
+  // Allocating 1 and converting to char will leave us with the first byte used
+  // to represent the int. On a little endian machine, we're left with 1 on a
+  // big endian machine, we're left with 0.
+  unsigned int i = 1;
+  // Conversion to char lets us access bytes individually.
+  // We return the first byte.
+  return (int) ((char*)&i)[0];
+}

--- a/core/carp_binary.h
+++ b/core/carp_binary.h
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+uint16_t Binary_to_MINUS_int16(uint8_t b1, uint8_t b2) {
+  return (uint16_t) (b2 << 8) | b1;
+}
+
+uint32_t Binary_to_MINUS_int32(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4) {
+  return (uint32_t) b1 | (b2 << 8) | (b3 << 16) | (b4 << 24);
+}
+
+uint64_t Binary_to_MINUS_int64(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6, uint8_t b7, uint8_t b8) {
+  return (uint64_t) b1 | (b2 << 8) | (b3 << 16) | (b4 << 24) | ((uint64_t)b5 << 32) | 
+    ((uint64_t)b6 << 40) | ((uint64_t)b7 << 48) | ((uint64_t)b8 << 56);
+}

--- a/scratch
+++ b/scratch
@@ -1,0 +1,17 @@
+(defn safe-to-int16 [m m2]
+    (match m
+      (Maybe.Just b) 
+        (match m2 
+          (Maybe.Just bb) (Maybe.Just (to-int16 b bb))
+          (Maybe.Nothing) (Maybe.Nothing))
+      (Maybe.Nothing) (Maybe.Nothing)))
+
+(doc bytes->int16
+    "Interprets the first two bytes in a byte sequence as an int16 value.")
+  (sig bytes->int16 (Fn [Order (Ref (Array Byte) a)] (Maybe Int)))
+  (defn bytes->int16 [order bs]
+    (let [first-byte (Array.nth bs 0)
+          second-byte (Array.nth bs 1)]
+    (match order 
+      (Order.LittleEndian) (safe-to-int16 first-byte second-byte)
+      (Order.BigEndian) (safe-to-int16 second-byte first-byte))))

--- a/test/binary.carp
+++ b/test/binary.carp
@@ -36,9 +36,17 @@
                 "Unsafe little endian bytes->int16-seq works as expected.")
 
   (assert-equal test
-                &[(Maybe.Just (Uint16.from-long 776l)) (Maybe.Just (Uint16.from-long 2051l)) (Maybe.Nothing)]
+                &(Pair.init [(Uint16.from-long 776l) (Uint16.from-long 2051l)] 1)
                 &(bytes->int16-seq (Binary.Order.BigEndian) &[3b 8b 8b 3b 2b])
-                "Unsafe big endian bytes->int16-seq works as expected.")
+                "Big endian bytes->int16-seq works as expected.")
+
+  ;; We unwrap the error here since it's simpler than defining equality over
+  ;; arrays of Uint values.
+  ;; TODO: Define equality for arrays of non-ref values.
+  (assert-equal test
+                &(Result.unsafe-from-error (the (Result (Array Uint16) Int) (Result.Error 1)))
+                &(Result.unsafe-from-error (bytes->int16-seq-exact (Binary.Order.BigEndian) &[3b 8b 8b 3b 2b]))
+                "Big endian bytes->int16-seq-exact works as expected.")
 
   (assert-equal test
                 &[3b 8b]
@@ -82,9 +90,14 @@
                 "Unsafe little endian bytes->int32-seq works as expected.")
 
   (assert-equal test
-                &[(Maybe.Just  (Uint32.from-long 16909060l)) (Maybe.Just  (Uint32.from-long 67305985l)) (Maybe.Nothing)]
+                &(Pair.init [(Uint32.from-long 16909060l) (Uint32.from-long 67305985l)] 1)
                 &(bytes->int32-seq (Binary.Order.BigEndian) &[1b 2b 3b 4b 4b 3b 2b 1b 5b])
-                "Unsafe big endian bytes->int32-seq works as expected.")
+                "Big endian bytes->int32-seq works as expected.")
+
+  (assert-equal test
+                &(Result.unsafe-from-error (the (Result (Array Uint32) Int) (Result.Error 1)))
+                &(Result.unsafe-from-error (bytes->int32-seq-exact (Binary.Order.BigEndian) &[1b 2b 3b 4b 4b 3b 2b 1b 5b]))
+                "Big endian bytes->int32-seq-exact works as expected.")
 
   (assert-equal test
                 &[1b 2b 3b 4b]
@@ -129,9 +142,14 @@
                 "Unsafe little endian bytes->int64-seq works as expected.")
 
   (assert-equal test
-                &[(Maybe.Just (Uint64.from-long 72623859790381056l)) (Maybe.Just (Uint64.from-long 6618611909121l)) (Maybe.Nothing)]
+                &(Pair.init [(Uint64.from-long 72623859790381056l) (Uint64.from-long 6618611909121l)] 1)
                 &(bytes->int64-seq (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b 5b])
                 "Unsafe big endian bytes->int64-seq works as expected.")
+
+  (assert-equal test
+                &(Result.unsafe-from-error (the (Result (Array Uint64) Int) (Result.Error 1)))
+                &(Result.unsafe-from-error (bytes->int64-seq-exact (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b 5b]))
+                "Unsafe big endian bytes->int64-seq-exact works as expected.")
 
   (assert-equal test
                 &[1b 2b 3b 4b 5b 6b 0b 0b]

--- a/test/binary.carp
+++ b/test/binary.carp
@@ -1,0 +1,145 @@
+(use Binary)
+
+(load "Test.carp")
+(use Test)
+
+(deftest test
+  ;; int16 tests
+  (assert-equal test
+                (Uint16.from-long 2051l)
+                (unsafe-bytes->int16 (Binary.Order.LittleEndian) &[3b 8b])
+                "Unsafe little endian unsafe-bytes->int16 works as expected.")
+
+  (assert-equal test
+                (Uint16.from-long 776l)
+                (unsafe-bytes->int16 (Binary.Order.BigEndian) &[3b 8b])
+                "Unsafe big endian unsafe-bytes->int16 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Just (Uint16.from-long 2051l))
+                &(bytes->int16 (Binary.Order.LittleEndian) &[3b 8b])
+                "Unsafe little endian bytes->int16 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Just (Uint16.from-long 776l))
+                &(bytes->int16 (Binary.Order.BigEndian) &[3b 8b])
+                "Unsafe big endian bytes->int16 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(bytes->int16 (Binary.Order.LittleEndian) &[3b])
+                "bytes->int16 returns Nothing on insufficient data.")
+
+  (assert-equal test
+                &[(Uint16.from-long 2051l) (Uint16.from-long 776l)]
+                &(unsafe-bytes->int16-seq (Binary.Order.LittleEndian) &[3b 8b 8b 3b])
+                "Unsafe little endian bytes->int16-seq works as expected.")
+
+  (assert-equal test
+                &[(Maybe.Just (Uint16.from-long 776l)) (Maybe.Just (Uint16.from-long 2051l)) (Maybe.Nothing)]
+                &(bytes->int16-seq (Binary.Order.BigEndian) &[3b 8b 8b 3b 2b])
+                "Unsafe big endian bytes->int16-seq works as expected.")
+
+  (assert-equal test
+                &[3b 8b]
+                &(int16->bytes (Binary.Order.LittleEndian) (Uint16.from-long 2051l))
+                "Little endian int16->bytes works as expected.")
+
+  (assert-equal test
+                &[[3b 8b] [8b 3b]]
+                &(int16-seq->bytes (Binary.Order.LittleEndian) &[(Uint16.from-long 2051l) (Uint16.from-long 776l)])
+                "Little endian int16->bytes works as expected.")
+
+  ;; int32 tests
+  (assert-equal test
+                (Uint32.from-long 67305985l)
+                (unsafe-bytes->int32 (Binary.Order.LittleEndian) &[1b 2b 3b 4b])
+                "Unsafe little endian unsafe-bytes->int32 works as expected.")
+
+  (assert-equal test
+                (Uint32.from-long 16909060l)
+                (unsafe-bytes->int32 (Binary.Order.BigEndian) &[1b 2b 3b 4b])
+                "Unsafe big endian unsafe-bytes->int32 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Just (Uint32.from-long 67305985l))
+                &(bytes->int32 (Binary.Order.LittleEndian) &[1b 2b 3b 4b])
+                "Unsafe little endian bytes->int32 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Just (Uint32.from-long 16909060l))
+                &(bytes->int32 (Binary.Order.BigEndian) &[1b 2b 3b 4b])
+                "Unsafe big endian bytes->int32 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(bytes->int32 (Binary.Order.LittleEndian) &[3b])
+                "bytes->int32 returns Nothing on insufficient data.")
+
+  (assert-equal test
+                &[(Uint32.from-long 67305985l) (Uint32.from-long 16909060l)]
+                &(unsafe-bytes->int32-seq (Binary.Order.LittleEndian) &[1b 2b 3b 4b 4b 3b 2b 1b])
+                "Unsafe little endian bytes->int32-seq works as expected.")
+
+  (assert-equal test
+                &[(Maybe.Just  (Uint32.from-long 16909060l)) (Maybe.Just  (Uint32.from-long 67305985l)) (Maybe.Nothing)]
+                &(bytes->int32-seq (Binary.Order.BigEndian) &[1b 2b 3b 4b 4b 3b 2b 1b 5b])
+                "Unsafe big endian bytes->int32-seq works as expected.")
+
+  (assert-equal test
+                &[1b 2b 3b 4b]
+                &(int32->bytes (Binary.Order.LittleEndian) (Uint32.from-long 67305985l))
+                "Little endian int32->bytes works as expected.")
+
+  (assert-equal test
+                &[[1b 2b 3b 4b] [4b 3b 2b 1b]]
+                &(int32-seq->bytes (Binary.Order.LittleEndian) &[(Uint32.from-long 67305985l) (Uint32.from-long 16909060l)])
+                "Little endian int32-seq->bytes works as expected.")
+
+  ;; int64 tests
+  ;; We only go up to 6b in the 6th position--going higher seems to cause precision loss (at least on my system).
+  (assert-equal test
+                (Uint64.from-long 6618611909121l)
+                (unsafe-bytes->int64 (Binary.Order.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                "Unsafe little endian unsafe-bytes->int64 works as expected.")
+
+  (assert-equal test
+                (Uint64.from-long 72623859790381056l)
+                (unsafe-bytes->int64 (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                "Unsafe big endian unsafe-bytes->int64 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Just  (Uint64.from-long 6618611909121l))
+                &(bytes->int64 (Binary.Order.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                "Unsafe little endian bytes->int64 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Just (Uint64.from-long 72623859790381056l))
+                &(bytes->int64 (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                "Unsafe big endian bytes->int64 works as expected.")
+
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(bytes->int64 (Binary.Order.LittleEndian) &[3b])
+                "bytes->int64 returns Nothing on insufficient data.")
+
+  (assert-equal test
+                &[(Uint64.from-long 6618611909121l) (Uint64.from-long 72623859790381056l)]
+                &(unsafe-bytes->int64-seq (Binary.Order.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b])
+                "Unsafe little endian bytes->int64-seq works as expected.")
+
+  (assert-equal test
+                &[(Maybe.Just (Uint64.from-long 72623859790381056l)) (Maybe.Just (Uint64.from-long 6618611909121l)) (Maybe.Nothing)]
+                &(bytes->int64-seq (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b 5b])
+                "Unsafe big endian bytes->int64-seq works as expected.")
+
+  (assert-equal test
+                &[1b 2b 3b 4b 5b 6b 0b 0b]
+                &(int64->bytes (Binary.Order.LittleEndian) (Uint64.from-long 6618611909121l))
+                "Little endian int64->bytes works as expected.")
+
+  (assert-equal test
+                &[[1b 2b 3b 4b 5b 6b 0b 0b] [0b 0b 6b 5b 4b 3b 2b 1b]]
+                &(int64-seq->bytes (Binary.Order.LittleEndian) &[ (Uint64.from-long 6618611909121l) (Uint64.from-long 72623859790381056l)])
+                "Little endian int64-seq->bytes works as expected.")
+)


### PR DESCRIPTION
This PR adds a binary module for converting byte sequences to and from commonplace int encodings (16, 32, 64). 

## Open Questions:

1. *Do we need a new module for this?* We could simply add this functionality to the `Byte` module (which inspired this module)--my original reason for separating the two is that the `Byte` module is currently nice and small, and while these modules are interrelated, their functionality is separable. That said, it might be nice to keep it all in one place--I'm open to suggestions on this point.

2. *Is there a way we can use the `Byte` functions directly to implement this?* I couldn't figure out how. Seems like we need to do the type conversion (and unfortunately thus the actual bit twiddling in C to make it work). If that is the case, this might be one argument for merging this with `Byte` to reduce the number of headers we rely on.

## Progress
- [x] Add unsafe byte sequence -> intN functions
- [x] Add safe byte sequence -> intN functions
- [x] Add intN -> byte sequence functions
- [x] Add tests for the Binary module 

## Out of Scope/ Future Work

I'd like to pursue these improvements, but I'd like to get the baseline conversion functions we've defined at this point into core first.

- Add safe binary sequence -> intVar for variable length encodings.
- Add functions for retrieving n bits from a byte sequence