### PR TITLE
core: add stdint types

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -36,6 +36,7 @@
 (load "Array.carp")
 (load "Char.carp")
 (load "String.carp")
+(load "StdInt.carp")
 (load "System.carp")
 (load "IO.carp")
 (load "Pattern.carp")

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -34,11 +34,43 @@
 )
 
 (defmodule Float
-  (defn hash [k] (to-bytes @k))
+  (defn hash [k] (Float.to-bytes @k))
 )
 
 (defmodule Double
-  (defn hash [k] (Long.to-int (to-bytes @k)))
+  (defn hash [k] (Long.to-int (Double.to-bytes @k)))
+)
+
+(defmodule Int8
+  (defn hash [k] (Long.to-int (Int8.to-long @k)))
+)
+
+(defmodule Int16
+  (defn hash [k] (Long.to-int (Int16.to-long @k)))
+)
+
+(defmodule Int32
+  (defn hash [k] (Long.to-int (Int32.to-long @k)))
+)
+
+(defmodule Int64
+  (defn hash [k] (Long.to-int (Int64.to-long @k)))
+)
+
+(defmodule Uint8
+  (defn hash [k] (Long.to-int (Uint8.to-long @k)))
+)
+
+(defmodule Uint16
+  (defn hash [k] (Long.to-int (Uint16.to-long @k)))
+)
+
+(defmodule Uint32
+  (defn hash [k] (Long.to-int (Uint32.to-long @k)))
+)
+
+(defmodule Uint64
+  (defn hash [k] (Long.to-int (Uint64.to-long @k)))
 )
 
 (defmodule Pair

--- a/core/StdInt.carp
+++ b/core/StdInt.carp
@@ -1,0 +1,250 @@
+(relative-include "carp_stdint.h")
+
+(register-type Uint8)
+(register-type Uint16)
+(register-type Uint32)
+(register-type Uint64)
+(register-type Int8)
+(register-type Int16)
+(register-type Int32)
+(register-type Int64)
+
+(defmodule Int8
+  (register = (λ [Int8 Int8] Bool))
+  (register > (λ [Int8 Int8] Bool))
+  (register < (λ [Int8 Int8] Bool))
+  (register + (λ [Int8 Int8] Int8))
+  (register - (λ [Int8 Int8] Int8))
+  (register * (λ [Int8 Int8] Int8))
+  (register / (λ [Int8 Int8] Int8))
+  (register bit-shift-left (λ [Int8 Int8] Int8))
+  (register bit-shift-right (λ [Int8 Int8] Int8))
+  (register bit-or (λ [Int8 Int8] Int8))
+  (register bit-and (λ [Int8 Int8] Int8))
+  (register bit-not (λ [Int8] Int8))
+  (register bit-xor (λ [Int8 Int8] Int8))
+  (register to-long (λ [Int8] Long))
+  (register from-long (λ [Long] Int8))
+  (register str (λ [Int8] String))
+  (register copy (Fn [&Int8] Int8))
+
+  (defn prn [a] (Int8.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Int8)))
+)
+
+(defmodule Int8Extra
+  (defn prn [a] (Int8.prn @a))
+  (defn str [a] (Int8.str @a))
+  (defn = [a b] (Int8.= @a @b))
+)
+
+(defmodule Int16
+  (register = (λ [Int16 Int16] Bool))
+  (register > (λ [Int16 Int16] Bool))
+  (register < (λ [Int16 Int16] Bool))
+  (register + (λ [Int16 Int16] Int16))
+  (register - (λ [Int16 Int16] Int16))
+  (register * (λ [Int16 Int16] Int16))
+  (register / (λ [Int16 Int16] Int16))
+  (register bit-shift-left (λ [Int16 Int16] Int16))
+  (register bit-shift-right (λ [Int16 Int16] Int16))
+  (register bit-or (λ [Int16 Int16] Int16))
+  (register bit-and (λ [Int16 Int16] Int16))
+  (register bit-not (λ [Int16] Int16))
+  (register bit-xor (λ [Int16 Int16] Int16))
+  (register to-long (λ [Int16] Long))
+  (register from-long (λ [Long] Int16))
+  (register str (λ [Int16] String))
+  (register copy (Fn [&Int16] Int16))
+
+  (defn prn [a] (Int16.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Int16)))
+)
+
+(defmodule Int16Extra
+  (defn prn [a] (Int16.prn @a))
+  (defn str [a] (Int16.str @a))
+  (defn = [a b] (Int16.= @a @b))
+)
+
+(defmodule Int32
+  (register = (λ [Int32 Int32] Bool))
+  (register > (λ [Int32 Int32] Bool))
+  (register < (λ [Int32 Int32] Bool))
+  (register + (λ [Int32 Int32] Int32))
+  (register - (λ [Int32 Int32] Int32))
+  (register * (λ [Int32 Int32] Int32))
+  (register / (λ [Int32 Int32] Int32))
+  (register bit-shift-left (λ [Int32 Int32] Int32))
+  (register bit-shift-right (λ [Int32 Int32] Int32))
+  (register bit-or (λ [Int32 Int32] Int32))
+  (register bit-and (λ [Int32 Int32] Int32))
+  (register bit-not (λ [Int32] Int32))
+  (register bit-xor (λ [Int32 Int32] Int32))
+  (register to-long (λ [Int32] Long))
+  (register from-long (λ [Long] Int32))
+  (register str (λ [Int32] String))
+  (register copy (Fn [&Int32] Int32))
+
+  (defn prn [a] (Int32.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Int32)))
+)
+
+(defmodule Int32Extra
+  (defn prn [a] (Int32.prn @a))
+  (defn str [a] (Int32.str @a))
+  (defn = [a b] (Int32.= @a @b))
+)
+
+(defmodule Int64
+  (register = (λ [Int64 Int64] Bool))
+  (register > (λ [Int64 Int64] Bool))
+  (register < (λ [Int64 Int64] Bool))
+  (register + (λ [Int64 Int64] Int64))
+  (register - (λ [Int64 Int64] Int64))
+  (register * (λ [Int64 Int64] Int64))
+  (register / (λ [Int64 Int64] Int64))
+  (register bit-shift-left (λ [Int64 Int64] Int64))
+  (register bit-shift-right (λ [Int64 Int64] Int64))
+  (register bit-or (λ [Int64 Int64] Int64))
+  (register bit-and (λ [Int64 Int64] Int64))
+  (register bit-not (λ [Int64] Int64))
+  (register bit-xor (λ [Int64 Int64] Int64))
+  (register to-long (λ [Int64] Long))
+  (register from-long (λ [Long] Int64))
+  (register str (λ [Int64] String))
+  (register copy (Fn [&Int64] Int64))
+
+  (defn prn [a] (Int64.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Int64)))
+)
+
+(defmodule Int64Extra
+  (defn prn [a] (Int64.prn @a))
+  (defn str [a] (Int64.str @a))
+  (defn = [a b] (Int64.= @a @b))
+)
+
+(defmodule Uint8
+  (register = (λ [Uint8 Uint8] Bool))
+  (register > (λ [Uint8 Uint8] Bool))
+  (register < (λ [Uint8 Uint8] Bool))
+  (register + (λ [Uint8 Uint8] Uint8))
+  (register - (λ [Uint8 Uint8] Uint8))
+  (register * (λ [Uint8 Uint8] Uint8))
+  (register / (λ [Uint8 Uint8] Uint8))
+  (register bit-shift-left (λ [Uint8 Uint8] Uint8))
+  (register bit-shift-right (λ [Uint8 Uint8] Uint8))
+  (register bit-or (λ [Uint8 Uint8] Uint8))
+  (register bit-and (λ [Uint8 Uint8] Uint8))
+  (register bit-not (λ [Uint8] Uint8))
+  (register bit-xor (λ [Uint8 Uint8] Uint8))
+  (register to-long (λ [Uint8] Long))
+  (register from-long (λ [Long] Uint8))
+  (register str (λ [Uint8] String))
+  (register copy (Fn [&Uint8] Uint8))
+
+  (defn prn [a] (Uint8.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Uint8)))
+)
+
+(defmodule Uint8Extra
+  (defn prn [a] (Uint8.prn @a))
+  (defn str [a] (Uint8.str @a))
+  (defn = [a b] (Uint8.= @a @b))
+)
+
+(defmodule Uint16
+  (register = (λ [Uint16 Uint16] Bool))
+  (register > (λ [Uint16 Uint16] Bool))
+  (register < (λ [Uint16 Uint16] Bool))
+  (register + (λ [Uint16 Uint16] Uint16))
+  (register - (λ [Uint16 Uint16] Uint16))
+  (register * (λ [Uint16 Uint16] Uint16))
+  (register / (λ [Uint16 Uint16] Uint16))
+  (register bit-shift-left (λ [Uint16 Uint16] Uint16))
+  (register bit-shift-right (λ [Uint16 Uint16] Uint16))
+  (register bit-or (λ [Uint16 Uint16] Uint16))
+  (register bit-and (λ [Uint16 Uint16] Uint16))
+  (register bit-not (λ [Uint16] Uint16))
+  (register bit-xor (λ [Uint16 Uint16] Uint16))
+  (register to-long (λ [Uint16] Long))
+  (register from-long (λ [Long] Uint16))
+  (register str (λ [Uint16] String))
+  (register copy (Fn [&Uint16] Uint16))
+
+  (defn prn [a] (Uint16.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Uint16)))
+)
+
+(defmodule Uint16Extra
+  (defn prn [a] (Uint16.prn @a))
+  (defn str [a] (Uint16.str @a))
+  (defn = [a b] (Uint16.= @a @b))
+)
+
+(defmodule Uint32
+  (register = (λ [Uint32 Uint32] Bool))
+  (register > (λ [Uint32 Uint32] Bool))
+  (register < (λ [Uint32 Uint32] Bool))
+  (register + (λ [Uint32 Uint32] Uint32))
+  (register - (λ [Uint32 Uint32] Uint32))
+  (register * (λ [Uint32 Uint32] Uint32))
+  (register / (λ [Uint32 Uint32] Uint32))
+  (register bit-shift-left (λ [Uint32 Uint32] Uint32))
+  (register bit-shift-right (λ [Uint32 Uint32] Uint32))
+  (register bit-or (λ [Uint32 Uint32] Uint32))
+  (register bit-and (λ [Uint32 Uint32] Uint32))
+  (register bit-not (λ [Uint32] Uint32))
+  (register bit-xor (λ [Uint32 Uint32] Uint32))
+  (register to-long (λ [Uint32] Long))
+  (register from-long (λ [Long] Uint32))
+  (register str (λ [Uint32] String))
+  (register copy (Fn [&Uint32] Uint32))
+
+  (defn prn [a] (Uint32.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Uint32)))
+)
+
+(defmodule Uint32Extra
+  (defn prn [a] (Uint32.prn @a))
+  (defn str [a] (Uint32.str @a))
+  (defn = [a b] (Uint32.= @a @b))
+)
+
+(defmodule Uint64
+  (register = (λ [Uint64 Uint64] Bool))
+  (register > (λ [Uint64 Uint64] Bool))
+  (register < (λ [Uint64 Uint64] Bool))
+  (register + (λ [Uint64 Uint64] Uint64))
+  (register - (λ [Uint64 Uint64] Uint64))
+  (register * (λ [Uint64 Uint64] Uint64))
+  (register / (λ [Uint64 Uint64] Uint64))
+  (register bit-shift-left (λ [Uint64 Uint64] Uint64))
+  (register bit-shift-right (λ [Uint64 Uint64] Uint64))
+  (register bit-or (λ [Uint64 Uint64] Uint64))
+  (register bit-and (λ [Uint64 Uint64] Uint64))
+  (register bit-not (λ [Uint64] Uint64))
+  (register bit-xor (λ [Uint64 Uint64] Uint64))
+  (register to-long (λ [Uint64] Long))
+  (register from-long (λ [Long] Uint64))
+  (register str (λ [Uint64] String))
+  (register copy (Fn [&Uint64] Uint64))
+
+  (defn prn [a] (Uint64.str a))
+
+  (register from-bytes (Fn [&(Array Byte)] (Array Uint64)))
+)
+
+(defmodule Uint64Extra
+  (defn prn [a] (Uint64.prn @a))
+  (defn str [a] (Uint64.str @a))
+  (defn = [a b] (Uint64.= @a @b))
+)

--- a/core/carp_stdint.h
+++ b/core/carp_stdint.h
@@ -1,0 +1,544 @@
+typedef uint8_t Uint8;
+typedef uint16_t Uint16;
+typedef uint32_t Uint32;
+typedef uint64_t Uint64;
+typedef int8_t Int8;
+typedef int16_t Int16;
+typedef int32_t Int32;
+typedef int64_t Int64;
+
+Uint8 Uint8__PLUS_(Uint8 x, Uint8 y) {
+    return x + y;
+}
+Uint8 Uint8__MINUS_(Uint8 x, Uint8 y) {
+    return x - y;
+}
+Uint8 Uint8__MUL_(Uint8 x, Uint8 y) {
+    return x * y;
+}
+Uint8 Uint8__DIV_(Uint8 x, Uint8 y) {
+    return x / y;
+}
+bool Uint8__EQ_(Uint8 x, Uint8 y) {
+    return x == y;
+}
+bool Uint8__LT_(Uint8 x, Uint8 y) {
+    return x < y;
+}
+bool Uint8__GT_(Uint8 x, Uint8 y) {
+    return x > y;
+}
+Uint8 Uint8_bit_MINUS_shift_MINUS_left(Uint8 x, Uint8 y) {
+    return x << y;
+}
+Uint8 Uint8_bit_MINUS_shift_MINUS_right(Uint8 x, Uint8 y) {
+    return x >> y;
+}
+Uint8 Uint8_bit_MINUS_or(Uint8 x, Uint8 y) {
+    return x | y;
+}
+Uint8 Uint8_bit_MINUS_and(Uint8 x, Uint8 y) {
+    return x & y;
+}
+Uint8 Uint8_bit_MINUS_not(Uint8 x) {
+    return ~x;
+}
+Uint8 Uint8_bit_MINUS_xor(Uint8 x, Uint8 y) {
+    return x ^ y;
+}
+String Uint8_str(Uint8 x) {
+    int size = snprintf(NULL, 0, "Uint8(%hhu)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Uint8(%hhu)", x);
+    return buffer;
+}
+Uint8 Uint8_from_MINUS_long(long x) {
+    return (Uint8)x;
+}
+long Uint8_to_MINUS_long(Uint8 x) {
+    return (long)x;
+}
+Uint8 Uint8_copy(Uint8* x) {
+    return *x;
+}
+
+Array Uint8_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    uint8_t* d = (uint8_t*)a->data;
+    x.len = a->len;
+    x.capacity = a->capacity;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}
+
+Uint16 Uint16__PLUS_(Uint16 x, Uint16 y) {
+    return x + y;
+}
+Uint16 Uint16__MINUS_(Uint16 x, Uint16 y) {
+    return x - y;
+}
+Uint16 Uint16__MUL_(Uint16 x, Uint16 y) {
+    return x * y;
+}
+Uint16 Uint16__DIV_(Uint16 x, Uint16 y) {
+    return x / y;
+}
+bool Uint16__EQ_(Uint16 x, Uint16 y) {
+    return x == y;
+}
+bool Uint16__LT_(Uint16 x, Uint16 y) {
+    return x < y;
+}
+bool Uint16__GT_(Uint16 x, Uint16 y) {
+    return x > y;
+}
+Uint16 Uint16_bit_MINUS_shift_MINUS_left(Uint16 x, Uint16 y) {
+    return x << y;
+}
+Uint16 Uint16_bit_MINUS_shift_MINUS_right(Uint16 x, Uint16 y) {
+    return x >> y;
+}
+Uint16 Uint16_bit_MINUS_or(Uint16 x, Uint16 y) {
+    return x | y;
+}
+Uint16 Uint16_bit_MINUS_and(Uint16 x, Uint16 y) {
+    return x & y;
+}
+Uint16 Uint16_bit_MINUS_not(Uint16 x) {
+    return ~x;
+}
+Uint16 Uint16_bit_MINUS_xor(Uint16 x, Uint16 y) {
+    return x ^ y;
+}
+String Uint16_str(Uint16 x) {
+    int size = snprintf(NULL, 0, "Uint16(%hu)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Uint16(%hu)", x);
+    return buffer;
+}
+Uint16 Uint16_from_MINUS_long(long x) {
+    return (Uint16)x;
+}
+long Uint16_to_MINUS_long(Uint16 x) {
+    return (long)x;
+}
+Uint16 Uint16_copy(Uint16* x) {
+    return *x;
+}
+
+Array Uint16_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    uint8_t* d = (uint8_t*)a->data;
+    x.len = a->len / 2;
+    x.capacity = a->capacity / 2;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}
+
+Uint32 Uint32__PLUS_(Uint32 x, Uint32 y) {
+    return x + y;
+}
+Uint32 Uint32__MINUS_(Uint32 x, Uint32 y) {
+    return x - y;
+}
+Uint32 Uint32__MUL_(Uint32 x, Uint32 y) {
+    return x * y;
+}
+Uint32 Uint32__DIV_(Uint32 x, Uint32 y) {
+    return x / y;
+}
+bool Uint32__EQ_(Uint32 x, Uint32 y) {
+    return x == y;
+}
+bool Uint32__LT_(Uint32 x, Uint32 y) {
+    return x < y;
+}
+bool Uint32__GT_(Uint32 x, Uint32 y) {
+    return x > y;
+}
+Uint32 Uint32_bit_MINUS_shift_MINUS_left(Uint32 x, Uint32 y) {
+    return x << y;
+}
+Uint32 Uint32_bit_MINUS_shift_MINUS_right(Uint32 x, Uint32 y) {
+    return x >> y;
+}
+Uint32 Uint32_bit_MINUS_or(Uint32 x, Uint32 y) {
+    return x | y;
+}
+Uint32 Uint32_bit_MINUS_and(Uint32 x, Uint32 y) {
+    return x & y;
+}
+Uint32 Uint32_bit_MINUS_not(Uint32 x) {
+    return ~x;
+}
+Uint32 Uint32_bit_MINUS_xor(Uint32 x, Uint32 y) {
+    return x ^ y;
+}
+String Uint32_str(Uint32 x) {
+    int size = snprintf(NULL, 0, "Uint32(%u)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Uint32(%u)", x);
+    return buffer;
+}
+Uint32 Uint32_from_MINUS_long(long x) {
+    return (Uint32)x;
+}
+long Uint32_to_MINUS_long(Uint32 x) {
+    return (long)x;
+}
+Uint32 Uint32_copy(Uint32* x) {
+    return *x;
+}
+
+Array Uint32_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    uint8_t* d = (uint8_t*)a->data;
+    x.len = a->len / 4;
+    x.capacity = a->capacity / 4;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}
+
+Uint64 Uint64__PLUS_(Uint64 x, Uint64 y) {
+    return x + y;
+}
+Uint64 Uint64__MINUS_(Uint64 x, Uint64 y) {
+    return x - y;
+}
+Uint64 Uint64__MUL_(Uint64 x, Uint64 y) {
+    return x * y;
+}
+Uint64 Uint64__DIV_(Uint64 x, Uint64 y) {
+    return x / y;
+}
+bool Uint64__EQ_(Uint64 x, Uint64 y) {
+    return x == y;
+}
+bool Uint64__LT_(Uint64 x, Uint64 y) {
+    return x < y;
+}
+bool Uint64__GT_(Uint64 x, Uint64 y) {
+    return x > y;
+}
+Uint64 Uint64_bit_MINUS_shift_MINUS_left(Uint64 x, Uint64 y) {
+    return x << y;
+}
+Uint64 Uint64_bit_MINUS_shift_MINUS_right(Uint64 x, Uint64 y) {
+    return x >> y;
+}
+Uint64 Uint64_bit_MINUS_or(Uint64 x, Uint64 y) {
+    return x | y;
+}
+Uint64 Uint64_bit_MINUS_and(Uint64 x, Uint64 y) {
+    return x & y;
+}
+Uint64 Uint64_bit_MINUS_not(Uint64 x) {
+    return ~x;
+}
+Uint64 Uint64_bit_MINUS_xor(Uint64 x, Uint64 y) {
+    return x ^ y;
+}
+String Uint64_str(Uint64 x) {
+    int size = snprintf(NULL, 0, "Uint64(%llu)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Uint64(%llu)", x);
+    return buffer;
+}
+Uint64 Uint64_from_MINUS_long(long x) {
+    return (Uint64)x;
+}
+long Uint64_to_MINUS_long(Uint64 x) {
+    return (long)x;
+}
+Uint64 Uint64_copy(Uint64* x) {
+    return *x;
+}
+
+Array Uint64_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    uint8_t* d = (uint8_t*)a->data;
+    x.len = a->len / 2;
+    x.capacity = a->capacity / 2;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}
+
+Int8 Int8__PLUS_(Int8 x, Int8 y) {
+    return x + y;
+}
+Int8 Int8__MINUS_(Int8 x, Int8 y) {
+    return x - y;
+}
+Int8 Int8__MUL_(Int8 x, Int8 y) {
+    return x * y;
+}
+Int8 Int8__DIV_(Int8 x, Int8 y) {
+    return x / y;
+}
+bool Int8__EQ_(Int8 x, Int8 y) {
+    return x == y;
+}
+bool Int8__LT_(Int8 x, Int8 y) {
+    return x < y;
+}
+bool Int8__GT_(Int8 x, Int8 y) {
+    return x > y;
+}
+Int8 Int8_bit_MINUS_shift_MINUS_left(Int8 x, Int8 y) {
+    return x << y;
+}
+Int8 Int8_bit_MINUS_shift_MINUS_right(Int8 x, Int8 y) {
+    return x >> y;
+}
+Int8 Int8_bit_MINUS_or(Int8 x, Int8 y) {
+    return x | y;
+}
+Int8 Int8_bit_MINUS_and(Int8 x, Int8 y) {
+    return x & y;
+}
+Int8 Int8_bit_MINUS_not(Int8 x) {
+    return ~x;
+}
+Int8 Int8_bit_MINUS_xor(Int8 x, Int8 y) {
+    return x ^ y;
+}
+String Int8_str(Int8 x) {
+    int size = snprintf(NULL, 0, "Int8(%hhd)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Int8(%hhd)", x);
+    return buffer;
+}
+Int8 Int8_from_MINUS_long(long x) {
+    return (Int8)x;
+}
+long Int8_to_MINUS_long(Int8 x) {
+    return (long)x;
+}
+Int8 Int8_copy(Int8* x) {
+    return *x;
+}
+
+Array Int8_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    int8_t* d = (int8_t*)a->data;
+    x.len = a->len;
+    x.capacity = a->capacity;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}
+
+Int16 Int16__PLUS_(Int16 x, Int16 y) {
+    return x + y;
+}
+Int16 Int16__MINUS_(Int16 x, Int16 y) {
+    return x - y;
+}
+Int16 Int16__MUL_(Int16 x, Int16 y) {
+    return x * y;
+}
+Int16 Int16__DIV_(Int16 x, Int16 y) {
+    return x / y;
+}
+bool Int16__EQ_(Int16 x, Int16 y) {
+    return x == y;
+}
+bool Int16__LT_(Int16 x, Int16 y) {
+    return x < y;
+}
+bool Int16__GT_(Int16 x, Int16 y) {
+    return x > y;
+}
+Int16 Int16_bit_MINUS_shift_MINUS_left(Int16 x, Int16 y) {
+    return x << y;
+}
+Int16 Int16_bit_MINUS_shift_MINUS_right(Int16 x, Int16 y) {
+    return x >> y;
+}
+Int16 Int16_bit_MINUS_or(Int16 x, Int16 y) {
+    return x | y;
+}
+Int16 Int16_bit_MINUS_and(Int16 x, Int16 y) {
+    return x & y;
+}
+Int16 Int16_bit_MINUS_not(Int16 x) {
+    return ~x;
+}
+Int16 Int16_bit_MINUS_xor(Int16 x, Int16 y) {
+    return x ^ y;
+}
+String Int16_str(Int16 x) {
+    int size = snprintf(NULL, 0, "Int16(%hd)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Int16(%hd)", x);
+    return buffer;
+}
+Int16 Int16_from_MINUS_long(long x) {
+    return (Int16)x;
+}
+long Int16_to_MINUS_long(Int16 x) {
+    return (long)x;
+}
+Int16 Int16_copy(Int16* x) {
+    return *x;
+}
+
+Array Int16_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    uint8_t* d = (uint8_t*)a->data;
+    x.len = a->len;
+    x.capacity = a->capacity;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}
+
+Int32 Int32__PLUS_(Int32 x, Int32 y) {
+    return x + y;
+}
+Int32 Int32__MINUS_(Int32 x, Int32 y) {
+    return x - y;
+}
+Int32 Int32__MUL_(Int32 x, Int32 y) {
+    return x * y;
+}
+Int32 Int32__DIV_(Int32 x, Int32 y) {
+    return x / y;
+}
+bool Int32__EQ_(Int32 x, Int32 y) {
+    return x == y;
+}
+bool Int32__LT_(Int32 x, Int32 y) {
+    return x < y;
+}
+bool Int32__GT_(Int32 x, Int32 y) {
+    return x > y;
+}
+Int32 Int32_bit_MINUS_shift_MINUS_left(Int32 x, Int32 y) {
+    return x << y;
+}
+Int32 Int32_bit_MINUS_shift_MINUS_right(Int32 x, Int32 y) {
+    return x >> y;
+}
+Int32 Int32_bit_MINUS_or(Int32 x, Int32 y) {
+    return x | y;
+}
+Int32 Int32_bit_MINUS_and(Int32 x, Int32 y) {
+    return x & y;
+}
+Int32 Int32_bit_MINUS_not(Int32 x) {
+    return ~x;
+}
+Int32 Int32_bit_MINUS_xor(Int32 x, Int32 y) {
+    return x ^ y;
+}
+String Int32_str(Int32 x) {
+    int size = snprintf(NULL, 0, "Int32(%d)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Int32(%d)", x);
+    return buffer;
+}
+Int32 Int32_from_MINUS_long(long x) {
+    return (Int32)x;
+}
+long Int32_to_MINUS_long(Int32 x) {
+    return (long)x;
+}
+Int32 Int32_copy(Int32* x) {
+    return *x;
+}
+
+Array Int32_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    uint8_t* d = (uint8_t*)a->data;
+    x.len = a->len / 4;
+    x.capacity = a->capacity / 4;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}
+
+Int64 Int64__PLUS_(Int64 x, Int64 y) {
+    return x + y;
+}
+Int64 Int64__MINUS_(Int64 x, Int64 y) {
+    return x - y;
+}
+Int64 Int64__MUL_(Int64 x, Int64 y) {
+    return x * y;
+}
+Int64 Int64__DIV_(Int64 x, Int64 y) {
+    return x / y;
+}
+bool Int64__EQ_(Int64 x, Int64 y) {
+    return x == y;
+}
+bool Int64__LT_(Int64 x, Int64 y) {
+    return x < y;
+}
+bool Int64__GT_(Int64 x, Int64 y) {
+    return x > y;
+}
+Int64 Int64_bit_MINUS_shift_MINUS_left(Int64 x, Int64 y) {
+    return x << y;
+}
+Int64 Int64_bit_MINUS_shift_MINUS_right(Int64 x, Int64 y) {
+    return x >> y;
+}
+Int64 Int64_bit_MINUS_or(Int64 x, Int64 y) {
+    return x | y;
+}
+Int64 Int64_bit_MINUS_and(Int64 x, Int64 y) {
+    return x & y;
+}
+Int64 Int64_bit_MINUS_not(Int64 x) {
+    return ~x;
+}
+Int64 Int64_bit_MINUS_xor(Int64 x, Int64 y) {
+    return x ^ y;
+}
+String Int64_str(Int64 x) {
+    int size = snprintf(NULL, 0, "Int64(%lld)", x) + 1;
+    char* buffer = CARP_MALLOC(size);
+    snprintf(buffer, size, "Int64(%lld)", x);
+    return buffer;
+}
+Int64 Int64_from_MINUS_long(long x) {
+    return (Int64)x;
+}
+long Int64_to_MINUS_long(Int64 x) {
+    return (long)x;
+}
+Int64 Int64_copy(Int64* x) {
+    return *x;
+}
+
+Array Int64_from_MINUS_bytes(Array* a) {
+    int i;
+    Array x;
+    uint8_t* d = (uint8_t*)a->data;
+    x.len = a->len / 2;
+    x.capacity = a->capacity / 2;
+    x.data = malloc(x.len);
+    memcpy(x.data, a->data, x.len);
+
+    return x;
+}

--- a/test/int16.carp
+++ b/test/int16.carp
@@ -1,0 +1,60 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Int16)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                (from-long -129l)
+                (bit-not (from-long 128l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Int16(1)"
+                &(str (from-long 1l))
+                "str works")
+)

--- a/test/int32.carp
+++ b/test/int32.carp
@@ -1,0 +1,60 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Int32)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                (from-long -129l)
+                (bit-not (from-long 128l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Int32(1)"
+                &(str (from-long 1l))
+                "str works")
+)

--- a/test/int64.carp
+++ b/test/int64.carp
@@ -1,0 +1,60 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Int64)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                (from-long -129l)
+                (bit-not (from-long 128l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Int64(1)"
+                &(str (from-long 1l))
+                "str works")
+)

--- a/test/int8.carp
+++ b/test/int8.carp
@@ -1,0 +1,64 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Int8)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                (from-long 127l)
+                (bit-not (from-long 128l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Int8(1)"
+                &(str (from-long 1l))
+                "str works")
+  (assert-equal test
+                &[(from-long -1l)]
+                &(from-bytes &[255b])
+                "from-bytes works")
+)

--- a/test/uint16.carp
+++ b/test/uint16.carp
@@ -1,0 +1,60 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Uint16)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                (from-long 65407l)
+                (bit-not (from-long 128l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Uint16(1)"
+                &(str (from-long 1l))
+                "str works")
+)

--- a/test/uint32.carp
+++ b/test/uint32.carp
@@ -1,0 +1,60 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Uint32)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                (from-long 4294967167l)
+                (bit-not (from-long 128l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Uint32(1)"
+                &(str (from-long 1l))
+                "str works")
+)

--- a/test/uint64.carp
+++ b/test/uint64.carp
@@ -1,0 +1,61 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Uint64)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                ; set 32 bits, shift up (higher 32 bits), then add lower 32 bits
+                (+ (bit-shift-left (from-long 4294967295l) (from-long 32l)) (from-long 4294967295l))
+                (bit-not (from-long 0l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Uint64(1)"
+                &(str (from-long 1l))
+                "str works")
+)

--- a/test/uint8.carp
+++ b/test/uint8.carp
@@ -1,0 +1,64 @@
+(load "Test.carp")
+(use Test)
+
+(load "stdint.carp")
+(use Uint8)
+
+(deftest test
+  (assert-equal test
+                (from-long 3l)
+                (+ (from-long 1l) (from-long 2l))
+                "addition works")
+  (assert-equal test
+                (from-long 3l)
+                (- (from-long 2l) (from-long -1l))
+                "subtraction works")
+  (assert-equal test
+                (from-long -4l)
+                (* (from-long 2l) (from-long -2l))
+                "multiplication works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 2l)
+                (/ (from-long 5l) (from-long 2l))
+                "division works")
+  (assert-equal test
+                (from-long 8l)
+                (bit-shift-left (from-long 2l) (from-long 2l))
+                "shift left works")
+  (assert-equal test
+                (from-long 1l)
+                (bit-shift-right (from-long 4l) (from-long 2l))
+                "shift right works")
+  (assert-equal test
+                (from-long 6l)
+                (bit-or (from-long 4l) (from-long 2l))
+                "binary or works")
+  (assert-equal test
+                (from-long 2l)
+                (bit-and (from-long 6l) (from-long 3l))
+                "binary and works")
+  (assert-equal test
+                (from-long 127l)
+                (bit-not (from-long 128l))
+                "binary not works")
+  (assert-equal test
+                (from-long 5l)
+                (bit-xor (from-long 6l) (from-long 3l))
+                "binary xor works")
+  (assert-equal test
+                5l
+                (to-long (from-long 5l))
+                "conversion works")
+  (assert-equal test
+                "Uint8(1)"
+                &(str (from-long 1l))
+                "str works")
+  (assert-equal test
+                &[(from-long 255l)]
+                &(from-bytes &[255b])
+                "from-bytes works")
+)


### PR DESCRIPTION
As discussed in #683, this PR adds the stdint module into the core of Carp proper. I expect that we can add even more functions to the mix, but this should be a solid base for having a set of integers with predictable widths.

Cheers