### PR TITLE
Add new test primitives and ref=

### DIFF
--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -5,6 +5,7 @@
 ;;(definterface str (λ [a] String))
 
 (definterface = (λ [a a] Bool))
+(definterface ref= (λ [&a &a] Bool))
 
 (definterface add-ref (λ [&a &a] a))
 (definterface sub-ref (λ [&a &a] a))

--- a/core/Maybe.carp
+++ b/core/Maybe.carp
@@ -43,7 +43,9 @@ It is the inverse of [`just?`](#just?).")
       (Nothing) true
       (Just x) false))
 
-  (doc = "equality is defined as the equality of both the constructor and the contained value, i.e. `(Just 1)` and `(Just 1)` are the same, but `(Just 1)` and `(Just 2)` are not.")
+  (doc = "equality is defined as the equality of both the constructor
+and the contained value, i.e. `(Just 1)` and `(Just 1)` are the same, but
+`(Just 1)` and `(Just 2)` are not.")
   (defn = [a b]
     (match @a
       (Nothing) (nothing? b)
@@ -51,6 +53,17 @@ It is the inverse of [`just?`](#just?).")
         (match @b
           (Nothing) false
           (Just y) (= x y))))
+
+  (doc ref= "reference equality is defined as the equality of both the
+constructor and the contained value (by reference), i.e. `(Just [1])` and
+`(Just [1])` are the same, but `(Just [1])` and `(Just [2])` are not.")
+  (defn ref= [a b]
+    (match @a
+      (Nothing) (nothing? b)
+      (Just x)
+        (match @b
+          (Nothing) false
+          (Just y) (= &x &y))))
 
   (doc unsafe-ptr "Creates a `(Ptr a)` from a `(Maybe a)`. If the `Maybe` was
 `Nothing`, this function will return a `NULL` value.")

--- a/core/Result.carp
+++ b/core/Result.carp
@@ -113,7 +113,7 @@ but `(Success 1)` and `(Success 2)` are not.")
 constructor and the contained value, i.e. `(Success [1])` and
 `(Success [1])` are the same, but `(Success [1])` and `(Success [2])` are
 not.")
-  (defn = [a b]
+  (defn ref= [a b]
     (match @a
       (Success x)
         (match @b

--- a/core/Result.carp
+++ b/core/Result.carp
@@ -95,7 +95,9 @@ It is the inverse of [`success?`](#success?).")
       (Error _) true
       (Success _) false))
 
-  (doc = "equality is defined as the equality of both the constructor and the contained value, i.e. `(Success 1)` and `(Success 1)` are the same, but `(Success 1)` and `(Success 2)` are not.")
+  (doc = "equality is defined as the equality of both the constructor
+and the contained value, i.e. `(Success 1)` and `(Success 1)` are the same,
+but `(Success 1)` and `(Success 2)` are not.")
   (defn = [a b]
     (match @a
       (Success x)
@@ -106,6 +108,21 @@ It is the inverse of [`success?`](#success?).")
         (match @b
           (Success _) false
           (Error y) (= x y))))
+
+  (doc ref= "reference equality is defined as the equality of both the
+constructor and the contained value, i.e. `(Success [1])` and
+`(Success [1])` are the same, but `(Success [1])` and `(Success [2])` are
+not.")
+  (defn = [a b]
+    (match @a
+      (Success x)
+        (match @b
+          (Error _) false
+          (Success y) (= &x &y))
+      (Error x)
+        (match @b
+          (Success _) false
+          (Error y) (= &x &y))))
 )
 
 (defmodule Maybe

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -26,6 +26,10 @@
   (defn assert-equal [state x y descr]
     (handler state x y descr "value" =))
 
+  (doc assert-ref-equal "Assert that x and y are equal by reference. Reference equality needs to be implemented for their type.")
+  (defn assert-ref-equal [state x y descr]
+    (handler state x y descr "value" ref=))
+
   (doc assert-not-equal "Assert that x and y are not equal. Equality needs to be implemented for their type.")
   (defn assert-not-equal [state x y descr]
     (handler state x y descr "not value" /=))
@@ -37,6 +41,22 @@
   (doc assert-false "Assert that x is false.")
   (defn assert-false [state x descr]
     (assert-equal state false x descr))
+
+  (doc assert-just "Assert that x is a `Just`.")
+  (defn assert-just [state x descr]
+    (assert-true state (Maybe.just? x) descr))
+
+  (doc assert-nothing "Assert that x is a `Nothing`.")
+  (defn assert-nothing [state x descr]
+    (assert-true state (Maybe.nothing? x) descr))
+
+  (doc assert-success "Assert that x is a `Success`.")
+  (defn assert-success [state x descr]
+    (assert-true state (Result.success? x) descr))
+
+  (doc assert-error "Assert that x is an `Error`.")
+  (defn assert-error [state x descr]
+    (assert-true state (Result.error? x) descr))
 
   (doc reset "Reset test state.")
   (defn reset [state]

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -167,7 +167,9 @@
                     (= a b)
                 </pre>
                 <p class="doc">
-                    <p>equality is defined as the equality of both the constructor and the contained value, i.e. <code>(Just 1)</code> and <code>(Just 1)</code> are the same, but <code>(Just 1)</code> and <code>(Just 2)</code> are not.</p>
+                    <p>equality is defined as the equality of both the constructor
+and the contained value, i.e. <code>(Just 1)</code> and <code>(Just 1)</code> are the same, but
+<code>(Just 1)</code> and <code>(Just 2)</code> are not.</p>
 
                 </p>
             </div>
@@ -412,6 +414,28 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                 </span>
                 <p class="doc">
                     <p>stringifies a <code>&quot;Maybe&quot;</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ref=">
+                    <h3 id="ref=">
+                        ref=
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (Maybe a) b), (Ref (Maybe a) c)] Bool)
+                </p>
+                <pre class="args">
+                    (ref= a b)
+                </pre>
+                <p class="doc">
+                    <p>reference equality is defined as the equality of both the
+constructor and the contained value (by reference), i.e. <code>(Just [1])</code> and
+<code>(Just [1])</code> are the same, but <code>(Just [1])</code> and <code>(Just [2])</code> are not.</p>
 
                 </p>
             </div>

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -167,7 +167,9 @@
                     (= a b)
                 </pre>
                 <p class="doc">
-                    <p>equality is defined as the equality of both the constructor and the contained value, i.e. <code>(Success 1)</code> and <code>(Success 1)</code> are the same, but <code>(Success 1)</code> and <code>(Success 2)</code> are not.</p>
+                    <p>equality is defined as the equality of both the constructor
+and the contained value, i.e. <code>(Success 1)</code> and <code>(Success 1)</code> are the same,
+but <code>(Success 1)</code> and <code>(Success 2)</code> are not.</p>
 
                 </p>
             </div>
@@ -449,6 +451,29 @@
                 </span>
                 <p class="doc">
                     <p>stringifies a <code>&quot;Result&quot;</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#ref=">
+                    <h3 id="ref=">
+                        ref=
+                    </h3>
+                </a>
+                <div class="description">
+                    doc-stub
+                </div>
+                <p class="sig">
+                    a
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>reference equality is defined as the equality of both the
+constructor and the contained value, i.e. <code>(Success [1])</code> and
+<code>(Success [1])</code> are the same, but <code>(Success [1])</code> and <code>(Success [2])</code> are
+not.</p>
 
                 </p>
             </div>

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -461,14 +461,14 @@ but <code>(Success 1)</code> and <code>(Success 2)</code> are not.</p>
                     </h3>
                 </a>
                 <div class="description">
-                    doc-stub
+                    defn
                 </div>
                 <p class="sig">
-                    a
+                    (λ [(Ref (Result a b) c), (Ref (Result a b) d)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (ref= a b)
+                </pre>
                 <p class="doc">
                     <p>reference equality is defined as the equality of both the
 constructor and the contained value, i.e. <code>(Success [1])</code> and

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -191,6 +191,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#assert-error">
+                    <h3 id="assert-error">
+                        assert-error
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State a), (Ref (Result b c) d), (Ref e f)] State)
+                </p>
+                <pre class="args">
+                    (assert-error state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is an <code>Error</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#assert-exit">
                     <h3 id="assert-exit">
                         assert-exit
@@ -231,6 +251,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#assert-just">
+                    <h3 id="assert-just">
+                        assert-just
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State a), (Ref (Maybe b) c), (Ref d e)] State)
+                </p>
+                <pre class="args">
+                    (assert-just state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is a <code>Just</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#assert-not-equal">
                     <h3 id="assert-not-equal">
                         assert-not-equal
@@ -247,6 +287,26 @@
                 </pre>
                 <p class="doc">
                     <p>Assert that x and y are not equal. Equality needs to be implemented for their type.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-nothing">
+                    <h3 id="assert-nothing">
+                        assert-nothing
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State a), (Ref (Maybe b) c), (Ref d e)] State)
+                </p>
+                <pre class="args">
+                    (assert-nothing state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is a <code>Nothing</code>.</p>
 
                 </p>
             </div>
@@ -271,6 +331,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#assert-ref-equal">
+                    <h3 id="assert-ref-equal">
+                        assert-ref-equal
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State a), (Ref b c), (Ref b d), (Ref e f)] State)
+                </p>
+                <pre class="args">
+                    (assert-ref-equal state x y descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x and y are equal by reference. Reference equality needs to be implemented for their type.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#assert-signal">
                     <h3 id="assert-signal">
                         assert-signal
@@ -287,6 +367,26 @@
                 </pre>
                 <p class="doc">
                     
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-success">
+                    <h3 id="assert-success">
+                        assert-success
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref State a), (Ref (Result b c) d), (Ref e f)] State)
+                </p>
+                <pre class="args">
+                    (assert-success state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is a <code>Success</code>.</p>
+
                 </p>
             </div>
             <div class="binder">

--- a/test/io.carp
+++ b/test/io.carp
@@ -2,13 +2,12 @@
 (use-all IO Test)
 
 (deftest test
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(IO.getenv @"thisdoesnotexist")
-                "getenv works on non-existant variable"
+  (assert-nothing test
+                  &(IO.getenv @"thisdoesnotexist")
+                  "getenv works on non-existant variable"
   )
-  (assert-true test
-               (Maybe.just? &(IO.getenv @"PATH"))
+  (assert-just test
+               &(IO.getenv @"PATH")
                "getenv works on existant variable"
   )
 )


### PR DESCRIPTION
This PR fixes #689 by introducing:

- `ref=` for reference equality (currently only used in `Maybe` and `Success`, but maybe we should make this a more general idiom?),
- `Test.assert-just` for testing if something is a `Maybe.Just`,
- `Test.assert-nothing` for testing if something is a `Maybe.Nothing`,
- `Test.assert-success` for testing if something is a `Result.Success`,
- `Test.assert-error` for testing if something is a `Result.Error`, and
- `Test.assert-ref-equal` for testing if two things are `ref=`.

This already simplifies some code in our tests, and should make things simpler in the future generally.

Cheers