### PR TITLE
Reformat carp_binary.h

### DIFF
--- a/core/carp_binary.h
+++ b/core/carp_binary.h
@@ -1,40 +1,42 @@
 #include <stdint.h>
 
 uint16_t Binary_to_MINUS_int16(uint8_t b1, uint8_t b2) {
-  return (uint16_t) (b2 << 8) | b1;
+    return (uint16_t)(b2 << 8) | b1;
 }
 
 uint32_t Binary_to_MINUS_int32(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4) {
-  return (uint32_t) b1 | (b2 << 8) | (b3 << 16) | (b4 << 24);
+    return (uint32_t)b1 | (b2 << 8) | (b3 << 16) | (b4 << 24);
 }
 
-uint64_t Binary_to_MINUS_int64(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6, uint8_t b7, uint8_t b8) {
-  return (uint64_t) b1 | (b2 << 8) | (b3 << 16) | (b4 << 24) | ((uint64_t)b5 << 32) | 
-    ((uint64_t)b6 << 40) | ((uint64_t)b7 << 48) | ((uint64_t)b8 << 56);
+uint64_t Binary_to_MINUS_int64(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4,
+                               uint8_t b5, uint8_t b6, uint8_t b7, uint8_t b8) {
+    return (uint64_t)b1 | (b2 << 8) | (b3 << 16) | (b4 << 24) |
+           ((uint64_t)b5 << 32) | ((uint64_t)b6 << 40) | ((uint64_t)b7 << 48) |
+           ((uint64_t)b8 << 56);
 }
 
 uint8_t Binary_int16_MINUS_to_MINUS_byte(uint16_t *x) {
-  return *x & 0xff;
+    return *x & 0xff;
 }
 
 uint8_t Binary_int32_MINUS_to_MINUS_byte(uint32_t *x) {
-  return *x & 0xff;
+    return *x & 0xff;
 }
 
 uint8_t Binary_int64_MINUS_to_MINUS_byte(uint64_t *x) {
-  return *x & 0xff;
+    return *x & 0xff;
 }
 
 int Binary_system_MINUS_endianness_MINUS_internal() {
-  // The int type is always >= 16 bits, two bytes, according to The C
-  // Programming Language, Second Edition. Contrarily, char is always a single
-  // byte. 
-  //
-  // Allocating 1 and converting to char will leave us with the first byte used
-  // to represent the int. On a little endian machine, we're left with 1 on a
-  // big endian machine, we're left with 0.
-  unsigned int i = 1;
-  // Conversion to char lets us access bytes individually.
-  // We return the first byte.
-  return (int) ((char*)&i)[0];
+    // The int type is always >= 16 bits, two bytes, according to The C
+    // Programming Language, Second Edition. Contrarily, char is always a single
+    // byte.
+    //
+    // Allocating 1 and converting to char will leave us with the first byte
+    // used to represent the int. On a little endian machine, we're left with 1
+    // on a big endian machine, we're left with 0.
+    unsigned int i = 1;
+    // Conversion to char lets us access bytes individually.
+    // We return the first byte.
+    return (int)((char *)&i)[0];
 }


### PR DESCRIPTION
In the spirit of other reformatting PRs, this PR reformats `carp_binary.h` using `clang-format`.  Sorry I didn’t catch that earlier.

Cheers