### PR TITLE
Fix life example

### DIFF
--- a/examples/life.carp
+++ b/examples/life.carp
@@ -107,7 +107,7 @@
     (Random.seed)
     (let [app (create "~ Game of Life ~" 800 600)
           rend @(renderer &app)
-          world (repeat (* height width) flip)
+          world (repeat (* height width) &flip)
           play false]
       (while true
         (do


### PR DESCRIPTION
This PR fixes the example `life.carp`, which was detected by @pluckyporcupine!

It’s a simple API change that went undetected.

Cheers