### PR TITLE
Temporarily fix reloading errors related to the Binary module

### DIFF
--- a/core/Binary.carp
+++ b/core/Binary.carp
@@ -54,8 +54,9 @@
                  (Just y3) (Just (~f x y z x2 y2 z2 x3 y3)))))))))))
 )
 
-(defmodule Binary
-  (doc Order
+;; Temporary fix for issue #698
+;; The underlying issue is deeper, and should probably be fixed.
+(doc ByteOrder
     "The type of byte orders.
 
     LittleEndian designates the little endian ordering, and indicates the least
@@ -63,8 +64,9 @@
 
     BigEndian designates the big endian ordering, and indicates the most
     significant byte occurs first in a given byte sequence.")
-  (deftype Order LittleEndian BigEndian)
+  (deftype ByteOrder LittleEndian BigEndian)
 
+(defmodule Binary
   (register to-int16 (λ [Byte Byte] Uint16))
   (register to-int32 (λ [Byte Byte Byte Byte] Uint32))
   (register to-int64 (λ [Byte Byte Byte Byte Byte Byte Byte Byte] Uint64))
@@ -114,21 +116,21 @@
 
   (doc system-endianness
     "Returns the endianness of the host system.")
-  (sig system-endianness (λ [] Order))
+  (sig system-endianness (λ [] ByteOrder))
   (defn system-endianness []
     (if (= (system-endianness-internal) 1)
-        (Order.LittleEndian)
-        (Order.BigEndian)))
+        (ByteOrder.LittleEndian)
+        (ByteOrder.BigEndian)))
 
   (doc unsafe-bytes->int16
     "Interprets the first two bytes in a byte sequence as an Uint16 value.
      **This operation is unsafe.**")
-  (sig unsafe-bytes->int16 (Fn [Order (Ref (Array Byte) a)] Uint16))
+  (sig unsafe-bytes->int16 (Fn [ByteOrder (Ref (Array Byte) a)] Uint16))
   (defn unsafe-bytes->int16 [order bs]
     (match order
-      (Order.LittleEndian)
+      (ByteOrder.LittleEndian)
         (to-int16 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1))
-      (Order.BigEndian)
+      (ByteOrder.BigEndian)
         (to-int16 @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
   (doc bytes->int16
@@ -136,28 +138,28 @@
 
      If the first two bytes are inaccessible, or the given array contains less
      than two bytes, returns Maybe.Nothing.")
-  (sig bytes->int16 (Fn [Order (Ref (Array Byte) a)] (Maybe Uint16)))
+  (sig bytes->int16 (Fn [ByteOrder (Ref (Array Byte) a)] (Maybe Uint16)))
   (defn bytes->int16 [order bytes]
     (match order
-      (Order.LittleEndian)
+      (ByteOrder.LittleEndian)
         (Maybe.zip &to-int16 (Array.nth bytes 0) (Array.nth bytes 1))
-      (Order.BigEndian)
+      (ByteOrder.BigEndian)
         (Maybe.zip &to-int16 (Array.nth bytes 1) (Array.nth bytes 0))))
 
   (doc int16->bytes
     "Converts a Uint16 to a sequence of bytes representing the value using the provided `order`")
-  (sig int16->bytes (Fn [Order Uint16] (Array Byte)))
+  (sig int16->bytes (Fn [ByteOrder Uint16] (Array Byte)))
   (defn int16->bytes [order i]
     (match order
-      (Order.LittleEndian)
+      (ByteOrder.LittleEndian)
         (Array.copy-map &int16-to-byte &[i (Uint16.bit-shift-right i (Uint16.from-long 8l))])
-      (Order.BigEndian)
+      (ByteOrder.BigEndian)
         (Array.copy-map &int16-to-byte &[(Uint16.bit-shift-right i (Uint16.from-long 8l)) i])))
 
   (doc unsafe-bytes->int16-seq
     "Interprets a sequence of bytes as a sequence of Uint16 values.
      **This operation is unsafe.**")
-  (sig unsafe-bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint16)))
+  (sig unsafe-bytes->int16-seq (Fn [ByteOrder (Ref (Array Byte) a)] (Array Uint16)))
   (defn unsafe-bytes->int16-seq [order bs]
     (let [partitions (Array.partition bs 2)
           f (fn [b] (unsafe-bytes->int16 order b))]
@@ -167,7 +169,7 @@
     "Interprets a sequence of bytes as a sequence of Uint16 values.
 
      Returns a pair containing interpreted values and the number of bytes that were not interpreted.")
-  (sig bytes->int16-seq (Fn [Order (Ref (Array Byte) a)] (Pair (Array Uint16) Int)))
+  (sig bytes->int16-seq (Fn [ByteOrder (Ref (Array Byte) a)] (Pair (Array Uint16) Int)))
   (defn bytes->int16-seq [order bs]
     (let [partitions (Array.partition bs 2)
           f (byte-converter &bytes->int16 order)]
@@ -178,7 +180,7 @@
     "Attempts to interpret a given byte sequence as an exact sequence of Uint16 values.
 
      If successful, returns the interpreted values. If unsuccessful, returns the number of excess bytes.")
-  (sig bytes->int16-seq-exact (Fn [Order (Ref (Array Byte) a)] (Result (Array Uint16) Int)))
+  (sig bytes->int16-seq-exact (Fn [ByteOrder (Ref (Array Byte) a)] (Result (Array Uint16) Int)))
   (defn bytes->int16-seq-exact [order bs]
     (let [r (bytes->int16-seq order bs)]
       (if (= 0 @(Pair.b &r))
@@ -187,7 +189,7 @@
 
   (doc int16-seq->bytes
     "Converts an array of Uint16 values into byte sequences.")
-  (sig int16-seq->bytes (Fn [Order (Ref (Array Uint16) a)] (Array (Array Byte))))
+  (sig int16-seq->bytes (Fn [ByteOrder (Ref (Array Uint16) a)] (Array (Array Byte))))
   (defn int16-seq->bytes [order is]
     (let [f (fn [i] (int16->bytes order @i))]
       (Array.copy-map &f is)))
@@ -195,13 +197,13 @@
   (doc unsafe-bytes->int32
     "Interprets the first four bytes in a byte sequence as an Uint32 value.
      **This operation is unsafe.**")
-  (sig unsafe-bytes->int32 (Fn [Order (Ref (Array Byte))] Uint32))
+  (sig unsafe-bytes->int32 (Fn [ByteOrder (Ref (Array Byte))] Uint32))
   (defn unsafe-bytes->int32 [order bs]
     (match order
-      (Order.LittleEndian)
+      (ByteOrder.LittleEndian)
         (to-int32 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)
                   @(Array.unsafe-nth bs 2) @(Array.unsafe-nth bs 3))
-      (Order.BigEndian)
+      (ByteOrder.BigEndian)
         (to-int32 @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
                   @(Array.unsafe-nth bs 1) @(Array.unsafe-nth bs 0))))
 
@@ -210,33 +212,33 @@
 
      If the first four bytes are inaccessible, or the given array contains less
      than four bytes, returns Maybe.Nothing.")
-  (sig bytes->int32 (Fn [Order (Ref (Array Byte))] (Maybe Uint32)))
+  (sig bytes->int32 (Fn [ByteOrder (Ref (Array Byte))] (Maybe Uint32)))
   (defn bytes->int32 [order bs]
     (match order
-      (Order.LittleEndian)
+      (ByteOrder.LittleEndian)
         (Maybe.zip4 &to-int32 (Array.nth bs 0) (Array.nth bs 1)
                               (Array.nth bs 2) (Array.nth bs 3))
-      (Order.BigEndian)
+      (ByteOrder.BigEndian)
         (Maybe.zip4 &to-int32 (Array.nth bs 3) (Array.nth bs 2)
                               (Array.nth bs 1) (Array.nth bs 0))))
 
   (doc int32->bytes
     "Converts a Uint32 to a sequence of bytes representing the value using the provided `order`")
-  (sig int32->bytes (Fn [Order Uint32] (Array Byte)))
+  (sig int32->bytes (Fn [ByteOrder Uint32] (Array Byte)))
   (defn int32->bytes [order i]
     (let [shift (fn [lng] (Uint32.bit-shift-right i (Uint32.from-long lng)))]
       (match order
-        (Order.LittleEndian)
+        (ByteOrder.LittleEndian)
           (Array.copy-map &int32-to-byte
             &[i (shift 8l) (shift 16l) (shift 24l)])
-        (Order.BigEndian)
+        (ByteOrder.BigEndian)
           (Array.copy-map &int32-to-byte
             &[(shift 24l) (shift 16l) (shift 8l) i]))))
 
   (doc unsafe-bytes->int32-seq
     "Interprets a sequence of bytes as a sequence of Uint32 values.
      **This operation is unsafe.**")
-  (sig unsafe-bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint32)))
+  (sig unsafe-bytes->int32-seq (Fn [ByteOrder (Ref (Array Byte) a)] (Array Uint32)))
   (defn unsafe-bytes->int32-seq [order bs]
     (let [partitions (Array.partition bs 4)
           f (fn [b] (unsafe-bytes->int32 order b))]
@@ -246,7 +248,7 @@
     "Interprets a sequence of bytes as a sequence of Uint32 values.
 
      Returns a pair containing interpreted values and the number of bytes that were not interpreted.")
-  (sig bytes->int32-seq (Fn [Order (Ref (Array Byte) a)] (Pair (Array Uint32) Int)))
+  (sig bytes->int32-seq (Fn [ByteOrder (Ref (Array Byte) a)] (Pair (Array Uint32) Int)))
   (defn bytes->int32-seq [order bs]
     (let [partitions (Array.partition bs 4)
           f (byte-converter &bytes->int32 order)]
@@ -257,7 +259,7 @@
     "Attempts to interpret a given byte sequence as an exact sequence of Uint32 values.
 
      If successful, returns the interpreted values. If unsuccessful, returns the number of excess bytes.")
-  (sig bytes->int32-seq-exact (Fn [Order (Ref (Array Byte) a)] (Result (Array Uint32) Int)))
+  (sig bytes->int32-seq-exact (Fn [ByteOrder (Ref (Array Byte) a)] (Result (Array Uint32) Int)))
   (defn bytes->int32-seq-exact [order bs]
     (let [r (bytes->int32-seq order bs)]
       (if (= 0 @(Pair.b &r))
@@ -266,7 +268,7 @@
 
   (doc int32-seq->bytes
     "Converts an array of Uint32 values into byte sequences.")
-  (sig int32-seq->bytes (Fn [Order (Ref (Array Uint32) a)] (Array (Array Byte))))
+  (sig int32-seq->bytes (Fn [ByteOrder (Ref (Array Uint32) a)] (Array (Array Byte))))
   (defn int32-seq->bytes [order is]
     (let [f (fn [i] (int32->bytes order @i))]
       (Array.copy-map &f is)))
@@ -274,15 +276,15 @@
   (doc unsafe-bytes->int64
     "Interprets the first eight bytes in a byte sequence as an Uint64 value.
      **This operation is unsafe.**")
-  (sig unsafe-bytes->int64 (Fn [Order (Ref (Array Byte) a)] Uint64))
+  (sig unsafe-bytes->int64 (Fn [ByteOrder (Ref (Array Byte) a)] Uint64))
   (defn unsafe-bytes->int64 [order bs]
     (match order
-      (Order.LittleEndian)
+      (ByteOrder.LittleEndian)
         (to-int64 @(Array.unsafe-nth bs 0) @(Array.unsafe-nth bs 1)
                   @(Array.unsafe-nth bs 2) @(Array.unsafe-nth bs 3)
                   @(Array.unsafe-nth bs 4) @(Array.unsafe-nth bs 5)
                   @(Array.unsafe-nth bs 6) @(Array.unsafe-nth bs 7))
-      (Order.BigEndian)
+      (ByteOrder.BigEndian)
         (to-int64 @(Array.unsafe-nth bs 7) @(Array.unsafe-nth bs 6)
                   @(Array.unsafe-nth bs 5) @(Array.unsafe-nth bs 4)
                   @(Array.unsafe-nth bs 3) @(Array.unsafe-nth bs 2)
@@ -293,31 +295,31 @@
 
      If the first eight bytes are inaccessible, or the given array contains less
      than eight bytes, returns Maybe.Nothing.")
-  (sig bytes->int64 (Fn [Order (Ref (Array Byte) a)] (Maybe Uint64)))
+  (sig bytes->int64 (Fn [ByteOrder (Ref (Array Byte) a)] (Maybe Uint64)))
   (defn bytes->int64 [order bs]
     (match order
-      (Order.LittleEndian)
+      (ByteOrder.LittleEndian)
         (Maybe.zip8 &to-int64 (Array.nth bs 0) (Array.nth bs 1)
                               (Array.nth bs 2) (Array.nth bs 3)
                               (Array.nth bs 4) (Array.nth bs 5)
                               (Array.nth bs 6) (Array.nth bs 7))
-      (Order.BigEndian)
+      (ByteOrder.BigEndian)
         (Maybe.zip8 &to-int64 (Array.nth bs 7) (Array.nth bs 6)
                               (Array.nth bs 5) (Array.nth bs 4)
                               (Array.nth bs 3) (Array.nth bs 2)
                               (Array.nth bs 1) (Array.nth bs 0))))
   (doc int64->bytes
     "Converts a Uint64 to a sequence of bytes representing the value using the provided `order`")
-  (sig int64->bytes (Fn [Order Uint64] (Array Byte)))
+  (sig int64->bytes (Fn [ByteOrder Uint64] (Array Byte)))
   (defn int64->bytes [order i]
     (let [shift (fn [lng] (Uint64.bit-shift-right i (Uint64.from-long lng)))]
       (match order
-        (Order.LittleEndian)
+        (ByteOrder.LittleEndian)
           (Array.copy-map &int64-to-byte
             &[i (shift 8l) (shift 16l)
                 (shift 24l) (shift 32l)
                 (shift 40l) (shift 48l) (shift 56l)])
-        (Order.BigEndian)
+        (ByteOrder.BigEndian)
           (Array.copy-map &int64-to-byte
             &[(shift 56l) (shift 48l)
               (shift 40l) (shift 32l)
@@ -326,7 +328,7 @@
   (doc unsafe-bytes->int64-seq
     "Interprets a sequence of bytes as a sequence of Uint64 values.
      **This operation is unsafe.**")
-  (sig unsafe-bytes->int64-seq (Fn [Order (Ref (Array Byte) a)] (Array Uint64)))
+  (sig unsafe-bytes->int64-seq (Fn [ByteOrder (Ref (Array Byte) a)] (Array Uint64)))
   (defn unsafe-bytes->int64-seq [order bs]
     (let [partitions (Array.partition bs 8)
           f (fn [b] (unsafe-bytes->int64 order b))]
@@ -336,7 +338,7 @@
     "Interprets a sequence of bytes as a sequence of Uint64 values.
 
      Returns a pair containing interpreted values and the number of bytes that were not interpreted.")
-  (sig bytes->int64-seq (Fn [Order (Ref (Array Byte) a)] (Pair (Array Uint64) Int)))
+  (sig bytes->int64-seq (Fn [ByteOrder (Ref (Array Byte) a)] (Pair (Array Uint64) Int)))
   (defn bytes->int64-seq [order bs]
     (let [partitions (Array.partition bs 8)
           f (byte-converter &bytes->int64 order)]
@@ -347,7 +349,7 @@
     "Attempts to interpret a given byte sequence as an exact sequence of Uint64 values.
 
      If successful, returns the interpreted values. If unsuccessful, returns the number of excess bytes.")
-  (sig bytes->int64-seq-exact (Fn [Order (Ref (Array Byte) a)] (Result (Array Uint64) Int)))
+  (sig bytes->int64-seq-exact (Fn [ByteOrder (Ref (Array Byte) a)] (Result (Array Uint64) Int)))
   (defn bytes->int64-seq-exact [order bs]
     (let [r (bytes->int64-seq order bs)]
       (if (= 0 @(Pair.b &r))
@@ -356,7 +358,7 @@
 
   (doc int64-seq->bytes
     "Converts an array of Uint64 values into byte sequences.")
-  (sig int64-seq->bytes (Fn [Order (Ref (Array Uint64) a)] (Array (Array Byte))))
+  (sig int64-seq->bytes (Fn [ByteOrder (Ref (Array Uint64) a)] (Array (Array Byte))))
   (defn int64-seq->bytes [order is]
     (let [f (fn [i] (int64->bytes order @i))]
       (Array.copy-map &f is)))

--- a/test/binary.carp
+++ b/test/binary.carp
@@ -7,37 +7,37 @@
   ;; int16 tests
   (assert-equal test
                 (Uint16.from-long 2051l)
-                (unsafe-bytes->int16 (Binary.Order.LittleEndian) &[3b 8b])
+                (unsafe-bytes->int16 (ByteOrder.LittleEndian) &[3b 8b])
                 "Unsafe little endian unsafe-bytes->int16 works as expected.")
 
   (assert-equal test
                 (Uint16.from-long 776l)
-                (unsafe-bytes->int16 (Binary.Order.BigEndian) &[3b 8b])
+                (unsafe-bytes->int16 (ByteOrder.BigEndian) &[3b 8b])
                 "Unsafe big endian unsafe-bytes->int16 works as expected.")
 
   (assert-equal test
                 &(Maybe.Just (Uint16.from-long 2051l))
-                &(bytes->int16 (Binary.Order.LittleEndian) &[3b 8b])
+                &(bytes->int16 (ByteOrder.LittleEndian) &[3b 8b])
                 "Unsafe little endian bytes->int16 works as expected.")
 
   (assert-equal test
                 &(Maybe.Just (Uint16.from-long 776l))
-                &(bytes->int16 (Binary.Order.BigEndian) &[3b 8b])
+                &(bytes->int16 (ByteOrder.BigEndian) &[3b 8b])
                 "Unsafe big endian bytes->int16 works as expected.")
 
   (assert-equal test
                 &(Maybe.Nothing)
-                &(bytes->int16 (Binary.Order.LittleEndian) &[3b])
+                &(bytes->int16 (ByteOrder.LittleEndian) &[3b])
                 "bytes->int16 returns Nothing on insufficient data.")
 
   (assert-equal test
                 &[(Uint16.from-long 2051l) (Uint16.from-long 776l)]
-                &(unsafe-bytes->int16-seq (Binary.Order.LittleEndian) &[3b 8b 8b 3b])
+                &(unsafe-bytes->int16-seq (ByteOrder.LittleEndian) &[3b 8b 8b 3b])
                 "Unsafe little endian bytes->int16-seq works as expected.")
 
   (assert-equal test
                 &(Pair.init [(Uint16.from-long 776l) (Uint16.from-long 2051l)] 1)
-                &(bytes->int16-seq (Binary.Order.BigEndian) &[3b 8b 8b 3b 2b])
+                &(bytes->int16-seq (ByteOrder.BigEndian) &[3b 8b 8b 3b 2b])
                 "Big endian bytes->int16-seq works as expected.")
 
   ;; We unwrap the error here since it's simpler than defining equality over
@@ -45,119 +45,119 @@
   ;; TODO: Define equality for arrays of non-ref values.
   (assert-equal test
                 &(Result.unsafe-from-error (the (Result (Array Uint16) Int) (Result.Error 1)))
-                &(Result.unsafe-from-error (bytes->int16-seq-exact (Binary.Order.BigEndian) &[3b 8b 8b 3b 2b]))
+                &(Result.unsafe-from-error (bytes->int16-seq-exact (ByteOrder.BigEndian) &[3b 8b 8b 3b 2b]))
                 "Big endian bytes->int16-seq-exact works as expected.")
 
   (assert-equal test
                 &[3b 8b]
-                &(int16->bytes (Binary.Order.LittleEndian) (Uint16.from-long 2051l))
+                &(int16->bytes (ByteOrder.LittleEndian) (Uint16.from-long 2051l))
                 "Little endian int16->bytes works as expected.")
 
   (assert-equal test
                 &[[3b 8b] [8b 3b]]
-                &(int16-seq->bytes (Binary.Order.LittleEndian) &[(Uint16.from-long 2051l) (Uint16.from-long 776l)])
+                &(int16-seq->bytes (ByteOrder.LittleEndian) &[(Uint16.from-long 2051l) (Uint16.from-long 776l)])
                 "Little endian int16->bytes works as expected.")
 
   ;; int32 tests
   (assert-equal test
                 (Uint32.from-long 67305985l)
-                (unsafe-bytes->int32 (Binary.Order.LittleEndian) &[1b 2b 3b 4b])
+                (unsafe-bytes->int32 (ByteOrder.LittleEndian) &[1b 2b 3b 4b])
                 "Unsafe little endian unsafe-bytes->int32 works as expected.")
 
   (assert-equal test
                 (Uint32.from-long 16909060l)
-                (unsafe-bytes->int32 (Binary.Order.BigEndian) &[1b 2b 3b 4b])
+                (unsafe-bytes->int32 (ByteOrder.BigEndian) &[1b 2b 3b 4b])
                 "Unsafe big endian unsafe-bytes->int32 works as expected.")
 
   (assert-equal test
                 &(Maybe.Just (Uint32.from-long 67305985l))
-                &(bytes->int32 (Binary.Order.LittleEndian) &[1b 2b 3b 4b])
+                &(bytes->int32 (ByteOrder.LittleEndian) &[1b 2b 3b 4b])
                 "Unsafe little endian bytes->int32 works as expected.")
 
   (assert-equal test
                 &(Maybe.Just (Uint32.from-long 16909060l))
-                &(bytes->int32 (Binary.Order.BigEndian) &[1b 2b 3b 4b])
+                &(bytes->int32 (ByteOrder.BigEndian) &[1b 2b 3b 4b])
                 "Unsafe big endian bytes->int32 works as expected.")
 
   (assert-equal test
                 &(Maybe.Nothing)
-                &(bytes->int32 (Binary.Order.LittleEndian) &[3b])
+                &(bytes->int32 (ByteOrder.LittleEndian) &[3b])
                 "bytes->int32 returns Nothing on insufficient data.")
 
   (assert-equal test
                 &[(Uint32.from-long 67305985l) (Uint32.from-long 16909060l)]
-                &(unsafe-bytes->int32-seq (Binary.Order.LittleEndian) &[1b 2b 3b 4b 4b 3b 2b 1b])
+                &(unsafe-bytes->int32-seq (ByteOrder.LittleEndian) &[1b 2b 3b 4b 4b 3b 2b 1b])
                 "Unsafe little endian bytes->int32-seq works as expected.")
 
   (assert-equal test
                 &(Pair.init [(Uint32.from-long 16909060l) (Uint32.from-long 67305985l)] 1)
-                &(bytes->int32-seq (Binary.Order.BigEndian) &[1b 2b 3b 4b 4b 3b 2b 1b 5b])
+                &(bytes->int32-seq (ByteOrder.BigEndian) &[1b 2b 3b 4b 4b 3b 2b 1b 5b])
                 "Big endian bytes->int32-seq works as expected.")
 
   (assert-equal test
                 &(Result.unsafe-from-error (the (Result (Array Uint32) Int) (Result.Error 1)))
-                &(Result.unsafe-from-error (bytes->int32-seq-exact (Binary.Order.BigEndian) &[1b 2b 3b 4b 4b 3b 2b 1b 5b]))
+                &(Result.unsafe-from-error (bytes->int32-seq-exact (ByteOrder.BigEndian) &[1b 2b 3b 4b 4b 3b 2b 1b 5b]))
                 "Big endian bytes->int32-seq-exact works as expected.")
 
   (assert-equal test
                 &[1b 2b 3b 4b]
-                &(int32->bytes (Binary.Order.LittleEndian) (Uint32.from-long 67305985l))
+                &(int32->bytes (ByteOrder.LittleEndian) (Uint32.from-long 67305985l))
                 "Little endian int32->bytes works as expected.")
 
   (assert-equal test
                 &[[1b 2b 3b 4b] [4b 3b 2b 1b]]
-                &(int32-seq->bytes (Binary.Order.LittleEndian) &[(Uint32.from-long 67305985l) (Uint32.from-long 16909060l)])
+                &(int32-seq->bytes (ByteOrder.LittleEndian) &[(Uint32.from-long 67305985l) (Uint32.from-long 16909060l)])
                 "Little endian int32-seq->bytes works as expected.")
 
   ;; int64 tests
   ;; We only go up to 6b in the 6th position--going higher seems to cause precision loss (at least on my system).
   (assert-equal test
                 (Uint64.from-long 6618611909121l)
-                (unsafe-bytes->int64 (Binary.Order.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                (unsafe-bytes->int64 (ByteOrder.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
                 "Unsafe little endian unsafe-bytes->int64 works as expected.")
 
   (assert-equal test
                 (Uint64.from-long 72623859790381056l)
-                (unsafe-bytes->int64 (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                (unsafe-bytes->int64 (ByteOrder.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
                 "Unsafe big endian unsafe-bytes->int64 works as expected.")
 
   (assert-equal test
                 &(Maybe.Just  (Uint64.from-long 6618611909121l))
-                &(bytes->int64 (Binary.Order.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                &(bytes->int64 (ByteOrder.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
                 "Unsafe little endian bytes->int64 works as expected.")
 
   (assert-equal test
                 &(Maybe.Just (Uint64.from-long 72623859790381056l))
-                &(bytes->int64 (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
+                &(bytes->int64 (ByteOrder.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
                 "Unsafe big endian bytes->int64 works as expected.")
 
   (assert-equal test
                 &(Maybe.Nothing)
-                &(bytes->int64 (Binary.Order.LittleEndian) &[3b])
+                &(bytes->int64 (ByteOrder.LittleEndian) &[3b])
                 "bytes->int64 returns Nothing on insufficient data.")
 
   (assert-equal test
                 &[(Uint64.from-long 6618611909121l) (Uint64.from-long 72623859790381056l)]
-                &(unsafe-bytes->int64-seq (Binary.Order.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b])
+                &(unsafe-bytes->int64-seq (ByteOrder.LittleEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b])
                 "Unsafe little endian bytes->int64-seq works as expected.")
 
   (assert-equal test
                 &(Pair.init [(Uint64.from-long 72623859790381056l) (Uint64.from-long 6618611909121l)] 1)
-                &(bytes->int64-seq (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b 5b])
+                &(bytes->int64-seq (ByteOrder.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b 5b])
                 "Unsafe big endian bytes->int64-seq works as expected.")
 
   (assert-equal test
                 &(Result.unsafe-from-error (the (Result (Array Uint64) Int) (Result.Error 1)))
-                &(Result.unsafe-from-error (bytes->int64-seq-exact (Binary.Order.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b 5b]))
+                &(Result.unsafe-from-error (bytes->int64-seq-exact (ByteOrder.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b 0b 0b 6b 5b 4b 3b 2b 1b 5b]))
                 "Unsafe big endian bytes->int64-seq-exact works as expected.")
 
   (assert-equal test
                 &[1b 2b 3b 4b 5b 6b 0b 0b]
-                &(int64->bytes (Binary.Order.LittleEndian) (Uint64.from-long 6618611909121l))
+                &(int64->bytes (ByteOrder.LittleEndian) (Uint64.from-long 6618611909121l))
                 "Little endian int64->bytes works as expected.")
 
   (assert-equal test
                 &[[1b 2b 3b 4b 5b 6b 0b 0b] [0b 0b 6b 5b 4b 3b 2b 1b]]
-                &(int64-seq->bytes (Binary.Order.LittleEndian) &[ (Uint64.from-long 6618611909121l) (Uint64.from-long 72623859790381056l)])
+                &(int64-seq->bytes (ByteOrder.LittleEndian) &[ (Uint64.from-long 6618611909121l) (Uint64.from-long 72623859790381056l)])
                 "Little endian int64-seq->bytes works as expected.")
 )


### PR DESCRIPTION
This PR contains a temporary fix for the issue described in #698--it doesn't resolve the underlying issue, defining types in modules, and setting their doc meta still results in "too many functions" errors on reload, but this at least fixes the problem temporarily for the Binary module.﻿
