### PR TITLE
Add support for explicit null pointers

### DIFF
--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -1,4 +1,9 @@
+(system-include "carp_pointer.h")
+
 (defmodule Pointer
   (defn inc [a] (Pointer.add a 1l))
   (defn dec [a] (Pointer.sub a 1l))
+  (register void (Fn [] (Ptr ())) "void_pointer")
+  (sig str (Fn [(Ref (Ptr ()))] String))
+  (defn str [p] @"(Ptr ())")
 )

--- a/core/carp_pointer.h
+++ b/core/carp_pointer.h
@@ -1,0 +1,5 @@
+void* void_pointer() {
+  void* p;
+  p = NULL;
+  return p;
+}


### PR DESCRIPTION
This change adds a simple function to create a *null* void pointer from Carp.

## Background

The impetus for this is that older C libraries sometimes use null pointers as arguments to functions; I encountered this in practice while working with ncurses; many of the attr functions in ncurses take a void pointer argument which was "reserved for future use" and never actually used. The current implementation of ncurses I have expects an Int pointer for two of these functions but otherwise checks that this argument is NULL (according to the curs_attr) man page.

In the current version of ncurses that I have (6.1), it appears that the NULL checks don't actually exist. The opts argument is magic-wanded away through much configuration and macro processing (for most cases, so far as I can tell) But presumably the safe thing to do is to follow the letter of the manpage here, for compatibility reasons.

## Questions

1. Is this really necessary?

I'm not sure how common this practice is. I've only encountered it in ncurses. A pretty clean alternative here is to leave this out of core and to let implementors handle it case-by-case. For example, I can resolve this just for ncurses by writing some helper c code and binding carp bindings to the helpers instead of ncurses functions directly.

2. Does Carp's `NULL` already do this?

`NULL` seemed like a possible answer to this, but I was quite confused as to what it does--it wasn't totally clear to me from the `Maybe.carp` ptr transformation code. Does it already satisfy this use case? Should we document it somewhere?

Could have made this an issue first, but the gist of the change was simple enough so I went ahead with a PR for discussion, thanks!