### PR TITLE
Fix args test

### DIFF
--- a/test/args.carp
+++ b/test/args.carp
@@ -2,7 +2,10 @@
 (use Test)
 
 (defndynamic _make-exe-path [pth]
-  (String.join (array (Project.get-config "output-directory") pth)))
+  (let [out (Project.get-config "output-directory")
+        sep (if (= (os) "windows") "\\" "/")
+        lst (String.suffix out (- (String.length out) 1))]
+    (String.join (array out (if (= lst sep) "" sep) pth))))
 
 (defmacro make-exe-path [pth]
   (_make-exe-path pth))


### PR DESCRIPTION
This PR fixes a bug discovered by @TimDeve. One of the tests in `test/args.carp` constructed the path to the executable erroneously when there was no trailing path separator.

Cheers