### PR TITLE
Fix args test for windows (again)

### DIFF
--- a/test/args.carp
+++ b/test/args.carp
@@ -3,7 +3,7 @@
 
 (defndynamic _make-exe-path [pth]
   (let [out (Project.get-config "output-directory")
-        sep (if (= (os) "windows") "\\" "/")
+        sep (if (Dynamic.or (= (os) "windows") (= (os) "mingw32")) "\\" "/")
         lst (String.suffix out (- (String.length out) 1))]
     (String.join (array out (if (= lst sep) "" sep) pth))))
 


### PR DESCRIPTION
As pointed out by @TimDeve we should also include `mingw32` in the test for a Windows system in `test/args.carp`.

Cheers