### PR TITLE
Create CI for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,55 @@
+name: Windows CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Save git commit SHA 
+        run: echo ::set-env name=GITHUB_SHA::%GITHUB_SHA%
+        shell: cmd
+
+      - name: Install Scoop
+        run: |
+          iwr -useb get.scoop.sh | iex
+          echo "::add-path::~\scoop\shims"
+          echo "::add-path::C:\ProgramData\scoop\shims"
+
+      - name: Install Stack
+        run: scoop install stack
+
+      - uses: actions/cache@v1
+        name: Cache stack dependencies
+        with:
+          path: C:\\Users\\runneradmin\\AppData\\Local\\Programs\\stack
+          key: ${{ runner.os }}-stack-deps-${{ env.GITHUB_SHA }} 
+          restore-keys: ${{ runner.os }}-stack-deps
+
+      - uses: actions/cache@v1
+        name: Cache stack build
+        with:
+          path: C:\\Users\\runneradmin\\AppData\\Roaming\\stack\
+          key: ${{ runner.os }}-stack-build-${{ env.GITHUB_SHA }}
+          restore-keys: ${{ runner.os }}-stack-build
+
+      - name: Install Clang
+        run: scoop install llvm --global
+
+      - name: Build
+        run: stack build
+
+      - name: Run Compiler Tests
+        run: stack test
+
+      - name: Run Carp Tests
+        run: ./run_carp_tests.ps1
+

--- a/run_carp_tests.ps1
+++ b/run_carp_tests.ps1
@@ -1,0 +1,38 @@
+# Stops script if there is an error
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$PSDefaultParameterValues['*:ErrorAction']='Stop'
+
+function exitOnError {
+  param([scriptblock]$ScriptBlock)
+  & @ScriptBlock
+  if ($lastexitcode -ne 0) {
+    exit $lastexitcode
+  }
+}
+
+# TODO Add building of examples
+
+# Actual tests (using the test suite)
+Get-ChildItem -Filter test/*.carp | ForEach-Object -Process {
+  exitOnError {
+    echo $_.FullName
+    stack exec carp "--" -x --log-memory $_.FullName
+    echo ""
+  }
+}
+
+# TODO Add tests for error messages
+
+# Just make sure these compile
+exitOnError { stack exec carp "--" ./examples/mutual_recursion.carp -b }
+exitOnError { stack exec carp "--" ./examples/guessing.carp -b }
+exitOnError { stack exec carp "--" ./examples/no_core.carp --no-core -b }
+exitOnError { stack exec carp "--" ./examples/check_malloc.carp -b }
+
+# Generate docs
+exitOnError { stack exec carp "--" ./docs/core/generate_core_docs.carp }
+exitOnError { stack exec carp "--" ./docs/sdl/generate_sdl_docs.carp }
+
+echo "ALL TESTS DONE."
+


### PR DESCRIPTION
This PR creates a Powershell script so that the test suite can be run on Windows.

It's just a draft for now to get some feedback.

Aside from the issues in https://github.com/carp-lang/Carp/pull/705 and https://github.com/carp-lang/Carp/pull/704 the only failing tests seems related to int64 and uint64 probably because of https://github.com/carp-lang/Carp/pull/577, should these tests be skipped on Windows for now?

The script also doesn't include the output checks for errors and the examples, I'm looking at adding this later.

My goal with this script is to hopefully get Windows CI running similar to https://github.com/carp-lang/Carp/pull/706 so that regressions on Windows can be detected earlier.