### PR TITLE
Adds stack test to CI

### DIFF
--- a/.github/workflows/carp.yml
+++ b/.github/workflows/carp.yml
@@ -28,5 +28,8 @@ jobs:
     - name: Build
       run: stack build
 
+    - name: Run Compiler Tests
+      run: stack test
+
     - name: Run Carp Tests
       run: ./run_carp_tests.sh --no_sdl


### PR DESCRIPTION
This is a follow up to https://github.com/carp-lang/Carp/pull/706, it wasn't included then because some of the tests failed when running `stack test`, now that https://github.com/carp-lang/Carp/commit/f616945ebd2f699d53ac7a3b86bfc1bd0b6c8b10 has happened we should be able to run `stack test` in the CI.