### PR TITLE
Add functions to: turn Ptr into value & prevent destructor from being run 

### DIFF
--- a/docs/core/Pointer.html
+++ b/docs/core/Pointer.html
@@ -330,6 +330,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#to-value">
+                    <h3 id="to-value">
+                        to-value
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (λ [(Ptr a)] a)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>converts a pointer to a value. The user will have to ensure themselves that this is a safe operation.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#width">
                     <h3 id="width">
                         width

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -386,7 +386,7 @@ unsafeModule = Env { envBindings = bindings
                    , envUseModules = []
                    , envMode = ExternalEnv
                    , envFunctionNestingLevel = 0 }
-  where bindings = Map.fromList [ templateCoerce ]
+  where bindings = Map.fromList [ templateCoerce, templateLeak ]
 
 -- | A template for coercing (casting) a type to another type
 templateCoerce :: (String, Binder)
@@ -397,6 +397,17 @@ templateCoerce = defineTemplate
   (toTemplate "$a $NAME ($b b)")
   (toTemplate $ unlines ["$DECL {"
                         ,"   return ($a)b;"
+                        ,"}"])
+  (const [])
+
+-- | A template function for preventing destructor from being run on a value (it's up to the user of this function to make sure that memory is freed).
+templateLeak = defineTemplate
+  (SymPath ["Unsafe"] "leak")
+  (FuncTy [(VarTy "a")] UnitTy StaticLifetimeTy)
+  "prevents a destructor from being run on a value a."
+  (toTemplate "void $NAME ($a a)")
+  (toTemplate $ unlines ["$DECL {"
+                        ,"    // Leak"
                         ,"}"])
   (const [])
 

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -56,6 +56,7 @@ pointerModule = Env { envBindings = bindings
   where bindings = Map.fromList [ templatePointerCopy
                                 , templatePointerEqual
                                 , templatePointerToRef
+                                , templatePointerToValue
                                 , templatePointerAdd
                                 , templatePointerSub
                                 , templatePointerWidth
@@ -93,6 +94,18 @@ templatePointerToRef = defineTemplate
   (toTemplate "$p* $NAME ($p *p)")
   (toTemplate $ unlines ["$DECL {"
                         ,"    return p;"
+                        ,"}"])
+  (const [])
+
+
+-- | A template function for converting pointers to values (it's up to the user of this function to make sure that is a safe operation).
+templatePointerToValue = defineTemplate
+  (SymPath ["Pointer"] "to-value")
+  (FuncTy [PointerTy (VarTy "p")] (VarTy "p") StaticLifetimeTy)
+  "converts a pointer to a value. The user will have to ensure themselves that this is a safe operation."
+  (toTemplate "$p $NAME ($p *p)")
+  (toTemplate $ unlines ["$DECL {"
+                        ,"    return *p;"
                         ,"}"])
   (const [])
 

--- a/test/pointer.carp
+++ b/test/pointer.carp
@@ -7,6 +7,9 @@
 (def xa (to-long x))
 (def w (width x))
 
+(defn ref-to-ptr [r]
+  (the (Ptr a) (Unsafe.coerce (the (Ref a) r))))
+
 ; these tests are sadly a little unsafe
 (deftest test
   (assert-equal test
@@ -34,5 +37,10 @@
                 (- xa w)
                 (to-long (dec x))
                 "Pointer.dec works as expected"
+  )
+  (assert-equal test
+                (to-value (ref-to-ptr &123))
+                123
+                "Pointer.to-value works as expected"
   )
 )

--- a/test/unsafe.carp
+++ b/test/unsafe.carp
@@ -1,0 +1,12 @@
+(load "Test.carp")
+(use Test)
+
+(deftest test
+  (assert-equal test
+                1l
+                (do
+                  (Debug.reset-memory-balance!)
+                  (let [s @"String"]
+                    (Unsafe.leak s))
+                  (Debug.memory-balance))
+                "Unsafe.leak should stop Carp from freeing allocated memory"))


### PR DESCRIPTION
Adds two functions:

Pointer.to-value turns a Ptr into an owned value

Unsafe.leak consumes a value and prevents it from being freed by Carp

This is a draft because there isn't any tests yet and I'm not sure this is something that people want.

Combining the two allows to extract values out of a struct without copy.

Example:
```clojure
(defn to-ptr [r] (the (Ptr a) (Unsafe.coerce (the (Ref a) r))))

(defn unsafe-value [a] (Pointer.to-value (to-ptr a)))

(defn main []
  (let [p (Pair.init @"Hello" @"Sup")]
    (let [a (unsafe-value (Pair.a &p))
          b (unsafe-value (Pair.b &p))
          _ (Unsafe.leak p)]

      (println* (String.concat &[a b])))))
```