### PR TITLE
Add immutable macro, update Emit to handle const

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -43,6 +43,16 @@
 (defmacro annotate [name annotation]
   (list 'meta-set! name "annotations" (annotate-helper name annotation)))
 
+(doc immutable
+  "Annotate a binding as immutable. Emits the correpsonding c code for the
+  binding qualified with `const`.
+
+   Carp itself performs no checks against such bindings, rebinding a value
+   annotated as immutable is valid in Carp, but it will result in invalid
+   reassignment in the emitted C, which won't compile.")
+(defmacro immutable [name]
+  (list 'meta-set! name "annotations" (annotate-helper name "const")))
+
 (defmodule Dynamic
   (defndynamic caar [pair] (car (car pair)))
   (defndynamic cadr [pair] (car (cdr pair)))


### PR DESCRIPTION
Generally speaking, this change enables the annotate macro for Def
forms.

This commit adds a new macro that's short hand for a "const" annotation
in C. This effectively marks a variable as immutable (subsequent set)
calls will produce invalid C. There's no checking of the immutability
within carp itself, Carp will emit the C as is, which will fail to
compile if a def declared immutable is mutated at some point in the
program.

I've also had to update Emit.hs to handle `const` defs as a special
case. Carp's current strategy is to declare the types of names before
actually initializing their values, and to assign values later in a
special init function e.g.

```c
int foo;
// ...
carp_init_globals() {
  // ...
  foo = 4;
}
```

This is problematic for const qualified types, since C will initialize
them to a default value, then consider the subsequent initialization
emitted by Carp to be an error:

```c
int const foo;
// ...
carp_init_globals() {
  // ...
  foo = 4; // ERROR!
}
```

So, we have to handle const explicitly, and change the emitters behavior
for these cases. This commit handles that, and the emitter will emit the
  following for const annotated defs:

```c
int const foo = 4;
```

At the moment, there is a duplication issue--we still emit the
assignment in the init function, and I'd welcome solutions to resolving
this. So, what we really emit for consts, as of this commit is:

```c
int const foo = 4;
// ...
carp_init_globals() {
  // ...
int const foo = 4; // OK
}
```

This emulates the desired behavior whereby subsequent `set` calls will
result in invalid c, i.e.

```
(def foo 4)

(immutable foo)

(defn main []
  (set! foo 5)
)
```

Results in:

```c
int const foo = 4;

carp_globals_init() {
  // ...
  int const foo = 4;
}

main() {
  foo = 5; // ERROR!
}
```

So, the duplication in the init function is a-ok, at least according to
my compiler. Contrarily adding the qualifier later doesn't work and has
no actual effect.

```c
int foo;

carp_init_globals() {
  // ...
int const foo = 4;
```