### PR TITLE
Guard against calling main directly

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -409,6 +409,9 @@ executeCommand ctx@(Context env _ _ _ _ _ _ _) xobj =
          reportExecutionError newCtx (show e)
          return (xobj, newCtx)
        -- special case: calling a function at the repl
+       Right (XObj (Lst (XObj (Lst (XObj (Defn _) _ _:(XObj (Sym (SymPath [] "main") _) _ _):_)) _ _:_)) _ _) -> do
+        reportExecutionError newCtx "`main` should not be called from the REPL. Use `(build)` and `(run)` instead."
+        return (xobj, newCtx)
        Right (XObj (Lst (XObj (Lst (XObj (Defn _) _ _:name:_)) _ _:args)) i _) -> do
         (nc, r) <- annotateWithinContext False newCtx (XObj (Lst (name:args)) i Nothing)
         case r of

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -409,9 +409,8 @@ executeCommand ctx@(Context env _ _ _ _ _ _ _) xobj =
          reportExecutionError newCtx (show e)
          return (xobj, newCtx)
        -- special case: calling a function at the repl
-       Right (XObj (Lst (XObj (Lst (XObj (Defn _) _ _:(XObj (Sym (SymPath [] "main") _) _ _):_)) _ _:_)) _ _) -> do
-        reportExecutionError newCtx "`main` should not be called from the REPL. Use `(build)` and `(run)` instead."
-        return (xobj, newCtx)
+       Right (XObj (Lst (XObj (Lst (XObj (Defn _) _ _:(XObj (Sym (SymPath [] "main") _) _ _):_)) _ _:_)) _ _) ->
+        executeCommand newCtx (withBuildAndRun (XObj (Lst []) (Just dummyInfo) Nothing))
        Right (XObj (Lst (XObj (Lst (XObj (Defn _) _ _:name:_)) _ _:args)) i _) -> do
         (nc, r) <- annotateWithinContext False newCtx (XObj (Lst (name:args)) i Nothing)
         case r of


### PR DESCRIPTION
This PR fixes #713 by adding a check to calling a function at the REPL: if that function is `main`, we emit an error.

Cheers