### PR TITLE
Add bit-width command

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -3,6 +3,7 @@ module Commands where
 import Control.Exception
 import Control.Monad (join, when)
 import Control.Monad.IO.Class (liftIO, MonadIO)
+import Data.Bits (finiteBitSize)
 import Data.List (elemIndex)
 import Data.Maybe (fromMaybe)
 import System.Exit (exitSuccess, exitFailure, exitWith, ExitCode(..))
@@ -808,6 +809,11 @@ commandWriteFile ctx [filename, contents] =
           return (evalError ctx ("The second argument to `write-file` must be a string, I got `" ++ pretty contents ++ "`") (info contents))
     _ ->
       return (evalError ctx ("The first argument to `write-file` must be a string, I got `" ++ pretty filename ++ "`") (info filename))
+
+commandBitWidth :: CommandCallback
+commandBitWidth ctx [] =
+  let bitSize = fromIntegral (finiteBitSize (undefined :: Int))
+  in return (ctx, Right (XObj (Num IntTy bitSize) (Just dummyInfo) (Just IntTy)))
 
 commandSaveDocsInternal :: CommandCallback
 commandSaveDocsInternal ctx [modulePath] = do

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -318,6 +318,7 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "save-docs-internal" 1 commandSaveDocsInternal
                     , addCommand "read-file" 1 commandReadFile
                     , addCommand "write-file" 2 commandWriteFile
+                    , addCommand "bit-width" 0 commandBitWidth
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))


### PR DESCRIPTION
This PR adds the command `bit-width`, which  gives you the integer/pointer width of the platform (usually 32/64 bits on modern systems).

This could be a dynamic global variable, but since we currently do not have a good mechanism for adding variables like that I added this as a command. I’d also be open to change this to a variable and build some plumbing for that.

Cheers