### PR TITLE
Proposal show unbalanced elements in the prompt

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,6 +31,7 @@ defaultProject =
           , projectDocsURL = ""
           , projectDocsGenerateIndex = True
           , projectDocsStyling = "carp_style.css"
+          , projectBalanceHints = True
           , projectPrompt = case platform of
                               MacOS -> "鲤 "
                               _     -> "> "

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -116,6 +116,9 @@ commandProjectConfig ctx [xobj@(XObj (Str key) _ _), value] = do
                                                    _ -> Left ("Project.config can't understand the value '" ++ length ++ "' for key 'file-path-print-length.")
                   "generate-only" -> do generateOnly <- unwrapBoolXObj value
                                         return (proj { projectGenerateOnly = generateOnly })
+                  "paren-balance-hints" ->
+                    do balanceHints <- unwrapBoolXObj value
+                       return (proj { projectBalanceHints = balanceHints })
                   _ -> Left ("Project.config can't understand the key '" ++ key ++ "' at " ++ prettyInfoFromXObj xobj ++ ".")
   case newProj of
     Left errorMessage -> presentError ("[CONFIG ERROR] " ++ errorMessage) (ctx, dynamicNil)
@@ -149,7 +152,8 @@ commandProjectGetConfig ctx [xobj@(XObj (Str key) _ _)] = do
           "docs-generate-index" -> Right $ Bol $ projectDocsGenerateIndex proj
           "docs-styling" -> Right $ Str $ projectDocsStyling proj
           "file-path-print-length" -> Right $ Str $ show (projectFilePathPrintLength proj)
-          "generate-only" -> Right $ Str $ show (projectGenerateOnly proj)
+          "generate-only" -> Right $ Bol $ projectGenerateOnly proj
+          "paren-balance-hints" -> Right $ Bol $ projectBalanceHints proj
           _ -> Left key
 commandProjectGetConfig ctx [faultyKey] =
   presentError ("First argument to 'Project.config' must be a string: " ++ pretty faultyKey) (ctx, dynamicNil)

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -625,6 +625,7 @@ data Project = Project { projectTitle :: String
                        , projectCanExecute :: Bool
                        , projectFilePathPrintLength :: FilePathPrintLength
                        , projectGenerateOnly :: Bool
+                       , projectBalanceHints :: Bool
                        }
 
 projectFlags :: Project -> String
@@ -657,6 +658,7 @@ instance Show Project where
         canExecute
         filePathPrintLength
         generateOnly
+        balanceHints
        ) =
     unlines [ "Title: " ++ title
             , "Compiler: " ++ compiler
@@ -683,6 +685,7 @@ instance Show Project where
             , "Print AST (with 'info' command): " ++ showB printTypedAST
             , "File path print length (when using --check): " ++ show filePathPrintLength
             , "Generate Only: " ++ showB generateOnly
+            , "Balance Hints: " ++ showB balanceHints
             ]
     where showB b = if b then "true" else "false"
 

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -414,16 +414,16 @@ parse text fileName = let initState = ParseState (Info 1 1 fileName (Set.fromLis
 
 {-# ANN balance "HLint: ignore Use String" #-}
 -- | For detecting the parenthesis balance in a string, i.e. "((( ))" = 1
-balance :: String -> Int
+balance :: String -> String
 balance text =
   case Parsec.runParser parenSyntax [] "(parens)" text of
     Left err -> error (show err)
     Right ok -> ok
 
   where
-        parenSyntax :: Parsec.Parsec String [Char] Int
+        parenSyntax :: Parsec.Parsec String [Char] String
         parenSyntax = do _ <- Parsec.many character
-                         length <$> Parsec.getState
+                         reverse <$> Parsec.getState
 
         character :: Parsec.Parsec String [Char] ()
         character = do c <- Parsec.anyChar

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -135,16 +135,16 @@ repl readSoFar prompt =
           liftIO exitSuccess
           return ()
         Just i -> do
-          let concat = readSoFar ++ i ++ "\n"
-              balanced = balance concat
+          let concatenated = readSoFar ++ i ++ "\n"
+              balanced = balance concatenated
               proj = contextProj context
           case balanced of
             "" -> do
-              let input' = if concat == "\n" then contextLastInput context else concat -- Entering an empty string repeats last input
+              let input' = if concatenated == "\n" then contextLastInput context else concatenated -- Entering an empty string repeats last input
               context' <- liftIO $ executeString True True (resetAlreadyLoadedFiles context) (treatSpecialInput input') "REPL"
               put context'
               repl "" (projectPrompt proj)
-            _ -> repl concat (if projectBalanceHints proj then balanced else "")
+            _ -> repl concatenated (if projectBalanceHints proj then balanced else "")
 
 resetAlreadyLoadedFiles context =
   let proj = contextProj context

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -32,8 +32,8 @@ instance MonadState s m => MonadState s (InputT m) where
     state = lift . state
 
 completeKeywordsAnd :: Context -> String -> [Completion]
-completeKeywordsAnd context word = do
-  findKeywords word ((bindingNames $ contextGlobalEnv context) ++ keywords) []
+completeKeywordsAnd context word =
+  findKeywords word (bindingNames (contextGlobalEnv context) ++ keywords) []
   where
         findKeywords match [] res = res
         findKeywords match (x : xs) res =
@@ -137,13 +137,14 @@ repl readSoFar prompt =
         Just i -> do
           let concat = readSoFar ++ i ++ "\n"
               balanced = balance concat
+              proj = contextProj context
           case balanced of
             "" -> do
               let input' = if concat == "\n" then contextLastInput context else concat -- Entering an empty string repeats last input
               context' <- liftIO $ executeString True True (resetAlreadyLoadedFiles context) (treatSpecialInput input') "REPL"
               put context'
-              repl "" (projectPrompt (contextProj context))
-            _ -> repl concat balanced
+              repl "" (projectPrompt proj)
+            _ -> repl concat (if projectBalanceHints proj then balanced else "")
 
 resetAlreadyLoadedFiles context =
   let proj = contextProj context


### PR DESCRIPTION
This PR is an effort to clearer communicate what needs to be closed in multiline input (which led to e.g. #729 being opened).

We already match unclosed brackets, parens, and quotes. All we need to do is display them. A simple way to do that would be something like what I added:

<img width="387" alt="new prompt" src="https://user-images.githubusercontent.com/7725188/80344394-ce28a280-8867-11ea-9d4c-785cd210e17f.png">

What do y’all think? (Pinging especially @sdilts, since he got confused by this)

Cheers