### PR TITLE
Extend inner environments with lhs case bindings

### DIFF
--- a/src/Qualify.hs
+++ b/src/Qualify.hs
@@ -96,8 +96,6 @@ setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst (matchExpr@(XObj Match
        in  XObj (Lst (matchExpr : newExpr : concat newCasesXObjs)) i t
   else XObj (Lst (matchExpr : expr : casesXObjs)) i t -- Leave it untouched for the compiler to find the error.
 
-
-
 setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst [XObj With _ _, XObj (Sym path _) _ _, expression]) _ _) =
   let useThese = envUseModules env
       env' = if path `elem` useThese then env else env { envUseModules = path : useThese }

--- a/test/sumtypes.carp
+++ b/test/sumtypes.carp
@@ -1,0 +1,34 @@
+;; Generic tests on sumtypes.
+
+(load "Test.carp")
+(use Test)
+
+(deftype A (F [(Fn [] Int)]))
+(deftype (Nest a) (Nested [a]))
+
+(def nest (Nest.Nested (Nest.Nested (Nest.Nested 123))))
+
+(defn one-two-three [] 123)
+
+(defn m [a]
+  (match a
+    (A.F f) (f)))
+
+(deftest test 
+  (assert-equal test
+    123
+    (m (A.F one-two-three))
+    "match adds lhs bindings to inner environments")
+  (assert-equal test
+    "matched!"    
+    (match nest 
+          (Nest.Nested (Nest.Nested (Nest.Nested _)))
+          "matched!")
+    "Match matches nested sumtype constructors with underscores")
+  (assert-equal test
+    123    
+    (match nest 
+          (Nest.Nested (Nest.Nested (Nest.Nested x)))
+          x)
+    "Match matches nested sumtype constructors with variables")
+)

--- a/test/sumtypes.carp
+++ b/test/sumtypes.carp
@@ -4,7 +4,7 @@
 (use Test)
 
 (deftype A (F [(Fn [] Int)]))
-(deftype (Nest a) (Nested [a]))
+(deftype (Nest a) (Nested [a]) (End []))
 
 (def nest (Nest.Nested (Nest.Nested (Nest.Nested 123))))
 
@@ -21,7 +21,11 @@
     "match adds lhs bindings to inner environments")
   (assert-equal test
     "matched!"    
-    (match nest 
+    (match nest
+          (Nest.Nested (Nest.End))
+          "wrong!"
+          (Nest.Nested (Nest.Nested (Nest.End)))
+          "Also wrong!"
           (Nest.Nested (Nest.Nested (Nest.Nested _)))
           "matched!")
     "Match matches nested sumtype constructors with underscores")


### PR DESCRIPTION
Previously, we'd stopped doing this, but it leads to issues with matches
on functions, e.g.

```
(deftype A (F [(Fn [] Int)]))

(defn m [a]
  (match a
    (A.F f) (f)))

(defn main []
  (println* (m (A.F (fn [] 123)))))
```

Will result in a runtime error if the environment isn't extended.

Fixes #731