### PR TITLE
Adds functions to operate on StaticArray

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -106,7 +106,7 @@ Returns `Nothing` if the array is empty.")
               (break))))
         eq)))
 
-    (doc maximum "gets the maximum in an array (elements must support `<`) and wraps it in a `Just`.
+  (doc maximum "gets the maximum in an array (elements must support `<`) and wraps it in a `Just`.
 
 If the array is empty, it returns `Nothing`.")
   (defn maximum [xs]
@@ -127,7 +127,7 @@ If the array is empty, returns `Nothing`")
     (if (empty? xs)
       (Maybe.Nothing)
       (let-do [result (unsafe-nth xs 0)
-             n (length xs)]
+               n (length xs)]
         (for [i 1 n]
           (let [x (unsafe-nth xs i)]
             (when (> result x)
@@ -323,9 +323,9 @@ The trailing elements of the longer array will be discarded.")
 
 If the `index` is out of bounds, return `Maybe.Nothing`")
   (defn nth [xs index]
-  (if (and (>= index 0) (< index (length xs)))
-    (Maybe.Just @(unsafe-nth xs index)) ; the copy will go away with lifetimes
-    (Maybe.Nothing)))
+    (if (and (>= index 0) (< index (length xs)))
+       (Maybe.Just @(unsafe-nth xs index)) ; the copy will go away with lifetimes
+       (Maybe.Nothing)))
 
   (doc remove "removes all occurrences of the element `el` in the array `arr`, in place.")
   (defn remove [el arr]
@@ -341,7 +341,7 @@ If the `index` is out of bounds, return `Maybe.Nothing`")
         (aset! &arr j @(unsafe-nth &arr (inc j))))
       (pop-back arr)))
 
-   (doc copy-filter "filters the elements in an array.
+  (doc copy-filter "filters the elements in an array.
 
 It will create a copy. If you want to avoid that, consider using [`endo-filter`](#endo-filter) instead.")
   (defn copy-filter [f a] (endo-filter f @a))
@@ -389,5 +389,5 @@ It will create a copy. If you want to avoid that, consider using [`endo-filter`]
               (set! y (Array.length arr)))
             (set! a (push-back a (Array.slice arr x y)))
             (set! x y)))
-        a))
-)
+        a)))
+

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -389,5 +389,12 @@ It will create a copy. If you want to avoid that, consider using [`endo-filter`]
               (set! y (Array.length arr)))
             (set! a (push-back a (Array.slice arr x y)))
             (set! x y)))
-        a)))
+        a))
+
+  (doc from-static "Turns a `StaticArray` into an `Array`. Copies elements.")
+  (defn from-static [sarr]
+    (let-do [darr (allocate (StaticArray.length sarr))]
+      (for [i 0 (StaticArray.length sarr)]
+        (aset-uninitialized! &darr i @(StaticArray.unsafe-nth sarr i)))
+      darr)))
 

--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -195,4 +195,22 @@ If the array is empty, returns `Nothing`")
     (let-do [x @(unsafe-nth a i)
              y @(unsafe-nth a j)]
       (aset! a i y)
-      (aset! a j x))))
+      (aset! a j x)))
+
+  (doc nth "gets a reference to the `n`th element from an array `arr` wrapped on a `Maybe`.
+
+  If the `index` is out of bounds, return `Maybe.Nothing`")
+  (defn nth [xs index]
+   (if (and (>= index 0) (< index (length xs)))
+     (Maybe.Just @(unsafe-nth xs index)) ; the copy will go away with lifetimes
+     (Maybe.Nothing)))
+
+  (doc contains? "checks wether an element exists in the array.")
+  (defn contains? [arr el]
+    (let-do [result false]
+      (for [i 0 (length arr)]
+        (when (= el (unsafe-nth arr i))
+          (do
+            (set! result true)
+            (break))))
+      result)))

--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -1,5 +1,7 @@
 (defmodule StaticArray
 
+  ;; NOTE: Following function declarations are copy of the ones in Array
+  ;; could we share inmplementation between Array and StaticArray?
   (defndynamic foreach-internal [var xs expr]
     (let [xsym (gensym-with 'xs)
           len (gensym-with 'len)
@@ -10,7 +12,6 @@
                   (list 'let [var (list 'StaticArray.unsafe-nth xsym i)]
                         expr)))))
 
-  ;; NOTE: Exact copy of the Array.foreach macro, could be made "generic" by removing the module prefixes.
   (defmacro foreach [binding expr]
     (StaticArray.foreach-internal (car binding) (cadr binding) expr))
 
@@ -19,7 +20,6 @@
     (for [i 0 (StaticArray.length xs)]
       (StaticArray.aset! xs i (~f (StaticArray.unsafe-nth xs i)))))
 
-  ;; NOTE: Exact copy of the Array.reduce function.
   (defn reduce [f x xs]
     (let [total x]
       (do
@@ -39,4 +39,26 @@
               (break))))
         eq)))
 
-  )
+  (doc empty? "checks whether the array `a` is empty.")
+  (defn empty? [a]
+    (= (StaticArray.length a) 0))
+
+  (doc any? "checks whether any of the elements in `a` match the function `f`.")
+  (defn any? [f a]
+    (let-do [res false]
+      (for [i 0 (length a)]
+        (when (~f (unsafe-nth a i))
+          (do
+            (set! res true)
+            (break))))
+      res))
+
+  (doc all? "checks whether all of the elements in `a` match the function `f`.")
+  (defn all? [f a]
+    (let-do [res true]
+      (for [i 0 (length a)]
+        (when (not (~f (unsafe-nth a i)))
+          (do
+            (set! res false)
+            (break))))
+      res)))

--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -1,5 +1,21 @@
 (defmodule StaticArray
 
+  (doc map! "Maps a function over the static array `xs`, mutating it in place. The difference to Array.endo-map (which does the same thing internally) is that this function takes a ref (since you can never have static arrays as values) and that it returns ().")
+  (defn map! [xs f]
+    (for [i 0 (StaticArray.length xs)]
+      (StaticArray.aset! xs i (~f (StaticArray.unsafe-nth xs i)))))
+
+  (doc reverse! "Reverse array in place.")
+  (defn reverse! [a]
+    (let-do [i 0
+             j (Int.dec (length a))]
+      (while (Int.< i j)
+        (let-do [tmp @(unsafe-nth a i)]
+          (aset! a i @(unsafe-nth a j))
+          (set! i (Int.inc i))
+          (aset! a j tmp)
+          (set! j (Int.dec j))))))
+
   ;; NOTE: Following function declarations are copy of the ones in Array
   ;; could we share inmplementation between Array and StaticArray?
   (defndynamic foreach-internal [var xs expr]
@@ -14,11 +30,6 @@
 
   (defmacro foreach [binding expr]
     (StaticArray.foreach-internal (car binding) (cadr binding) expr))
-
-  (doc map! "Maps a function over the static array `xs`, mutating it in place. The difference to Array.endo-map (which does the same thing internally) is that this function takes a ref (since you can never have static arrays as values) and that it returns ().")
-  (defn map! [xs f]
-    (for [i 0 (StaticArray.length xs)]
-      (StaticArray.aset! xs i (~f (StaticArray.unsafe-nth xs i)))))
 
   (defn reduce [f x xs]
     (let [total x]

--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -61,4 +61,28 @@
           (do
             (set! res false)
             (break))))
-      res)))
+      res))
+
+  (doc find "finds an element in `a` that matches the function `f` and wraps it in a `Just`.
+
+If it doesn’t find an element, `Nothing` will be returned.")
+  (defn find [f a]
+    (let-do [res (Maybe.Nothing)]
+      (for [i 0 (length a)]
+        (when (~f (unsafe-nth a i))
+          (do
+            (set! res (Maybe.Just @(unsafe-nth a i)))
+            (break))))
+      res))
+
+  (doc find-index "finds the index of the first element in `a` that matches the function `f` and wraps it in a `Just`.
+
+If it doesn’t find an index, `Nothing` will be returned.")
+  (defn find-index [f a]
+    (let-do [ret (Maybe.Nothing)]
+      (for [i 0 (length a)]
+        (when (~f (unsafe-nth a i))
+          (do
+            (set! ret (Maybe.Just i))
+            (break))))
+      ret)))

--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -153,4 +153,46 @@ If the array is empty, returns `Nothing`")
           (let [x (unsafe-nth xs i)]
             (when (> result x)
               (set! result x))))
-        (Maybe.Just @result)))))
+        (Maybe.Just @result))))
+
+  (doc sum "sums an array (elements must support `+` and `zero`).")
+  (defn sum [xs]
+    (reduce &(fn [x y] (+ x @y)) (zero) xs))
+
+  (doc index-of "gets the index of element `e` in an array and wraps it on a `Just`.
+
+  If the element is not found, returns `Nothing`")
+  (defn index-of [a e]
+    (let-do [idx (Maybe.Nothing)]
+      (for [i 0 (length a)]
+        (when (= (unsafe-nth a i) e)
+          (do
+            (set! idx (Maybe.Just i))
+            (break))))
+      idx))
+
+  (doc element-count "counts the occurrences of element `e` in an array.")
+  (defn element-count [a e]
+    (let-do [c 0]
+      (for [i 0 (length a)]
+        (when (= e (unsafe-nth a i)) (set! c (Int.inc c))))
+      c))
+
+  (doc predicate-count "counts the number of elements satisfying the predicate function `pred` in an array.")
+  (defn predicate-count [a pred]
+    (let-do [c 0]
+      (for [i 0 (length a)]
+        (when (~pred (unsafe-nth a i))
+          (set! c (Int.inc c))))
+      c))
+
+  (doc aupdate! "transmutes (i.e. updates) the element at index `i` of an array `a` using the function `f` in place.")
+  (defn aupdate! [a i f]
+    (aset! a i (~f (unsafe-nth a i))))
+
+  (doc swap! "swaps the indices `i` and `j` of an array `a` in place.")
+  (defn swap! [a i j]
+    (let-do [x @(unsafe-nth a i)
+             y @(unsafe-nth a j)]
+      (aset! a i y)
+      (aset! a j x))))

--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -114,4 +114,32 @@ Returns `Nothing` if the array is empty.")
   (defn last [a]
     (if (empty? a)
       (Maybe.Nothing)
-      (Maybe.Just @(unsafe-nth a (Int.dec (length a)))))))
+      (Maybe.Just @(unsafe-nth a (Int.dec (length a))))))
+
+  (doc maximum "gets the maximum in an array (elements must support `<`) and wraps it in a `Just`.
+
+If the array is empty, it returns `Nothing`.")
+  (defn maximum [xs]
+    (if (empty? xs)
+      (Maybe.Nothing)
+      (let-do [result (unsafe-nth xs 0)
+               n (length xs)]
+        (for [i 1 n]
+          (let [x (unsafe-nth xs i)]
+            (when (< result x)
+              (set! result x))))
+        (Maybe.Just @result))))
+
+  (doc minimum "gets the minimum in an array (elements must support `>`) and wraps it in a `Just`.
+
+If the array is empty, returns `Nothing`")
+  (defn minimum [xs]
+    (if (empty? xs)
+      (Maybe.Nothing)
+      (let-do [result (unsafe-nth xs 0)
+               n (length xs)]
+        (for [i 1 n]
+          (let [x (unsafe-nth xs i)]
+            (when (> result x)
+              (set! result x))))
+        (Maybe.Just @result)))))

--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -85,4 +85,33 @@ If it doesn’t find an index, `Nothing` will be returned.")
           (do
             (set! ret (Maybe.Just i))
             (break))))
-      ret)))
+      ret))
+
+  (doc unsafe-first "takes the first element of an array.
+
+Generates a runtime error if the array is empty.")
+  (defn unsafe-first [a]
+    @(unsafe-nth a 0))
+
+  (doc first "takes the first element of an array and returns a `Just`.
+
+Returns `Nothing` if the array is empty.")
+  (defn first [a]
+    (if (empty? a)
+      (Maybe.Nothing)
+      (Maybe.Just @(unsafe-nth a 0))))
+
+  (doc unsafe-last "takes the last element of an array.
+
+Generates a runtime error if the array is empty.")
+  (defn unsafe-last [a]
+    @(unsafe-nth a (Int.dec (length a))))
+
+
+  (doc last "takes the last element of an array and returns a `Just`.
+
+Returns `Nothing` if the array is empty.")
+  (defn last [a]
+    (if (empty? a)
+      (Maybe.Nothing)
+      (Maybe.Just @(unsafe-nth a (Int.dec (length a)))))))

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -622,6 +622,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#from-static">
+                    <h3 id="from-static">
+                        from-static
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] (Array a))
+                </p>
+                <pre class="args">
+                    (from-static sarr)
+                </pre>
+                <p class="doc">
+                    <p>Turns a StaticArray into an Array. Copies elements.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#index-of">
                     <h3 id="index-of">
                         index-of

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -277,6 +277,48 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#find">
+                    <h3 id="find">
+                        find
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] (Maybe a))
+                </p>
+                <pre class="args">
+                    (find f a)
+                </pre>
+                <p class="doc">
+                    <p>finds an element in <code>a</code> that matches the function <code>f</code> and wraps it in a <code>Just</code>.</p>
+<p>If it doesn’t find an element, <code>Nothing</code> will be returned.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#find-index">
+                    <h3 id="find-index">
+                        find-index
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] (Maybe Int))
+                </p>
+                <pre class="args">
+                    (find-index f a)
+                </pre>
+                <p class="doc">
+                    <p>finds the index of the first element in <code>a</code> that matches the function <code>f</code> and wraps it in a <code>Just</code>.</p>
+<p>If it doesn’t find an index, <code>Nothing</code> will be returned.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#foreach">
                     <h3 id="foreach">
                         foreach

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -500,6 +500,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#reverse!">
+                    <h3 id="reverse!">
+                        reverse!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] ())
+                </p>
+                <pre class="args">
+                    (reverse! a)
+                </pre>
+                <p class="doc">
+                    <p>Reverse array in place.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#str">
                     <h3 id="str">
                         str

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -439,6 +439,48 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#maximum">
+                    <h3 id="maximum">
+                        maximum
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                </p>
+                <pre class="args">
+                    (maximum xs)
+                </pre>
+                <p class="doc">
+                    <p>gets the maximum in an array (elements must support <code>&lt;</code>) and wraps it in a <code>Just</code>.</p>
+<p>If the array is empty, it returns <code>Nothing</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#minimum">
+                    <h3 id="minimum">
+                        minimum
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                </p>
+                <pre class="args">
+                    (minimum xs)
+                </pre>
+                <p class="doc">
+                    <p>gets the minimum in an array (elements must support <code>&gt;</code>) and wraps it in a <code>Just</code>.</p>
+<p>If the array is empty, returns <code>Nothing</code></p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#reduce">
                     <h3 id="reduce">
                         reduce

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -237,6 +237,46 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#aupdate!">
+                    <h3 id="aupdate!">
+                        aupdate!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b), Int, (Ref (λ [(Ref a b)] a c) d)] ())
+                </p>
+                <pre class="args">
+                    (aupdate! a i f)
+                </pre>
+                <p class="doc">
+                    <p>transmutes (i.e. updates) the element at index <code>i</code> of an array <code>a</code> using the function <code>f</code> in place.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#contains?">
+                    <h3 id="contains?">
+                        contains?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b), (Ref a b)] Bool)
+                </p>
+                <pre class="args">
+                    (contains? arr el)
+                </pre>
+                <p class="doc">
+                    <p>checks wether an element exists in the array.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#delete">
                     <h3 id="delete">
                         delete
@@ -253,6 +293,26 @@
                 </span>
                 <p class="doc">
                     <p>deletes a static array. This function should not be called manually (there shouldn't be a way to create value types of type StaticArray).</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#element-count">
+                    <h3 id="element-count">
+                        element-count
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b), (Ref a b)] Int)
+                </p>
+                <pre class="args">
+                    (element-count a e)
+                </pre>
+                <p class="doc">
+                    <p>counts the occurrences of element <code>e</code> in an array.</p>
 
                 </p>
             </div>
@@ -378,6 +438,27 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#index-of">
+                    <h3 id="index-of">
+                        index-of
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b), (Ref a b)] (Maybe Int))
+                </p>
+                <pre class="args">
+                    (index-of a e)
+                </pre>
+                <p class="doc">
+                    <p>gets the index of element <code>e</code> in an array and wraps it on a <code>Just</code>.</p>
+<p>If the element is not found, returns <code>Nothing</code></p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#last">
                     <h3 id="last">
                         last
@@ -481,6 +562,47 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#nth">
+                    <h3 id="nth">
+                        nth
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b), Int] (Maybe a))
+                </p>
+                <pre class="args">
+                    (nth xs index)
+                </pre>
+                <p class="doc">
+                    <p>gets a reference to the <code>n</code>th element from an array <code>arr</code> wrapped on a <code>Maybe</code>.</p>
+<p>If the <code>index</code> is out of bounds, return <code>Maybe.Nothing</code></p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#predicate-count">
+                    <h3 id="predicate-count">
+                        predicate-count
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b), (Ref (λ [(Ref a b)] Bool c) d)] Int)
+                </p>
+                <pre class="args">
+                    (predicate-count a pred)
+                </pre>
+                <p class="doc">
+                    <p>counts the number of elements satisfying the predicate function <code>pred</code> in an array.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#reduce">
                     <h3 id="reduce">
                         reduce
@@ -536,6 +658,46 @@
                 </span>
                 <p class="doc">
                     <p>converts a static array to a string.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#sum">
+                    <h3 id="sum">
+                        sum
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] a)
+                </p>
+                <pre class="args">
+                    (sum xs)
+                </pre>
+                <p class="doc">
+                    <p>sums an array (elements must support <code>+</code> and <code>zero</code>).</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#swap!">
+                    <h3 id="swap!">
+                        swap!
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b), Int, Int] ())
+                </p>
+                <pre class="args">
+                    (swap! a i j)
+                </pre>
+                <p class="doc">
+                    <p>swaps the indices <code>i</code> and <code>j</code> of an array <code>a</code> in place.</p>
 
                 </p>
             </div>

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -177,6 +177,46 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#all?">
+                    <h3 id="all?">
+                        all?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] Bool)
+                </p>
+                <pre class="args">
+                    (all? f a)
+                </pre>
+                <p class="doc">
+                    <p>checks whether all of the elements in <code>a</code> match the function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#any?">
+                    <h3 id="any?">
+                        any?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] Bool)
+                </p>
+                <pre class="args">
+                    (any? f a)
+                </pre>
+                <p class="doc">
+                    <p>checks whether any of the elements in <code>a</code> match the function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#aset!">
                     <h3 id="aset!">
                         aset!
@@ -213,6 +253,26 @@
                 </span>
                 <p class="doc">
                     <p>deletes a static array. This function should not be called manually (there shouldn't be a way to create value types of type StaticArray).</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#empty?">
+                    <h3 id="empty?">
+                        empty?
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] Bool)
+                </p>
+                <pre class="args">
+                    (empty? a)
+                </pre>
+                <p class="doc">
+                    <p>checks whether the array <code>a</code> is empty.</p>
 
                 </p>
             </div>

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -319,6 +319,27 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#first">
+                    <h3 id="first">
+                        first
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                </p>
+                <pre class="args">
+                    (first a)
+                </pre>
+                <p class="doc">
+                    <p>takes the first element of an array and returns a <code>Just</code>.</p>
+<p>Returns <code>Nothing</code> if the array is empty.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#foreach">
                     <h3 id="foreach">
                         foreach
@@ -354,6 +375,27 @@
                 </pre>
                 <p class="doc">
                     
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#last">
+                    <h3 id="last">
+                        last
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                </p>
+                <pre class="args">
+                    (last a)
+                </pre>
+                <p class="doc">
+                    <p>takes the last element of an array and returns a <code>Just</code>.</p>
+<p>Returns <code>Nothing</code> if the array is empty.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -432,6 +474,48 @@
                 </span>
                 <p class="doc">
                     <p>converts a static array to a string.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#unsafe-first">
+                    <h3 id="unsafe-first">
+                        unsafe-first
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] a)
+                </p>
+                <pre class="args">
+                    (unsafe-first a)
+                </pre>
+                <p class="doc">
+                    <p>takes the first element of an array.</p>
+<p>Generates a runtime error if the array is empty.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#unsafe-last">
+                    <h3 id="unsafe-last">
+                        unsafe-last
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (λ [(Ref (StaticArray a) b)] a)
+                </p>
+                <pre class="args">
+                    (unsafe-last a)
+                </pre>
+                <p class="doc">
+                    <p>takes the last element of an array.</p>
+<p>Generates a runtime error if the array is empty.</p>
 
                 </p>
             </div>

--- a/test/array.carp
+++ b/test/array.carp
@@ -306,4 +306,8 @@
                 &[1.0 1.5 2.0 2.5]
                 &(unreduce 1.0 &(fn [x] (< x 3.0)) &(fn [x] (+ x 0.5)))
                 "unreduce works")
-)
+  (assert-equal test
+                &[1 2 3]
+                &(from-static $[1 2 3])
+                "from-static works"))
+

--- a/test/array.carp
+++ b/test/array.carp
@@ -322,6 +322,12 @@
                 &[1.0 1.5 2.0 2.5]
                 &(unreduce 1.0 &(fn [x] (< x 3.0)) &(fn [x] (+ x 0.5)))
                 "unreduce works")
+  (assert-true test
+                (contains? &[0 1 2] &1)
+                "contains? works as expected I")
+  (assert-false test
+                (contains? &[0 1 2] &100)
+                "contains? works as expected II")
   (assert-equal test
                 &[1 2 3]
                 &(from-static $[1 2 3])

--- a/test/array.carp
+++ b/test/array.carp
@@ -164,9 +164,21 @@
                 &(swap [2 1] 0 1)
                 "swap works as expected")
   (assert-equal test
+                &[2 1]
+                &(let-do [arr [1 2]]
+                   (Array.swap! &arr 0 1)
+                   arr)
+                "swap! works as expected")
+  (assert-equal test
                 &[1 3]
                 &(aupdate [1 2] 1 &inc-ref)
                 "aupdate works as expected")
+  (assert-equal test
+                &[1 3]
+                &(let-do [arr [1 2]]
+                   (aupdate! &arr 1 &inc-ref)
+                   arr)
+                "aupdate! works as expected")
   (assert-equal test
                 &[1 2 3 4 5 6 7 8]
                 &(concat &[[1] [2 3] [4 5 6] [7 8]])
@@ -278,6 +290,10 @@
                 &(Maybe.Just 1)
                 &(find-index &(fn [i] (Int.even? @i)) &[1 8 5])
                 "find-index works II")
+  (assert-equal test
+                2
+                (element-count &[1 4 3 4] &4)
+                "element-count works as expected")
   (assert-equal test
                 2
                 (predicate-count &[1 8 5 10 3] &(fn [i] (Int.even? @i)))

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -47,5 +47,34 @@
                     arr
                     &(fn [val] (* @val 2)))
                   arr)
-                "map! works as expected"))
+                "map! works as expected")
 
+  (assert-equal test
+                true
+                (empty? (the (Ref (StaticArray Int)) $[]))
+                "empty? works as expected I")
+
+  (assert-equal test
+                false
+                (empty? $[1])
+                "empty? works as expected II")
+
+  (assert-equal test
+                true
+                (any? &(fn [x] (= 0 @x)) $[0 1 2 3])
+                "any? works as expected I")
+
+  (assert-equal test
+                false
+                (any? &(fn [x] (= 0 @x)) $[1 2 3 4])
+                "any? works as expected II")
+
+  (assert-equal test
+                true
+                (all? &(fn [x] (< 0 @x)) $[1 2 3])
+                "all? works as expected I")
+
+  (assert-equal test
+                false
+                (all? &(fn [x] (< 0 @x)) $[0 1 2])
+                "all? works as expected II"))

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -2,6 +2,8 @@
 (use Test)
 (use StaticArray)
 
+(defn inc-ref [x] (+ @x 1))
+
 (deftest test
 
   (assert-equal test
@@ -154,5 +156,43 @@
   (assert-equal test
                 &(Maybe.Just (Pair.init 1 3))
                 &(minimum $[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
-                "minimum works on pairs"))
+                "minimum works on pairs")
 
+  (assert-equal test
+                55
+                (sum $[1 2 3 4 5 6 7 8 9 10])
+                "sum works as expected")
+
+  (assert-equal test
+                &(Maybe.Just 3)
+                &(index-of $[1 2 3 4] &4)
+                "index-of works as expected when element is in the array")
+
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(index-of $[1 2 3 4] &7)
+                "index-of works as expected when element is not in the array")
+
+  (assert-equal test
+                2
+                (element-count $[1 4 3 4] &4)
+                "element-count works as expected")
+
+  (assert-equal test
+                2
+                (predicate-count $[1 8 5 10 3] &(fn [i] (Int.even? @i)))
+                "predicate-count works")
+
+  (assert-equal test
+                $[1 3]
+                (let-do [arr $[1 2]]
+                  (aupdate! arr 1 &inc-ref)
+                  arr)
+                "aupdate! works as expected")
+
+  (assert-equal test
+                $[2 1]
+                (let-do [arr $[1 2]]
+                  (StaticArray.swap! arr 0 1)
+                  arr)
+                "swap! works as expected"))

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -1,7 +1,6 @@
-(use StaticArray)
-
 (load "Test.carp")
 (use Test)
+(use StaticArray)
 
 (deftest test
 
@@ -32,4 +31,21 @@
   ;;                 &@(unsafe-nth nested 1))
   ;;               "unsafe-nth works as expected")
 
-  )
+  (assert-equal test
+                10
+                (let [arr $[2 2 2 2]]
+                  (reduce
+                    &(fn [acc val] (+ acc @val))
+                    2
+                    arr))
+                "reduce works as expected")
+
+  (assert-equal test
+                $[2 4 8]
+                (let-do [arr $[1 2 4]]
+                  (map!
+                    arr
+                    &(fn [val] (* @val 2)))
+                  arr)
+                "map! works as expected"))
+

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -97,4 +97,35 @@
   (assert-equal test
                 &(Maybe.Just 1)
                 &(find-index &(fn [i] (Int.even? @i)) $[1 8 5])
-                "find-index works II"))
+                "find-index works II")
+
+  (assert-equal test
+                1
+                (unsafe-first $[1 2 3])
+                "unsafe-first works as expected")
+
+  (assert-equal test
+                &(Maybe.Just 1)
+                &(first $[1 2 3])
+                "first works as expected")
+
+  (assert-equal test
+                &(the (Maybe Int) (Maybe.Nothing))
+                &(first $[])
+                "first works as expected on empty array")
+
+  (assert-equal test
+                \c
+                (unsafe-last $[\a \b \c])
+                "unsafe-last works as expected")
+
+  (assert-equal test
+                &(Maybe.Just \c)
+                &(last $[\a \b \c])
+                "last works as expected")
+
+  (assert-equal test
+                &(the (Maybe Char) (Maybe.Nothing))
+                &(last $[])
+                "last works as expected on empty array"))
+

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -6,21 +6,21 @@
 
 (deftest test
 
-  (assert-equal test
-                $[2 4 8]
-                (let-do [arr $[1 2 4]]
-                  (map!
-                    arr
-                    &(fn [val] (* @val 2)))
-                  arr)
-                "map! works as expected")
+  (let [arr $[1 2 4]]
+    (assert-equal test
+                  $[2 4 8]
+                  (do
+                    (map! arr &(fn [val] (* @val 2)))
+                    arr)
+                  "map! works as expected"))
 
-  (assert-equal test
-                $[3 2 1]
-                (let-do [arr $[1 2 3]]
-                  (reverse! arr)
-                  arr)
-                "reverse! works as expected")
+  (let [arr $[1 2 3]]
+    (assert-equal test
+                  $[3 2 1]
+                  (do
+                    (reverse! arr)
+                    arr)
+                  "reverse! works as expected"))
 
   (assert-true test
                (= $[1 2 3] $[1 2 3])
@@ -40,14 +40,13 @@
                   @(unsafe-nth a 5))
                 "unsafe-nth works as expected")
 
-  ;; TODO: FIX! THIS ONE IS PROBLEMATIC.
-  ;; (assert-equal test
-  ;;               &[4 5 6]
-  ;;               (let [nested $[[1 2 3]
-  ;;                              [4 5 6]
-  ;;                              [7 8 9]]]
-  ;;                 &@(unsafe-nth nested 1))
-  ;;               "unsafe-nth works as expected")
+  (assert-equal test
+                &[4 5 6]
+                &(let [nested $[[1 2 3]
+                                [4 5 6]
+                                [7 8 9]]]
+                   @(unsafe-nth nested 1))
+                "unsafe-nth works as expected with heap allocated elements")
 
   (assert-equal test
                 10
@@ -183,19 +182,21 @@
                 (predicate-count $[1 8 5 10 3] &(fn [i] (Int.even? @i)))
                 "predicate-count works")
 
-  (assert-equal test
-                $[1 3]
-                (let-do [arr $[1 2]]
-                  (aupdate! arr 1 &inc-ref)
-                  arr)
-                "aupdate! works as expected")
+  (let [arr $[1 2]]
+    (assert-equal test
+                  $[1 3]
+                  (do
+                    (aupdate! arr 1 &inc-ref)
+                    arr)
+                  "aupdate! works as expected"))
 
-  (assert-equal test
-                $[2 1]
-                (let-do [arr $[1 2]]
-                  (StaticArray.swap! arr 0 1)
-                  arr)
-                "swap! works as expected")
+  (let [arr $[1 2]]
+    (assert-equal test
+                  $[2 1]
+                  (do
+                    (StaticArray.swap! arr 0 1)
+                    arr)
+                  "swap! works as expected"))
 
   (assert-equal test
                 &(Maybe.Nothing)

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -195,4 +195,22 @@
                 (let-do [arr $[1 2]]
                   (StaticArray.swap! arr 0 1)
                   arr)
-                "swap! works as expected"))
+                "swap! works as expected")
+
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(nth $[0 1 2] 3)
+                "nth works as expected I")
+
+  (assert-equal test
+                &(Maybe.Just 0)
+                &(nth $[0 1 2] 0)
+                "nth works as expected II")
+
+  (assert-true test
+                (contains? $[0 1 2] &1)
+                "contains? works as expected I")
+
+  (assert-false test
+                (contains? $[0 1 2] &100)
+                "contains? works as expected II"))

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -127,5 +127,25 @@
   (assert-equal test
                 &(the (Maybe Char) (Maybe.Nothing))
                 &(last $[])
-                "last works as expected on empty array"))
+                "last works as expected on empty array")
+
+  (assert-equal test
+                &(Maybe.Just 10)
+                &(maximum $[8 10 9])
+                "maximum works as expected")
+
+  (assert-equal test
+                &(Maybe.Just (Pair.init 2 1))
+                &(maximum $[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
+                "maximum works on pairs")
+
+  (assert-equal test
+                &(Maybe.Just 1)
+                &(minimum $[3 1 2])
+                "minimum works as expected")
+
+  (assert-equal test
+                &(Maybe.Just (Pair.init 1 3))
+                &(minimum $[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
+                "minimum works on pairs"))
 

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -77,4 +77,24 @@
   (assert-equal test
                 false
                 (all? &(fn [x] (< 0 @x)) $[0 1 2])
-                "all? works as expected II"))
+                "all? works as expected II")
+
+  (assert-equal test
+                &(Maybe.Just 3)
+                &(find &(fn [x] (= 3 @x)) $[0 1 2 3])
+                "find works as expected I")
+
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(find &(fn [x] (= 4 @x)) $[0 1 2 3])
+                "find works as expected II")
+
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(find-index &(fn [i] (Int.even? @i)) $[1 3 5])
+                "find-index works I")
+
+  (assert-equal test
+                &(Maybe.Just 1)
+                &(find-index &(fn [i] (Int.even? @i)) $[1 8 5])
+                "find-index works II"))

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -4,6 +4,22 @@
 
 (deftest test
 
+  (assert-equal test
+                $[2 4 8]
+                (let-do [arr $[1 2 4]]
+                  (map!
+                    arr
+                    &(fn [val] (* @val 2)))
+                  arr)
+                "map! works as expected")
+
+  (assert-equal test
+                $[3 2 1]
+                (let-do [arr $[1 2 3]]
+                  (reverse! arr)
+                  arr)
+                "reverse! works as expected")
+
   (assert-true test
                (= $[1 2 3] $[1 2 3])
                "= works as expected I")
@@ -39,15 +55,6 @@
                     2
                     arr))
                 "reduce works as expected")
-
-  (assert-equal test
-                $[2 4 8]
-                (let-do [arr $[1 2 4]]
-                  (map!
-                    arr
-                    &(fn [val] (* @val 2)))
-                  arr)
-                "map! works as expected")
 
   (assert-equal test
                 true


### PR DESCRIPTION
This PR tries to get StaticArray to parity with Array function wise where possible. Functions that creates a new array were skipped. Also adds test where they were missing in `test/array.carp`.

Adds these functions:
- `Array.from-static`
- `StaticArray.reverse!`

Copies the following functions from Array to ArrayStatic:
- `empty?`
- `any?`
- `all?`
- `find`
- `find-index`
- `first`
- `unsafe-first`
- `last`
- `unsafe-last`
- `minimum`
- `maximum`
- `sum`
- `index-of`
- `element-count`
- `predicate-count`
- `aupdate!`
- `swap!`
- `nth`
- `contains?`
