### PR TITLE
Make primitives proper AST objects

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -47,7 +47,7 @@
 (load "Binary.carp")
 (load "Control.carp")
 
-(if (not (dynor (= "windows" (os)) (= "mingw32" (os))))
+(if (not (dynamic-or (= "windows" (os)) (= "mingw32" (os))))
   (do
     (system-include "sys/wait.h")
     (system-include "unistd.h"))

--- a/core/Core.carp
+++ b/core/Core.carp
@@ -15,12 +15,6 @@
 (system-include "core.h")
 (system-include "carp_memory.h")
 
-(if (not (Dynamic.or (= "windows" (os)) (= "mingw32" (os))))
-  (do
-    (system-include "sys/wait.h")
-    (system-include "unistd.h"))
-  ())
-
 (load "Interfaces.carp")
 (load "Bool.carp")
 (load "Macros.carp")
@@ -52,3 +46,10 @@
 (load "Sort.carp")
 (load "Binary.carp")
 (load "Control.carp")
+
+(if (not (dynor (= "windows" (os)) (= "mingw32" (os))))
+  (do
+    (system-include "sys/wait.h")
+    (system-include "unistd.h"))
+  ())
+

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -170,7 +170,7 @@
     ;; commands expand to (command <name>), fns expand to a non-list.
     ;;
     ;; TODO: Support passing anonymous functions.
-    (if (not (dynor (list? f) (list? g)))
+    (if (not (dynamic-or (list? f) (list? g)))
         (macro-error "compose can only compose named dynamic functions. To
                      compose anonymous functions, such as curried functions,
                      see comp.")
@@ -183,10 +183,10 @@
             ;; symbols such as '(p r a c)
             (list  f-name (list 'eval (list 'apply g-name (list 'quote arguments))))))))
 
-  (defndynamic dynor [x y]
+  (defndynamic dynamic-or [x y]
     (if x true y))
 
-  (defndynamic dynand [x y]
+  (defndynamic dynamic-and [x y]
     (if x y false))
 
   (doc curry
@@ -251,7 +251,7 @@
   (defndynamic unreduce-internal [f x lim acc counter]
     ;; Currently only works with anonymous functions and named functions.
     ;; does not work with commands.
-    (if (not (dynor (array? acc) (list? acc)))
+    (if (not (dynamic-or (array? acc) (list? acc)))
       (macro-error
         "Unreduce requires a dynamic data structure to collect results, such as
          (list) or (array).")
@@ -368,7 +368,7 @@
 
   (hidden zip-internal)
   (defndynamic zip-internal [f forms acc]
-    (if (reduce dynor false (map-internal empty? forms (list)))
+    (if (reduce dynamic-or false (map-internal empty? forms (list)))
         acc
         (zip-internal
           f
@@ -533,12 +533,12 @@
     ()))
 
 (defmacro windows-only [:rest forms]
-  (if (dynor (= "windows" (os)) (= "mingw32" (os)))
+  (if (dynamic-or (= "windows" (os)) (= "mingw32" (os)))
     (eval (cons (quote do) forms))
     ()))
 
 (defmacro not-on-windows [:rest forms]
-  (if (not (dynor (= "windows" (os)) (= "mingw32" (os))))
+  (if (not (dynamic-or (= "windows" (os)) (= "mingw32" (os))))
     (eval (cons (quote do) forms))
     ()))
 

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -170,7 +170,7 @@
     ;; commands expand to (command <name>), fns expand to a non-list.
     ;;
     ;; TODO: Support passing anonymous functions.
-    (if (not (Dynamic.or (list? f) (list? g)))
+    (if (not (dynor (list? f) (list? g)))
         (macro-error "compose can only compose named dynamic functions. To
                      compose anonymous functions, such as curried functions,
                      see comp.")
@@ -183,14 +183,10 @@
             ;; symbols such as '(p r a c)
             (list  f-name (list 'eval (list 'apply g-name (list 'quote arguments))))))))
 
-  ;; Dynamic.or already exists, but since it's a special form, it can't be passed
-  ;; to higher order functions like reduce. So, we define an alternative here.
-  (defndynamic or-internal [x y]
+  (defndynamic dynor [x y]
     (if x true y))
 
-  ;; Dynamic.and already exists, but since it's a special form, it can't be passed
-  ;; to higher order functions like reduce. So, we define an alternative here.
-  (defndynamic and-internal [x y]
+  (defndynamic dynand [x y]
     (if x y false))
 
   (doc curry
@@ -255,7 +251,7 @@
   (defndynamic unreduce-internal [f x lim acc counter]
     ;; Currently only works with anonymous functions and named functions.
     ;; does not work with commands.
-    (if (not (Dynamic.or (array? acc) (list? acc)))
+    (if (not (dynor (array? acc) (list? acc)))
       (macro-error
         "Unreduce requires a dynamic data structure to collect results, such as
          (list) or (array).")
@@ -372,7 +368,7 @@
 
   (hidden zip-internal)
   (defndynamic zip-internal [f forms acc]
-    (if (reduce or-internal false (map-internal empty? forms (list)))
+    (if (reduce dynor false (map-internal empty? forms (list)))
         acc
         (zip-internal
           f
@@ -537,12 +533,12 @@
     ()))
 
 (defmacro windows-only [:rest forms]
-  (if (Dynamic.or (= "windows" (os)) (= "mingw32" (os)))
+  (if (dynor (= "windows" (os)) (= "mingw32" (os)))
     (eval (cons (quote do) forms))
     ()))
 
 (defmacro not-on-windows [:rest forms]
-  (if (not (Dynamic.or (= "windows" (os)) (= "mingw32" (os))))
+  (if (not (dynor (= "windows" (os)) (= "mingw32" (os))))
     (eval (cons (quote do) forms))
     ()))
 

--- a/docs/Macros.md
+++ b/docs/Macros.md
@@ -175,9 +175,7 @@ kinds of Carp constructs there are for the evaluator:
   as you would do in higher order functions.
 - Primitives: these are regular Carp forms that do not evaluate their
   arguments, and they resemble builtin macros implemented in Haskell. Examples
-  for this category include `defmacro`, `defn`, and `quote`. They can also not
-  be passed around by value, but this is considered a bug and should be
-  resolved.
+  for this category include `defmacro`, `defn`, and `quote`.
 - Commands: these, too, are regular Carp forms. They evaluate their arguments
   and behave like builtin functions. Examples for this category include
   `Project.config`, `car`, and `cons`.
@@ -212,6 +210,3 @@ are:
 - `let` for defining local variables,
 - `the` for type annotations,
 - `fn` for function literals.
-
-`Dynamic.or` and `Dynamic.and` are also currently special forms, but this is
-considered a bug and should be resolved.

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -367,25 +367,6 @@
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#and-internal">
-                    <h3 id="and-internal">
-                        and-internal
-                    </h3>
-                </a>
-                <div class="description">
-                    dynamic
-                </div>
-                <p class="sig">
-                    Dynamic
-                </p>
-                <pre class="args">
-                    (and-internal x y)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
                 <a class="anchor" href="#append">
                     <h3 id="append">
                         append
@@ -1149,6 +1130,25 @@ in the list as an argument to the function.</p>
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#column">
+                    <h3 id="column">
+                        column
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#compose">
                     <h3 id="compose">
                         compose
@@ -1329,6 +1329,177 @@ and then to the following argument.</p>
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#defdynamic">
+                    <h3 id="defdynamic">
+                        defdynamic
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#defined?">
+                    <h3 id="defined?">
+                        defined?
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#definterface">
+                    <h3 id="definterface">
+                        definterface
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#defmacro">
+                    <h3 id="defmacro">
+                        defmacro
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#defmodule">
+                    <h3 id="defmodule">
+                        defmodule
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#defndynamic">
+                    <h3 id="defndynamic">
+                        defndynamic
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#deftype">
+                    <h3 id="deftype">
+                        deftype
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dynand">
+                    <h3 id="dynand">
+                        dynand
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (dynand x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#dynor">
+                    <h3 id="dynor">
+                        dynor
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (dynor x y)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#e">
                     <h3 id="e">
                         e
@@ -1416,6 +1587,25 @@ and then to the following argument.</p>
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#eval">
+                    <h3 id="eval">
+                        eval
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#eval-internal">
                     <h3 id="eval-internal">
                         eval-internal
@@ -1461,6 +1651,25 @@ and then to the following argument.</p>
                 </a>
                 <div class="description">
                     command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#file">
+                    <h3 id="file">
+                        file
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
                 </div>
                 <p class="sig">
                     Dynamic
@@ -1565,6 +1774,25 @@ and then to the following argument.</p>
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#info">
+                    <h3 id="info">
+                        info
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#last">
                     <h3 id="last">
                         last
@@ -1591,6 +1819,25 @@ and then to the following argument.</p>
                 </a>
                 <div class="description">
                     command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#line">
+                    <h3 id="line">
+                        line
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
                 </div>
                 <p class="sig">
                     Dynamic
@@ -1747,6 +1994,63 @@ applications.</p>
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#members">
+                    <h3 id="members">
+                        members
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#meta">
+                    <h3 id="meta">
+                        meta
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#meta-set!">
+                    <h3 id="meta-set!">
+                        meta-set!
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#no-echo">
                     <h3 id="no-echo">
                         no-echo
@@ -1824,25 +2128,6 @@ applications.</p>
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#or-internal">
-                    <h3 id="or-internal">
-                        or-internal
-                    </h3>
-                </a>
-                <div class="description">
-                    dynamic
-                </div>
-                <p class="sig">
-                    Dynamic
-                </p>
-                <pre class="args">
-                    (or-internal x y)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
                 <a class="anchor" href="#os">
                     <h3 id="os">
                         os
@@ -1888,6 +2173,25 @@ applications.</p>
                 </a>
                 <div class="description">
                     command
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#quote">
+                    <h3 id="quote">
+                        quote
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
                 </div>
                 <p class="sig">
                     Dynamic
@@ -1956,6 +2260,44 @@ applications.</p>
                     <p>Reduces or 'folds' a data literal, such as a list or array, into a single
 value through successive applications of <code>f</code>.</p>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#register">
+                    <h3 id="register">
+                        register
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#register-type">
+                    <h3 id="register-type">
+                        register-type
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">
@@ -2146,6 +2488,25 @@ value through successive applications of <code>f</code>.</p>
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#type">
+                    <h3 id="type">
+                        type
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#unreduce">
                     <h3 id="unreduce">
                         unreduce
@@ -2172,6 +2533,25 @@ Collects results in the structure given by <code>acc</code>.</p>
  ```
 </code></pre>
 
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#use">
+                    <h3 id="use">
+                        use
+                    </h3>
+                </a>
+                <div class="description">
+                    primitive
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -1145,7 +1145,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>returns the column a symbol was defined on.</p>
+<p>Example Usage</p>
+<pre><code>(column mysymbol)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1344,7 +1348,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>defines a new dynamic value, i.e. a value available at compile time.</p>
+<p>Example Usage</p>
+<pre><code>(defdynamic name value)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1363,7 +1371,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>checks whether a symbol is defined.</p>
+<p>Example Usage</p>
+<pre><code>(defined? mysymbol)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1382,7 +1394,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>defines a new interface (which could be a function or symbol).</p>
+<p>Example Usage</p>
+<pre><code>(definterface mysymbol MyType)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1401,7 +1417,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>defines a new macro.</p>
+<p>Example Usage</p>
+<pre><code>(defmacro name [args :rest restargs] body)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1420,7 +1440,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>defines a new module in which <code>expressions</code> are defined.</p>
+<p>Example Usage</p>
+<pre><code>(defmodule MyModule &lt;expressions&gt;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1439,7 +1463,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>defines a new dynamic function, i.e. a function available at compile time.</p>
+<p>Example Usage</p>
+<pre><code>(defndynamic name [args] body)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1458,13 +1486,17 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>defines a new sumtype or struct.</p>
+<p>Example Usage</p>
+<pre><code>(deftype Name &lt;members&gt;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dynand">
-                    <h3 id="dynand">
-                        dynand
+                <a class="anchor" href="#dynamic-and">
+                    <h3 id="dynamic-and">
+                        dynamic-and
                     </h3>
                 </a>
                 <div class="description">
@@ -1474,16 +1506,16 @@ and then to the following argument.</p>
                     Dynamic
                 </p>
                 <pre class="args">
-                    (dynand x y)
+                    (dynamic-and x y)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dynor">
-                    <h3 id="dynor">
-                        dynor
+                <a class="anchor" href="#dynamic-or">
+                    <h3 id="dynamic-or">
+                        dynamic-or
                     </h3>
                 </a>
                 <div class="description">
@@ -1493,7 +1525,7 @@ and then to the following argument.</p>
                     Dynamic
                 </p>
                 <pre class="args">
-                    (dynor x y)
+                    (dynamic-or x y)
                 </pre>
                 <p class="doc">
                     
@@ -1602,7 +1634,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>evaluates a list.</p>
+<p>Example Usage</p>
+<pre><code>(eval mycode)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1678,7 +1714,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>returns the file a symbol was defined in.</p>
+<p>Example Usage</p>
+<pre><code>(file mysymbol)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1789,7 +1829,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>prints all information associated with a symbol.</p>
+<p>Example Usage</p>
+<pre><code>(info mysymbol)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1846,7 +1890,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>returns the line a symbol was defined on.</p>
+<p>Example Usage</p>
+<pre><code>(line mysymbol)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2009,7 +2057,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>returns the members of a type as an array.</p>
+<p>Example Usage</p>
+<pre><code>(members MyType)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2028,7 +2080,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the value under <code>&quot;mykey&quot;</code> in the meta map associated with a symbol. It returns <code>()</code> if the key isn’t found.</p>
+<p>Example Usage</p>
+<pre><code>(meta mysymbol &quot;mykey&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2047,7 +2103,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets a new key and value pair on the meta map associated with a symbol.</p>
+<p>Example Usage</p>
+<pre><code>(meta-set! mysymbol &quot;mykey&quot; &quot;myval&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2200,7 +2260,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>quotes any value.</p>
+<p>Example Usage</p>
+<pre><code>(quote x) ; where x is an actual symbol
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2278,7 +2342,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>registers a new function. This is used to define C functions and other symbols that will be available at link time.</p>
+<p>Example Usage</p>
+<pre><code>(register name &lt;signature&gt; &lt;optional: override&gt;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2297,7 +2365,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>registers a new type from C.</p>
+<p>Example Usage</p>
+<pre><code>(register-type Name &lt;optional: members&gt;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2503,7 +2575,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>prints the type of a symbol.</p>
+<p>Example Usage</p>
+<pre><code>(type mysymbol)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2551,7 +2627,11 @@ Collects results in the structure given by <code>acc</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>uses a module, i.e. imports the symbols inside that module into the current module.</p>
+<p>Example Usage</p>
+<pre><code>(use MyModule)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -126,6 +126,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             External _ -> error (show (CannotEmitExternal xobj))
             ExternalType -> error (show (DontVisitObj xobj))
             e@(Command _) -> error (show (DontVisitObj xobj))
+            e@(Primitive _) -> error (show (DontVisitObj xobj))
             e@(Deftemplate _) ->  error (show (DontVisitObj xobj))
             e@(Instantiate _) ->  error (show (DontVisitObj xobj))
             e@(Defalias _) -> error (show (DontVisitObj xobj))
@@ -497,6 +498,10 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             XObj (Command _) _ _ : _ ->
               return ""
 
+            -- Primitive
+            XObj (Primitive _) _ _ : _ ->
+              return ""
+
             -- Interface
             XObj (Interface _ _) _ _ : _ ->
               return ""
@@ -765,6 +770,8 @@ toDeclaration (Binder meta xobj@(XObj (Lst xobjs) _ t)) =
     XObj ExternalType _ _ : _ ->
       ""
     XObj (Command _) _ _ : _ ->
+      ""
+    XObj (Primitive _) _ _ : _ ->
       ""
     _ -> error ("Internal compiler error: Can't emit other kinds of definitions: " ++ show xobj)
 toDeclaration _ = error "Missing case."

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -337,26 +337,26 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "read-file" 1 commandReadFile
                     , addCommand "write-file" 2 commandWriteFile
                     , addCommand "bit-width" 0 commandBitWidth
-                    , makePrim "quote" 1 "(quote x) ; where x is an actual symbol" (\_ ctx [x] -> return (ctx, Right x))
-                    , makeVarPrim "file" "(file mysymbol)" primitiveFile
-                    , makeVarPrim "line" "(line mysymbol)" primitiveLine
-                    , makeVarPrim "column" "(column mysymbol)" primitiveColumn
-                    , makePrim "info" 1 "(info mysymbol)" primitiveInfo
-                    , makeVarPrim "register-type" "(register-type Name <optional: members>)" primitiveRegisterType
-                    , makePrim "defmacro" 3 "(defmacro name [args :rest restargs] body)" primitiveDefmacro
-                    , makePrim "defndynamic" 3 "(defndynamic name [args] body)" primitiveDefndynamic
-                    , makePrim "defdynamic" 2 "(defdynamic name value)" primitiveDefdynamic
-                    , makePrim "type" 1 "(type mysymbol)" primitiveType
-                    , makePrim "members" 1 "(type mysymbol)" primitiveMembers
-                    , makeVarPrim "defmodule" "(defmodule MyModule <expressions>)" primitiveDefmodule
-                    , makePrim "meta-set!" 3 "(meta-set! mysymbol \"mykey\" \"myval\")" primitiveMetaSet
-                    , makePrim "meta" 2 "(meta mysymbol \"mykey\")" primitiveMeta
-                    , makePrim "definterface" 2 "(definterface myfunction MyType)" primitiveDefinterface
-                    , makeVarPrim "register" "(register name <signature> <optional: override>)" primitiveRegister
-                    , makeVarPrim "deftype" "(deftype name <members>)" primitiveDeftype
-                    , makePrim "use" 1 "(use MyModule)" primitiveUse
-                    , makePrim "eval" 1 "(evaluate mycode)" primitiveEval
-                    , makePrim "defined?" 1 "(defined? mycode)" primitiveDefined
+                    , makePrim "quote" 1 "quotes any value." "(quote x) ; where x is an actual symbol" (\_ ctx [x] -> return (ctx, Right x))
+                    , makeVarPrim "file" "returns the file a symbol was defined in." "(file mysymbol)" primitiveFile
+                    , makeVarPrim "line" "returns the line a symbol was defined on." "(line mysymbol)" primitiveLine
+                    , makeVarPrim "column" "returns the column a symbol was defined on." "(column mysymbol)" primitiveColumn
+                    , makePrim "info" 1 "prints all information associated with a symbol." "(info mysymbol)" primitiveInfo
+                    , makeVarPrim "register-type" "registers a new type from C." "(register-type Name <optional: members>)" primitiveRegisterType
+                    , makePrim "defmacro" 3 "defines a new macro." "(defmacro name [args :rest restargs] body)" primitiveDefmacro
+                    , makePrim "defndynamic" 3 "defines a new dynamic function, i.e. a function available at compile time." "(defndynamic name [args] body)" primitiveDefndynamic
+                    , makePrim "defdynamic" 2 "defines a new dynamic value, i.e. a value available at compile time." "(defdynamic name value)" primitiveDefdynamic
+                    , makePrim "type" 1 "prints the type of a symbol." "(type mysymbol)" primitiveType
+                    , makePrim "members" 1 "returns the members of a type as an array." "(members MyType)" primitiveMembers
+                    , makeVarPrim "defmodule" "defines a new module in which `expressions` are defined." "(defmodule MyModule <expressions>)" primitiveDefmodule
+                    , makePrim "meta-set!" 3 "sets a new key and value pair on the meta map associated with a symbol." "(meta-set! mysymbol \"mykey\" \"myval\")" primitiveMetaSet
+                    , makePrim "meta" 2 "gets the value under `\"mykey\"` in the meta map associated with a symbol. It returns `()` if the key isn’t found." "(meta mysymbol \"mykey\")" primitiveMeta
+                    , makePrim "definterface" 2 "defines a new interface (which could be a function or symbol)." "(definterface mysymbol MyType)" primitiveDefinterface
+                    , makeVarPrim "register" "registers a new function. This is used to define C functions and other symbols that will be available at link time." "(register name <signature> <optional: override>)" primitiveRegister
+                    , makeVarPrim "deftype" "defines a new sumtype or struct." "(deftype Name <members>)" primitiveDeftype
+                    , makePrim "use" 1 "uses a module, i.e. imports the symbols inside that module into the current module." "(use MyModule)" primitiveUse
+                    , makePrim "eval" 1 "evaluates a list." "(eval mycode)" primitiveEval
+                    , makePrim "defined?" 1 "checks whether a symbol is defined." "(defined? mysymbol)" primitiveDefined
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -14,6 +14,7 @@ import Commands
 import Parsing
 import Eval
 import Concretize
+import Primitives
 import Debug.Trace (trace)
 
 -- | These modules will be loaded in order before any other code is evaluated.
@@ -336,6 +337,26 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand "read-file" 1 commandReadFile
                     , addCommand "write-file" 2 commandWriteFile
                     , addCommand "bit-width" 0 commandBitWidth
+                    , makePrim "quote" 1 "(quote x) ; where x is an actual symbol" (\_ ctx [x] -> return (ctx, Right x))
+                    , makeVarPrim "file" "(file mysymbol)" primitiveFile
+                    , makeVarPrim "line" "(line mysymbol)" primitiveLine
+                    , makeVarPrim "column" "(column mysymbol)" primitiveColumn
+                    , makePrim "info" 1 "(info mysymbol)" primitiveInfo
+                    , makeVarPrim "register-type" "(register-type Name <optional: members>)" primitiveRegisterType
+                    , makePrim "defmacro" 3 "(defmacro name [args :rest restargs] body)" primitiveDefmacro
+                    , makePrim "defndynamic" 3 "(defndynamic name [args] body)" primitiveDefndynamic
+                    , makePrim "defdynamic" 2 "(defdynamic name value)" primitiveDefdynamic
+                    , makePrim "type" 1 "(type mysymbol)" primitiveType
+                    , makePrim "members" 1 "(type mysymbol)" primitiveMembers
+                    , makeVarPrim "defmodule" "(defmodule MyModule <expressions>)" primitiveDefmodule
+                    , makePrim "meta-set!" 3 "(meta-set! mysymbol \"mykey\" \"myval\")" primitiveMetaSet
+                    , makePrim "meta" 2 "(meta mysymbol \"mykey\")" primitiveMeta
+                    , makePrim "definterface" 2 "(definterface myfunction MyType)" primitiveDefinterface
+                    , makeVarPrim "register" "(register name <signature> <optional: override>)" primitiveRegister
+                    , makeVarPrim "deftype" "(deftype name <members>)" primitiveDeftype
+                    , makePrim "use" 1 "(use MyModule)" primitiveUse
+                    , makePrim "eval" 1 "(evaluate mycode)" primitiveEval
+                    , makePrim "defined?" 1 "(defined? mycode)" primitiveDefined
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))

--- a/test/args.carp
+++ b/test/args.carp
@@ -3,7 +3,7 @@
 
 (defndynamic _make-exe-path [pth]
   (let [out (Project.get-config "output-directory")
-        sep (if (Dynamic.or (= (os) "windows") (= (os) "mingw32")) "\\" "/")
+        sep (if (dynor (= (os) "windows") (= (os) "mingw32")) "\\" "/")
         lst (Dynamic.String.suffix out (- (String.length out) 1))]
     (Dynamic.String.concat (array out (if (= lst sep) "" sep) pth))))
 

--- a/test/args.carp
+++ b/test/args.carp
@@ -3,7 +3,7 @@
 
 (defndynamic _make-exe-path [pth]
   (let [out (Project.get-config "output-directory")
-        sep (if (dynor (= (os) "windows") (= (os) "mingw32")) "\\" "/")
+        sep (if (dynamic-or (= (os) "windows") (= (os) "mingw32")) "\\" "/")
         lst (Dynamic.String.suffix out (- (String.length out) 1))]
     (Dynamic.String.concat (array out (if (= lst sep) "" sep) pth))))
 

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -34,8 +34,8 @@
     1 true
     false))
 
-(defmacro test-and [a b] (Dynamic.and a b))
-(defmacro test-or [a b] (Dynamic.or a b))
+(defmacro test-and [a b] (dynand a b))
+(defmacro test-or [a b] (dynor a b))
 (defmacro test-not [a] (not a))
 (defmacro test-< [a b] (< a b))
 (defmacro test-> [a b] (> a b))
@@ -60,12 +60,12 @@
 
 (defmacro test-map []
   (let [mapped (Dynamic.map length '((a) (b c) (d e f)))]
-    (Dynamic.and (Dynamic.and (= 1 (Dynamic.car mapped)) (= 2 (Dynamic.cadr mapped))) (= 3
+    (dynand (dynand (= 1 (Dynamic.car mapped)) (= 2 (Dynamic.cadr mapped))) (= 3
     (Dynamic.caddr mapped)))))
 
 (defmacro test-zip []
   (let [zipped (Dynamic.zip array '('a 'd) '('c 'o) '('e 'g))]
-    (Dynamic.and (= 'ace (Symbol.concat (eval (Dynamic.car zipped))))
+    (dynand (= 'ace (Symbol.concat (eval (Dynamic.car zipped))))
       (= 'dog (Symbol.concat (eval (Dynamic.cadr zipped)))))))
 
 (defmacro test-curry []
@@ -81,12 +81,12 @@
   (= 10 (Dynamic.reduce + 0 '(1 2 3 4))))
 
 (defmacro test-unreduce []
-  (Dynamic.reduce Dynamic.and-internal true
+  (Dynamic.reduce dynand true
     (Dynamic.map 'eval
       (Dynamic.zip = '(1 2 3 4) (Dynamic.unreduce (curry + 1) 0 4 (list))))))
 
 (defmacro test-filter []
-  (Dynamic.reduce Dynamic.and-internal true
+  (Dynamic.reduce dynand true
     (Dynamic.map 'eval
       (Dynamic.zip = '('a 'a 'a 'a)
         (Dynamic.map Dynamic.quoted
@@ -95,17 +95,17 @@
 (defmacro test-empty []
   ;; We can't compare '[] and '[] for some reason.
   ;; But '() and '() are comparable
-  (Dynamic.and (= '() (Dynamic.empty '(1 2 3 4)))
+  (dynand (= '() (Dynamic.empty '(1 2 3 4)))
                (empty? (Dynamic.empty '[1 2 3 4]))))
 
 (defmacro test-reverse []
-  (Dynamic.reduce Dynamic.and-internal true
+  (Dynamic.reduce dynand true
     (Dynamic.map 'eval
       (Dynamic.zip = '(4 3 2 1) (Dynamic.reverse '(1 2 3 4))))))
 
 (defmacro test-take []
   (let [result  (Dynamic.take 2 '(1 2 3 4))]
-    (Dynamic.and (= 1 (car result ))
+    (dynand (= 1 (car result ))
                  (= '() (cddr result)))))
 
 (deftest test

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -34,8 +34,8 @@
     1 true
     false))
 
-(defmacro test-and [a b] (dynand a b))
-(defmacro test-or [a b] (dynor a b))
+(defmacro test-and [a b] (dynamic-and a b))
+(defmacro test-or [a b] (dynamic-or a b))
 (defmacro test-not [a] (not a))
 (defmacro test-< [a b] (< a b))
 (defmacro test-> [a b] (> a b))
@@ -60,12 +60,12 @@
 
 (defmacro test-map []
   (let [mapped (Dynamic.map length '((a) (b c) (d e f)))]
-    (dynand (dynand (= 1 (Dynamic.car mapped)) (= 2 (Dynamic.cadr mapped))) (= 3
+    (dynamic-and (dynamic-and (= 1 (Dynamic.car mapped)) (= 2 (Dynamic.cadr mapped))) (= 3
     (Dynamic.caddr mapped)))))
 
 (defmacro test-zip []
   (let [zipped (Dynamic.zip array '('a 'd) '('c 'o) '('e 'g))]
-    (dynand (= 'ace (Symbol.concat (eval (Dynamic.car zipped))))
+    (dynamic-and (= 'ace (Symbol.concat (eval (Dynamic.car zipped))))
       (= 'dog (Symbol.concat (eval (Dynamic.cadr zipped)))))))
 
 (defmacro test-curry []
@@ -81,12 +81,12 @@
   (= 10 (Dynamic.reduce + 0 '(1 2 3 4))))
 
 (defmacro test-unreduce []
-  (Dynamic.reduce dynand true
+  (Dynamic.reduce dynamic-and true
     (Dynamic.map 'eval
       (Dynamic.zip = '(1 2 3 4) (Dynamic.unreduce (curry + 1) 0 4 (list))))))
 
 (defmacro test-filter []
-  (Dynamic.reduce dynand true
+  (Dynamic.reduce dynamic-and true
     (Dynamic.map 'eval
       (Dynamic.zip = '('a 'a 'a 'a)
         (Dynamic.map Dynamic.quoted
@@ -95,17 +95,17 @@
 (defmacro test-empty []
   ;; We can't compare '[] and '[] for some reason.
   ;; But '() and '() are comparable
-  (dynand (= '() (Dynamic.empty '(1 2 3 4)))
+  (dynamic-and (= '() (Dynamic.empty '(1 2 3 4)))
                (empty? (Dynamic.empty '[1 2 3 4]))))
 
 (defmacro test-reverse []
-  (Dynamic.reduce dynand true
+  (Dynamic.reduce dynamic-and true
     (Dynamic.map 'eval
       (Dynamic.zip = '(4 3 2 1) (Dynamic.reverse '(1 2 3 4))))))
 
 (defmacro test-take []
   (let [result  (Dynamic.take 2 '(1 2 3 4))]
-    (dynand (= 1 (car result ))
+    (dynamic-and (= 1 (car result ))
                  (= '() (cddr result)))))
 
 (deftest test


### PR DESCRIPTION
This PR fixes #719 by making primitives less magical. Because of current limitations of name resolution, this also means that dynamic `or` and `and` have to be renamed, which is a bummer. I settled on `dynor` and `dynand`, but I’m not really happy with those, so if you have suggestions, let me know!

Cheers