### PR TITLE
Registered type aliasing

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -86,7 +86,7 @@ main = do setLocaleEncoding utf8
                       else return context
           finalContext <- loadFiles context' argFilesToLoad
           case execMode of
-            Repl -> do putStrLn "Welcome to Carp 0.3.1WIP"
+            Repl -> do putStrLn "Welcome to Carp 0.3.0"
                        putStrLn "This is free software with ABSOLUTELY NO WARRANTY."
                        putStrLn "Evaluate (help) for more information."
                        _ <- runRepl finalContext

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -86,7 +86,7 @@ main = do setLocaleEncoding utf8
                       else return context
           finalContext <- loadFiles context' argFilesToLoad
           case execMode of
-            Repl -> do putStrLn "Welcome to Carp 0.3.0"
+            Repl -> do putStrLn "Welcome to Carp 0.3.1WIP"
                        putStrLn "This is free software with ABSOLUTELY NO WARRANTY."
                        putStrLn "Evaluate (help) for more information."
                        _ <- runRepl finalContext

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -381,7 +381,7 @@ concretizeType typeEnv genericStructTy@(StructTy name _) =
       if isTypeGeneric originalStructTy
       then instantiateGenericSumtype typeEnv originalStructTy genericStructTy rest
       else Right []
-    Just (_, Binder _ (XObj (Lst (XObj ExternalType _ _ : _)) _ _)) ->
+    Just (_, Binder _ (XObj (Lst (XObj (ExternalType _) _ _ : _)) _ _)) ->
       Right []
     Just (_, Binder _ x) ->
       error ("Non-deftype found in type env: " ++ show x)
@@ -478,6 +478,8 @@ modeFromPath :: Env -> SymPath -> SymbolMode
 modeFromPath env p =
   case lookupInEnv p env of
     Just (_, Binder _ (XObj (Lst (XObj (External (Just overrideWithName)) _ _ : _)) _ _)) ->
+      LookupGlobalOverride overrideWithName
+    Just (_, Binder _ (XObj (Lst (XObj (ExternalType (Just overrideWithName)) _ _ : _)) _ _)) ->
       LookupGlobalOverride overrideWithName
     Just (_, Binder _ found@(XObj (Lst (XObj (External _) _ _ : _)) _ _)) ->
       LookupGlobal ExternalCode (definitionMode found)

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -762,8 +762,10 @@ toDeclaration (Binder meta xobj@(XObj (Lst xobjs) _ t)) =
       ""
     XObj (External _) _ _ : _ ->
       ""
-    XObj (ExternalType _) _ _ : _ ->
+    XObj (ExternalType Nothing) _ _ : _ ->
       ""
+    XObj (ExternalType (Just override)) _ _ : XObj (Sym path _) _ _ : _ ->
+      "typedef " ++ override ++ " " ++ pathToC path ++ ";"
     XObj (Command _) _ _ : _ ->
       ""
     _ -> error ("Internal compiler error: Can't emit other kinds of definitions: " ++ show xobj)

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -124,7 +124,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             e@(DefSumtype _) -> error (show (DontVisitObj xobj))
             Mod _ -> error (show (CannotEmitModKeyword xobj))
             External _ -> error (show (CannotEmitExternal xobj))
-            ExternalType -> error (show (DontVisitObj xobj))
+            ExternalType _ -> error (show (DontVisitObj xobj))
             e@(Command _) -> error (show (DontVisitObj xobj))
             e@(Deftemplate _) ->  error (show (DontVisitObj xobj))
             e@(Instantiate _) ->  error (show (DontVisitObj xobj))
@@ -762,7 +762,7 @@ toDeclaration (Binder meta xobj@(XObj (Lst xobjs) _ t)) =
       ""
     XObj (External _) _ _ : _ ->
       ""
-    XObj ExternalType _ _ : _ ->
+    XObj (ExternalType _) _ _ : _ ->
       ""
     XObj (Command _) _ _ : _ ->
       ""
@@ -788,7 +788,7 @@ binderToC toCMode binder =
   let xobj = binderXObj binder
   in  case xobj of
         XObj (External _) _ _ -> Right ""
-        XObj ExternalType _ _ -> Right ""
+        XObj (ExternalType _) _ _ -> Right ""
         XObj (Command _) _ _ -> Right ""
         XObj (Mod env) _ _ -> envToC env toCMode
         _ -> case ty xobj of

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -92,7 +92,7 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
                        (Mod _)            -> return (Left (InvalidObj If xobj))
                        e@(Deftype _)      -> return (Left (InvalidObj e xobj))
                        e@(External _)     -> return (Left (InvalidObj e xobj))
-                       ExternalType       -> return (Left (InvalidObj ExternalType xobj))
+                       e@(ExternalType _) -> return (Left (InvalidObj e xobj))
                        e@(Deftemplate _)  -> return (Left (InvalidObj e xobj))
                        e@(Instantiate _)  -> return (Left (InvalidObj e xobj))
                        e@(Defalias _)     -> return (Left (InvalidObj e xobj))

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -183,7 +183,7 @@ isExternalType typeEnv (PointerTy p) =
   isExternalType typeEnv p
 isExternalType typeEnv (StructTy name _) =
   case lookupInEnv (SymPath [] name) (getTypeEnv typeEnv) of
-    Just (_, Binder _ (XObj (Lst (XObj ExternalType _ _ : _)) _ _)) -> True
+    Just (_, Binder _ (XObj (Lst (XObj (ExternalType _) _ _ : _)) _ _)) -> True
     Just _ -> False
     Nothing -> False
 isExternalType _ _ =
@@ -194,7 +194,7 @@ isManaged :: TypeEnv -> Ty -> Bool
 isManaged typeEnv (StructTy name _) =
   (name == "Array") || (name == "StaticArray") || (name == "Dictionary") || (
     case lookupInEnv (SymPath [] name) (getTypeEnv typeEnv) of
-         Just (_, Binder _ (XObj (Lst (XObj ExternalType _ _ : _)) _ _)) -> False
+         Just (_, Binder _ (XObj (Lst (XObj (ExternalType _) _ _ : _)) _ _)) -> False
          Just (_, Binder _ (XObj (Lst (XObj (Deftype _) _ _ : _)) _ _)) -> True
          Just (_, Binder _ (XObj (Lst (XObj (DefSumtype _) _ _ : _)) _ _)) -> True
          Just (_, Binder _ (XObj wrong _ _)) -> error ("Invalid XObj in type env: " ++ show wrong)

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -358,7 +358,7 @@ prettyUpTo max xobj =
             Instantiate _ -> ""
             External Nothing -> ""
             External (Just override) -> ")"
-            ExternalType Nothing -> ")"
+            ExternalType Nothing -> ""
             ExternalType (Just override) -> ")"
             DocStub -> ""
             Defalias _ -> ""

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -71,7 +71,7 @@ data Obj = Sym SymPath SymbolMode
          | DefSumtype Ty
          | With
          | External (Maybe String)
-         | ExternalType
+         | ExternalType (Maybe String)
          | DocStub
          | Deftemplate TemplateCreator
          | Instantiate Template
@@ -200,7 +200,7 @@ getBinderDescription (XObj (Lst (XObj (Deftemplate _) _ _ : XObj (Sym _ _) _ _ :
 getBinderDescription (XObj (Lst (XObj (Instantiate _) _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "instantiate"
 getBinderDescription (XObj (Lst (XObj (Defalias _) _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "alias"
 getBinderDescription (XObj (Lst (XObj (External _) _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "external"
-getBinderDescription (XObj (Lst (XObj ExternalType _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "external-type"
+getBinderDescription (XObj (Lst (XObj (ExternalType _) _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "external-type"
 getBinderDescription (XObj (Lst (XObj DocStub _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "doc-stub"
 getBinderDescription (XObj (Lst (XObj (Deftype _) _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "deftype"
 getBinderDescription (XObj (Lst (XObj (DefSumtype _) _ _ : XObj (Sym _ _) _ _ : _)) _ _) = "deftype"
@@ -239,7 +239,7 @@ getPath (XObj (Lst (XObj (Deftemplate _) _ _ : XObj (Sym path _) _ _ : _)) _ _) 
 getPath (XObj (Lst (XObj (Instantiate _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj (Defalias _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj (External _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
-getPath (XObj (Lst (XObj ExternalType _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
+getPath (XObj (Lst (XObj (ExternalType _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj DocStub _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj (Deftype _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj (Mod _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
@@ -298,7 +298,7 @@ pretty = visit 0
             Instantiate _ -> "instantiate"
             External Nothing -> "external"
             External (Just override) -> "external (override: " ++ show override ++ ")"
-            ExternalType -> "external-type"
+            ExternalType (Just override) -> "external-type (override: " ++ show override ++ ")"
             DocStub -> "doc-stub"
             Defalias _ -> "defalias"
             Address -> "address"
@@ -358,7 +358,8 @@ prettyUpTo max xobj =
             Instantiate _ -> ""
             External Nothing -> ""
             External (Just override) -> ")"
-            ExternalType -> ""
+            ExternalType Nothing -> ")"
+            ExternalType (Just override) -> ")"
             DocStub -> ""
             Defalias _ -> ""
             Address -> ""

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -204,7 +204,6 @@ primitiveRegisterType _ ctx [x@(XObj (Sym (SymPath [] t) _) _ _), members] = do
                       })
       contextWithDefs <- liftIO $ foldM (define True) ctx' deps
       return (contextWithDefs, dynamicNil)
--- primitiveRegister _ ctx [XObj (Sym (SymPath _ name) _) _ _, ty, XObj (Str override) _ _] =
 primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _, ty, XObj (Str override) _ _] = do
   let pathStrings = contextPath ctx
       typeEnv = contextTypeEnv ctx

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -179,21 +179,34 @@ define hidden ctx@(Context globalEnv _ typeEnv _ proj _ _ _) annXObj =
                 return (ctx' { contextGlobalEnv = envInsertAt globalEnv (getPath annXObj) (Binder adjustedMeta annXObj) })
 
 primitiveRegisterType :: Primitive
-primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _] = do
-  let pathStrings = contextPath ctx
-      typeEnv = contextTypeEnv ctx
-      path = SymPath pathStrings t
-      typeDefinition = XObj (Lst [XObj (ExternalType Nothing) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
-  return (ctx { contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) t typeDefinition) }, dynamicNil)
+primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _] =
+  primitiveRegisterTypeWithoutFields ctx t Nothing
 primitiveRegisterType _ ctx [x] =
   return (evalError ctx ("`register-type` takes a symbol, but it got " ++ pretty x) (info x))
-primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _, XObj (Str override) _ _] = do
+primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _, XObj (Str override) _ _] =
+  primitiveRegisterTypeWithoutFields ctx t (Just override)
+primitiveRegisterType _ ctx [x@(XObj (Sym (SymPath [] t) _) _ _), (XObj (Str override) _ _), members] =
+  primitiveRegisterTypeWithFields ctx x t (Just override) members
+primitiveRegisterType _ ctx [x@(XObj (Sym (SymPath [] t) _) _ _), members] =
+  primitiveRegisterTypeWithFields ctx x t Nothing members
+primitiveRegisterType _ ctx _ =
+  return (evalError ctx (
+    "I don't understand this usage of `register-type`.\n\n" ++
+    "Valid usages :\n" ++
+    "  (register-type Name)\n" ++
+    "  (register-type Name [field0 Type, ...])") Nothing)
+
+
+primitiveRegisterTypeWithoutFields :: Context -> String -> (Maybe String) -> IO (Context, Either EvalError XObj)
+primitiveRegisterTypeWithoutFields ctx t override = do
   let pathStrings = contextPath ctx
       typeEnv = contextTypeEnv ctx
       path = SymPath pathStrings t
-      typeDefinition = XObj (Lst [XObj (ExternalType (Just override)) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
+      typeDefinition = XObj (Lst [XObj (ExternalType override) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
   return (ctx { contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) t typeDefinition) }, dynamicNil)
-primitiveRegisterType _ ctx (x@(XObj (Sym (SymPath [] t) _) _ _):(XObj (Str override) _ _):members) = do
+
+primitiveRegisterTypeWithFields :: Context -> XObj -> String -> (Maybe String) -> XObj -> IO (Context, Either EvalError XObj)
+primitiveRegisterTypeWithFields ctx x t override members = do
   let pathStrings = contextPath ctx
       globalEnv = contextGlobalEnv ctx
       typeEnv = contextTypeEnv ctx
@@ -204,38 +217,13 @@ primitiveRegisterType _ ctx (x@(XObj (Sym (SymPath [] t) _) _ _):(XObj (Str over
   case bindingsForRegisteredType typeEnv globalEnv pathStrings t [members] Nothing preExistingModule of
     Left err -> return (makeEvalError ctx (Just err) (show err) (info x))
     Right (typeModuleName, typeModuleXObj, deps) -> do
-      let typeDefinition = XObj (Lst [XObj (ExternalType (Just override)) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
-          ctx' = (ctx { contextGlobalEnv = envInsertAt globalEnv (SymPath pathStrings typeModuleName) (Binder emptyMeta typeModuleXObj)
-                      , contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) t typeDefinition)
-                      })
-      contextWithDefs <- liftIO $ foldM (define True) ctx' deps
-      return (contextWithDefs, dynamicNil)
-primitiveRegisterType _ ctx (x@(XObj (Sym (SymPath [] t) _) _ _):members) = do
-  let pathStrings = contextPath ctx
-      globalEnv = contextGlobalEnv ctx
-      typeEnv = contextTypeEnv ctx
-      path = SymPath pathStrings t
-      preExistingModule = case lookupInEnv (SymPath pathStrings t) globalEnv of
-                            Just (_, Binder _ (XObj (Mod found) _ _)) -> Just found
-                            _ -> Nothing
-  case bindingsForRegisteredType typeEnv globalEnv pathStrings t members Nothing preExistingModule of
-    Left err -> return (makeEvalError ctx (Just err) (show err) (info x))
-    Right (typeModuleName, typeModuleXObj, deps) -> do
-      let typeDefinition = XObj (Lst [XObj (ExternalType Nothing) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
+      let typeDefinition = XObj (Lst [XObj (ExternalType override) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
           ctx' = (ctx { contextGlobalEnv = envInsertAt globalEnv (SymPath pathStrings typeModuleName) (Binder emptyMeta typeModuleXObj)
                       , contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) t typeDefinition)
                       })
       contextWithDefs <- liftIO $ foldM (define True) ctx' deps
       return (contextWithDefs, dynamicNil)
 
-      typeDefinition = XObj (Lst [XObj (ExternalType (Just override)) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
-  return (ctx { contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) t typeDefinition) }, dynamicNil)
-primitiveRegisterType _ ctx _ =
-  return (evalError ctx (
-    "I don't understand this usage of `register-type`.\n\n" ++
-    "Valid usages :\n" ++
-    "  (register-type Name)\n" ++
-    "  (register-type Name [field0 Type, ...])") Nothing)
 
 notFound :: Context -> XObj -> SymPath -> IO (Context, Either EvalError XObj)
 notFound ctx x path =

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -187,7 +187,7 @@ primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _] = do
   return (ctx { contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) t typeDefinition) }, dynamicNil)
 primitiveRegisterType _ ctx [x] =
   return (evalError ctx ("`register-type` takes a symbol, but it got " ++ pretty x) (info x))
-primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _, ty, XObj (Str override) _ _] = do
+primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _, XObj (Str override) _ _] = do
   let pathStrings = contextPath ctx
       typeEnv = contextTypeEnv ctx
       path = SymPath pathStrings t

--- a/src/Scoring.hs
+++ b/src/Scoring.hs
@@ -22,6 +22,7 @@ scoreTypeBinder typeEnv b@(Binder _ (XObj (Lst (XObj x _ _ : XObj (Sym _ _) _ _ 
       in  (depthOfType typeEnv Set.empty selfName aliasedType + 1, b)
     Deftype s -> depthOfStruct s
     DefSumtype s -> depthOfStruct s
+    ExternalType _ -> (0, b)
     _ -> (500, b)
   where
     depthOfStruct (StructTy structName varTys) =


### PR DESCRIPTION
Implements #741.

As I'm very new to Haskell, I assume most of the things could be done in a better way but I really want to contribute.

To do:

- [x] Make the `ExternalType` object to have an optional string (like `External`) ;
- [x] ~~Make a `ExternalType (Just String)` emit the override instead of the type name (I think it's done, but I'm not completely sure about this, so if someone could check that as I dont really know how the emitting process works, I based my code on how it is done for `External`)~~ Make `ExternalType (Just String)` to emit a `typedef` declaration ;
- [x] Adds the reader handler for `(register-type Type "Alias")`
- [x] Adds the reader handler for `(register-type Type "Alias" [fields])`