### PR TITLE
Make invalid usages of `register-type` to gracefully errors out.

### DIFF
--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -187,7 +187,7 @@ primitiveRegisterType _ ctx [XObj (Sym (SymPath [] t) _) _ _] = do
   return (ctx { contextTypeEnv = TypeEnv (extendEnv (getTypeEnv typeEnv) t typeDefinition) }, dynamicNil)
 primitiveRegisterType _ ctx [x] =
   return (evalError ctx ("`register-type` takes a symbol, but it got " ++ pretty x) (info x))
-primitiveRegisterType _ ctx (x@(XObj (Sym (SymPath [] t) _) _ _):members) = do
+primitiveRegisterType _ ctx [x@(XObj (Sym (SymPath [] t) _) _ _), members] = do
   let pathStrings = contextPath ctx
       globalEnv = contextGlobalEnv ctx
       typeEnv = contextTypeEnv ctx
@@ -195,7 +195,7 @@ primitiveRegisterType _ ctx (x@(XObj (Sym (SymPath [] t) _) _ _):members) = do
       preExistingModule = case lookupInEnv (SymPath pathStrings t) globalEnv of
                             Just (_, Binder _ (XObj (Mod found) _ _)) -> Just found
                             _ -> Nothing
-  case bindingsForRegisteredType typeEnv globalEnv pathStrings t members Nothing preExistingModule of
+  case bindingsForRegisteredType typeEnv globalEnv pathStrings t [members] Nothing preExistingModule of
     Left err -> return (makeEvalError ctx (Just err) (show err) (info x))
     Right (typeModuleName, typeModuleXObj, deps) -> do
       let typeDefinition = XObj (Lst [XObj ExternalType Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -204,6 +204,12 @@ primitiveRegisterType _ ctx [x@(XObj (Sym (SymPath [] t) _) _ _), members] = do
                       })
       contextWithDefs <- liftIO $ foldM (define True) ctx' deps
       return (contextWithDefs, dynamicNil)
+primitiveRegisterType _ ctx _ =
+  return (evalError ctx (
+    "I don't understand this usage of `register-type`.\n\n" ++
+    "Valid usages :\n" ++
+    "  (register-type Name)\n" ++
+    "  (register-type Name [field0 Type, ...])") Nothing)
 
 notFound :: Context -> XObj -> SymPath -> IO (Context, Either EvalError XObj)
 notFound ctx x path =


### PR DESCRIPTION
Fixes #744.