### PR TITLE
Add kinds checking

### DIFF
--- a/core/Int.carp
+++ b/core/Int.carp
@@ -62,11 +62,11 @@
 
   (doc to-int "acts as the identity function to implement the interface.")
   (sig to-int (Fn [Int] Int))
-  (defn to-int [a] a)
+  (defn to-int [a] (the Int a))
 
   (doc from-int "acts as the identity function to implement the interface.")
   (sig from-int (Fn [Int] Int))
-  (defn from-int [a] a)
+  (defn from-int [a] (the Int a))
 )
 
 (defmodule IntRef

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -62,11 +62,11 @@
 
   (doc to-int "acts as the identity function to implement the interface.")
   (sig to-int (Fn [Int] Int))
-  (defn to-int [a] (the Int a))
+  (defn to-int [a] a)
 
   (doc from-int "acts as the identity function to implement the interface.")
   (sig from-int (Fn [Int] Int))
-  (defn from-int [a] (the Int a))
+  (defn from-int [a] a)
 )
 
 (defmodule IntRef

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -122,7 +122,7 @@ registerInInterfaceIfNeeded ctx path@(SymPath _ name) definitionSignature =
                      in  return $ ctx { contextTypeEnv = TypeEnv (extendEnv typeEnv name updatedInterface) }
                 else Left ("[INTERFACE ERROR] " ++ show path ++ " : " ++ show definitionSignature ++
                            " doesn't match the interface signature " ++ show interfaceSignature)
-           else Left ("[INTERFACE ERROR] " ++ show path ++ ":" ++ show definitionSignature ++ " kind mismatch")
+           else Left ("[INTERFACE ERROR] " ++ show path ++ ":" ++ " One or more types in the interface implementation " ++ show definitionSignature ++ " have kinds that do not match the kinds of the types in the interface signature " ++ show interfaceSignature ++ "\n" ++ "Types of the form (f a) must be matched by constructor types such as (Maybe a)")
        Just (_, Binder _ x) ->
          error ("A non-interface named '" ++ name ++ "' was found in the type environment: " ++ show x)
        Nothing -> return ctx

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -116,11 +116,13 @@ registerInInterfaceIfNeeded ctx path@(SymPath _ name) definitionSignature =
   let typeEnv = getTypeEnv (contextTypeEnv ctx)
   in case lookupInEnv (SymPath [] name) typeEnv of
        Just (_, Binder _ (XObj (Lst [XObj (Interface interfaceSignature paths) ii it, isym]) i t)) ->
-         if areUnifiable interfaceSignature definitionSignature
-         then let updatedInterface = XObj (Lst [XObj (Interface interfaceSignature (addIfNotPresent path paths)) ii it, isym]) i t
-              in  return $ ctx { contextTypeEnv = TypeEnv (extendEnv typeEnv name updatedInterface) }
-         else Left ("[INTERFACE ERROR] " ++ show path ++ " : " ++ show definitionSignature ++
-                    " doesn't match the interface signature " ++ show interfaceSignature)
+         if checkKinds interfaceSignature definitionSignature
+           then if areUnifiable interfaceSignature definitionSignature
+                then let updatedInterface = XObj (Lst [XObj (Interface interfaceSignature (addIfNotPresent path paths)) ii it, isym]) i t
+                     in  return $ ctx { contextTypeEnv = TypeEnv (extendEnv typeEnv name updatedInterface) }
+                else Left ("[INTERFACE ERROR] " ++ show path ++ " : " ++ show definitionSignature ++
+                           " doesn't match the interface signature " ++ show interfaceSignature)
+           else Left ("[INTERFACE ERROR] " ++ show path ++ ":" ++ show definitionSignature ++ " kind mismatch")
        Just (_, Binder _ x) ->
          error ("A non-interface named '" ++ name ++ "' was found in the type environment: " ++ show x)
        Nothing -> return ctx

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -364,7 +364,7 @@ machineReadableErrorStrings fppl err =
     (UsingDeadReference xobj dependsOn) ->
       [machineReadableInfoFromXObj fppl xobj ++ " The reference '" ++ pretty xobj ++ "' isn't alive."]
     (UninhabitedConstructor ty xobj got wanted) ->
-      [machineReadableInfoFromXObj fppl xobj ++ "Can't use an uninhabited type constructor as a member type. The type constructor " ++ show ty ++ "expects " ++ show wanted ++ "arguments but got " ++ show got]
+      [machineReadableInfoFromXObj fppl xobj ++ "Can't use an uninhabited type constructor as a member type. The type constructor " ++ show ty ++ " expects " ++ show wanted ++ "arguments but got " ++ show got]
 
     _ ->
       [show err]

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -242,7 +242,7 @@ instance Show TypeError where
   show (UsingDeadReference xobj dependsOn) =
     "The reference '" ++ pretty xobj ++ "' (depending on the variable '" ++ dependsOn ++ "') isn't alive at " ++ prettyInfoFromXObj xobj ++ "."
   show (UninhabitedConstructor ty xobj got wanted) =
-    "Can't use an uninhabited type constructor " ++ show ty ++ " as a member type at " ++ prettyInfoFromXObj xobj ++ ". The type constructor " ++ show ty ++ " expects " ++ show wanted ++ " arguments but got " ++ show got
+    "Can't use a struct or sumtype constructor without arguments as a member type at " ++ prettyInfoFromXObj xobj ++ ". The type constructor " ++ show ty ++ " expects " ++ show wanted ++ " arguments but got " ++ show got
 
 machineReadableErrorStrings :: FilePathPrintLength -> TypeError -> [String]
 machineReadableErrorStrings fppl err =
@@ -364,7 +364,7 @@ machineReadableErrorStrings fppl err =
     (UsingDeadReference xobj dependsOn) ->
       [machineReadableInfoFromXObj fppl xobj ++ " The reference '" ++ pretty xobj ++ "' isn't alive."]
     (UninhabitedConstructor ty xobj got wanted) ->
-      [machineReadableInfoFromXObj fppl xobj ++ "Can't use an uninhabited type constructor as a member type. The type constructor " ++ show ty ++ " expects " ++ show wanted ++ "arguments but got " ++ show got]
+      [machineReadableInfoFromXObj fppl xobj ++ "Can't use a struct or sumtype constructor without arguments as a member type at " ++ prettyInfoFromXObj xobj ++ ". The type constructor " ++ show ty ++ " expects " ++ show wanted ++ " arguments but got " ++ show got]
 
     _ ->
       [show err]

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -218,7 +218,7 @@ instance Show TypeError where
     ".\n\nSumtype cases look like this: `(Foo [Int typevar])`"
   show (InvalidMemberType t xobj) =
     "I can’t use the type `" ++ show t ++ "` as a member type at " ++
-    pretty xobj ++
+    prettyInfoFromXObj xobj ++
     ".\n\nIs it defined and captured in the head of the type definition?"
   show (InvalidMemberTypeWhenConcretizing t xobj err) =
     "I can’t use the concrete type `" ++ show t ++ "` at " ++ prettyInfoFromXObj xobj ++ ": " ++ show err

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -307,10 +307,10 @@ areUnifiable a b | a == b    = True
 checkKinds :: Ty -> Ty -> Bool
 -- Base < Higher
 checkKinds (FuncTy argTysA retTyA _) (FuncTy argTysB retTyB _) =
-  let argKinds = zipWith (<=) (map tyToKind argTysA) (map tyToKind argTysB)
+  let argKinds = zipWith checkKinds argTysA argTysB
       retKinds = tyToKind retTyA <= tyToKind retTyB
   in all (== True) (retKinds : argKinds)
-checkKinds t t' = tyToKind t == tyToKind t'
+checkKinds t t' = tyToKind t <= tyToKind t'
 
 -- | Put concrete types into the places where there are type variables.
 --   For example (Fn [a] b) => (Fn [Int] Bool)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -310,16 +310,6 @@ checkKinds (FuncTy argTysA retTyA _) (FuncTy argTysB retTyB _) =
   let argKinds = zipWith (<=) (map tyToKind argTysA) (map tyToKind argTysB)
       retKinds = tyToKind retTyA <= tyToKind retTyB
   in all (== True) (retKinds : argKinds)
---checkKinds (StructTy _ argTysA) (StructTy _ argTysB) =
---  let argKinds = zipWith checkKinds argTysA argTysB
---  in all (== True) argKinds
-----checkKinds s@(StructTy _ _) t = tyToKind s == tyToKind t
-----checkKinds t s@(StructTy _ _) = tyToKind s == tyToKind t
---checkKinds (RefTy argTyA _) (RefTy argTyB _) = checkKinds argTyA argTyB
---checkKinds (PointerTy argTyA) (PointerTy argTyB) = checkKinds argTyA argTyB
-----checkKinds (VarTy _) (VarTy _) = False -- prevent type erasures--a variable cannot be replaced by a variable.
---checkKinds (VarTy _) _ = True
---checkKinds _ (VarTy _) = True
 checkKinds t t' = tyToKind t == tyToKind t'
 
 -- | Put concrete types into the places where there are type variables.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -18,6 +18,7 @@ module Types ( TypeMappings
              , doesTypeContainTyVarWithName
              , lambdaEnvTy
              , typeEqIgnoreLifetimes
+             , checkKinds
              ) where
 
 import qualified Data.Map as Map
@@ -49,6 +50,21 @@ data Ty = IntTy
         | DynamicTy -- the type of dynamic functions (used in REPL and macros)
         | InterfaceTy
         deriving (Eq, Ord)
+
+-- | Kinds checking
+-- Carp's system is simple enough that we do not need to describe kinds by their airty.
+-- After confirming two tys have either base or higher kind
+-- unification checks are sufficient to determine whether their arities are compatible.
+data Kind = Base
+          | Higher
+          deriving (Eq, Ord, Show)
+
+tyToKind :: Ty -> Kind
+tyToKind (StructTy _ _) = Higher
+tyToKind (FuncTy _ _ _) = Higher -- the type of functions, consider the (->) constructor in Haskell
+tyToKind (PointerTy _)  = Higher
+tyToKind (RefTy _ _)    = Higher -- Refs may also be treated as a data constructor
+tyToKind _              = Base
 
 -- Exactly like '==' for Ty, but ignore lifetime parameter
 typeEqIgnoreLifetimes :: Ty -> Ty -> Bool
@@ -284,6 +300,27 @@ areUnifiable (FuncTy argTysA retTyA ltA) (FuncTy argTysB retTyB ltB)
 areUnifiable FuncTy{} _ = False
 areUnifiable a b | a == b    = True
           | otherwise = False
+
+-- Checks whether or not the kindedness of types match
+-- Kinds are polymorphic constructors such as (f a)
+-- Note that this disagrees with the notion of unifiablitity in areUnifiable
+checkKinds :: Ty -> Ty -> Bool
+-- Base < Higher
+checkKinds (FuncTy argTysA retTyA _) (FuncTy argTysB retTyB _) =
+  let argKinds = zipWith (<=) (map tyToKind argTysA) (map tyToKind argTysB)
+      retKinds = tyToKind retTyA <= tyToKind retTyB
+  in all (== True) (retKinds : argKinds)
+--checkKinds (StructTy _ argTysA) (StructTy _ argTysB) =
+--  let argKinds = zipWith checkKinds argTysA argTysB
+--  in all (== True) argKinds
+----checkKinds s@(StructTy _ _) t = tyToKind s == tyToKind t
+----checkKinds t s@(StructTy _ _) = tyToKind s == tyToKind t
+--checkKinds (RefTy argTyA _) (RefTy argTyB _) = checkKinds argTyA argTyB
+--checkKinds (PointerTy argTyA) (PointerTy argTyB) = checkKinds argTyA argTyB
+----checkKinds (VarTy _) (VarTy _) = False -- prevent type erasures--a variable cannot be replaced by a variable.
+--checkKinds (VarTy _) _ = True
+--checkKinds _ (VarTy _) = True
+checkKinds t t' = tyToKind t == tyToKind t'
 
 -- | Put concrete types into the places where there are type variables.
 --   For example (Fn [a] b) => (Fn [Int] Bool)

--- a/src/Validate.hs
+++ b/src/Validate.hs
@@ -68,7 +68,7 @@ canBeUsedAsMemberType typeEnv typeVariables t xobj =
              (ConcreteNameTy n) ->
                case lookupInEnv (SymPath [] n) (getTypeEnv typeEnv) of
                  Just (_, binder@(Binder _ xo@(XObj (Lst (XObj (Deftype t') _ _ : _))_ _))) ->
-                     checkInhabitants t'
+                   checkInhabitants t'
                  Just (_, binder@(Binder _ xo@(XObj (Lst (XObj (DefSumtype t') _ _ : _))_ _))) ->
                    checkInhabitants t'
                  _ -> Left (InvalidMemberType t xobj)


### PR DESCRIPTION
This commit adds basic kinds checking on interfaces, such that an
interface that takes a type constructor (f a) can't be implemented by a
function using a concrete type like `Int` in that position.

It also adds checks on deftypes to ensure uninhabited type constructors can't be set as members:

```
(deftype (Foo a) [pos Maybe])
Invalid type definition for 'Foo':

Can't use an uninhabited type constructor (Maybe a) as a member type at line 1, column 23 in 'REPL'. The type constructor (Maybe a) expects 1 arguments but got 0

Traceback:
(deftype (Foo a) [pos Maybe]) at REPL:1:1.
```

Fixes #561