### PR TITLE
Support sumtypes with higher-kinded members

### DIFF
--- a/src/Sumtypes.hs
+++ b/src/Sumtypes.hs
@@ -49,7 +49,7 @@ replaceGenericTypesOnCases :: TypeMappings -> [SumtypeCase] -> [SumtypeCase]
 replaceGenericTypesOnCases mappings cases =
   map replaceOnCase cases
   where replaceOnCase theCase =
-          let newTys = trace log (map (replaceTyVars mappings) (caseTys theCase))
+          let newTys = (map (replaceTyVars mappings) (caseTys theCase))
           in  theCase { caseTys = newTys }
 
 initers :: [String] -> Ty -> [SumtypeCase] -> Either TypeError [(String, Binder)]

--- a/src/Validate.hs
+++ b/src/Validate.hs
@@ -58,9 +58,8 @@ canBeUsedAsMemberType typeEnv typeVariables t xobj =
              case lookupInEnv (SymPath [] name') (getTypeEnv typeEnv) of
                Just _ -> return ()
                Nothing -> Left (NotAmongRegisteredTypes t xobj)
-        -- e.g. (deftype (Higher f a) (Of [(f a)]))
-        t@(VarTy _) -> do _ <- canBeUsedAsMemberType typeEnv typeVariables tyVars xobj
-                          canBeUsedAsMemberType typeEnv typeVariables t xobj
+        -- e.g. (deftype (Higher (f a)) (Of [(f a)]))
+        t@(VarTy _) -> return ()
     s@(StructTy name tyvar) ->
       if isExternalType typeEnv s
       then return ()


### PR DESCRIPTION
This commit does two things:

- Update validate to permit type defintions like:
  `(deftype (Higher (f a)) (Obj [(f a)]))`
- Replace all type vars in such cases so that we generate the correct C
  code.

**Previous Behavior:**
```
(deftype (Higher (f a)) (Obj [(f a)]))
Invalid type definition for 'Higher':

I can’t use the type `a` as a member type at line 1, column 25 in 'REPL'.

Is it defined and captured in the head of the type definition?

Traceback:
(deftype (Higher (f a)) (Obj [(f a)])) at REPL:1:1.
```

Or, once we accept that syntax:

```
(defn obj [x] (Higher.Obj x))
:i obj
obj : (λ [(a b)] (Higher a b)
(obj (Maybe.Just 3))
out/main.c:2196:41: error: unknown type name 'f__int'
Higher__Maybe_int Higher_Obj__int_Maybe(f__int member0);
                                        ^
out/main.c:6344:41: error: unknown type name 'f__int'
Higher__Maybe_int Higher_Obj__int_Maybe(f__int member0) {
```

**Behavior After this PR**:

```
(deftype (Higher (f a)) (Obj [(f a)]))
(defn obj [x] (Higher.Obj (Maybe.Just x)))
(obj 2)
(Obj (Just 2))
=> 0
```

Fixes #755