### PR TITLE
Make polymorphic struct types and functions unifiable

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -286,6 +286,9 @@ areUnifiable (StructTy a aArgs) (StructTy b bArgs)
   | areUnifiable a b = let argBools = zipWith areUnifiable aArgs bArgs
                        in  all (== True) argBools
   | otherwise = False
+areUnifiable (StructTy (VarTy _) aArgs) (FuncTy bArgs _ _)
+  | length aArgs /= length bArgs = False
+  | otherwise = all (== True) (zipWith areUnifiable aArgs bArgs)
 areUnifiable (StructTy _ _) _ = False
 areUnifiable (PointerTy a) (PointerTy b) = areUnifiable a b
 areUnifiable (PointerTy _) _ = False


### PR DESCRIPTION
This commit makes function types unifiable to *only* polymorphic
constructors (`StructTy` with a `VarTy` name). This enables one to implement
interfaces defined against constructors against functions so long as:

- The number of function arguments match the number of type constructor
arguments.

Thus, one can define:

```
(definterface constructor (Fn [(f a b)] (f a b)))
(defmodule Test (defn constructor [f] (the (Fn ([a b] a) f))))
```

But how is this useful?

Here's one scenario this corrects in practice. In Haskell, the `some`
function is typed generically as `some :: f a -> f [a]`. `some` takes a
type and successively  applies it until it returns an empty value, then
it returns a list of results of the applications. This is great for
types that actually have state, such as parsers, but for many values of
`f` it makes no sense. E.G. given a `Maybe` the function will never
terminate, since `Maybe.Just x` will never transform into the empty
value on its own. This problem is even worse when we don't have inherent
laziness to help us short-circuit application where possible.

In fact, using an obvious definition of `some`, a function is the only
(non-bottom) type in the `f a` position that may lead to eventual
termination without requiring rewriting `some` to explicitly match
against values. One could tuck a function away in a type constructor and
devise a clever enough instance of `choice` (which `some` calls) to make this work, but it's
simpler to define it against a function.

Another case: type equivalences. When types are unifiable with
constructors, it gives us an easy way to define concepts generically
across types and functions.

```
(definterface app (Fn [(f a) a] a))
(defmodule Func (defn app [f x] (f x)))
(defmodule Maybe (defn app [m x]
  (match m (Maybe.Nothing) (Maybe.Nothing)
           _ (Maybe.Just x))))
:i app
app : (Fn [(f a), a] a) = {
      Func.app
      Maybe.app
}

(definterface compose (Fn [(f a) (f b)] (f c)))
(defmodule Func (defn compose [f g] (fn [x] (f (g x)))))
:i Func.compose (Fn [(Fn [a] b c), (Fn [d] a c)] (Fn [d] b e))
;; In this case, we define composition as the explicit application of
;; the product
(defmodule Maybe (defn compose [ma mb]
  (let [x (match ma (Maybe.Nothing) (zero)
                    (Maybe.Just a) a)
        y (match mb (Maybe.Nothing) (zero)
                    (Maybe.Just b) b)]
    (Maybe.Just (Pair x y)))))
:i compose
compose : (Fn [(f a), (f b)] (f c)) = {
      Func.compose
      Maybe.compose
}
```

In a more general sense, this would enable us to use functions as a
constructor in type signatures, analogous to the use of (->) in haskell.  (e.g. `fmap :: f a -> a` has a (->) implementation, which is precisely just function composition `.`.

Whew, that wound up being a long explanation for three lines of code 😅but I felt it was a change that requires some consideration as to the potential benefits. There's nothing groundbreaking, but it should make quite a few things more flexible and enable greater amounts of abstraction.