### PR TITLE
Document and enforce documentation on registration

### DIFF
--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -1261,7 +1261,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>returns the column a symbol was defined on.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(column mysymbol)
 </code></pre>
 
@@ -1472,7 +1472,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>defines a new dynamic value, i.e. a value available at compile time.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(defdynamic name value)
 </code></pre>
 
@@ -1495,7 +1495,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>checks whether a symbol is defined.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(defined? mysymbol)
 </code></pre>
 
@@ -1518,7 +1518,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>defines a new interface (which could be a function or symbol).</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(definterface mysymbol MyType)
 </code></pre>
 
@@ -1541,7 +1541,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>defines a new macro.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(defmacro name [args :rest restargs] body)
 </code></pre>
 
@@ -1564,7 +1564,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>defines a new module in which <code>expressions</code> are defined.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(defmodule MyModule &lt;expressions&gt;)
 </code></pre>
 
@@ -1587,7 +1587,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>defines a new dynamic function, i.e. a function available at compile time.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(defndynamic name [args] body)
 </code></pre>
 
@@ -1610,7 +1610,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>defines a new sumtype or struct.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(deftype Name &lt;members&gt;)
 </code></pre>
 
@@ -1724,7 +1724,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>evaluates a list.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(eval mycode)
 </code></pre>
 
@@ -1808,7 +1808,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>returns the file a symbol was defined in.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(file mysymbol)
 </code></pre>
 
@@ -1927,7 +1927,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>prints all information associated with a symbol.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(info mysymbol)
 </code></pre>
 
@@ -1996,7 +1996,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>returns the line a symbol was defined on.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(line mysymbol)
 </code></pre>
 
@@ -2206,7 +2206,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>returns the members of a type as an array.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(members MyType)
 </code></pre>
 
@@ -2229,7 +2229,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>gets the value under <code>&quot;mykey&quot;</code> in the meta map associated with a symbol. It returns <code>()</code> if the key isn’t found.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(meta mysymbol &quot;mykey&quot;)
 </code></pre>
 
@@ -2252,7 +2252,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>sets a new key and value pair on the meta map associated with a symbol.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(meta-set! mysymbol &quot;mykey&quot; &quot;myval&quot;)
 </code></pre>
 
@@ -2425,7 +2425,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>quotes any value.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(quote x) ; where x is an actual symbol
 </code></pre>
 
@@ -2511,7 +2511,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>registers a new function. This is used to define C functions and other symbols that will be available at link time.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(register name &lt;signature&gt; &lt;optional: override&gt;)
 </code></pre>
 
@@ -2534,7 +2534,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>registers a new type from C.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(register-type Name &lt;optional: members&gt;)
 </code></pre>
 
@@ -2772,7 +2772,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>prints the type of a symbol.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(type mysymbol)
 </code></pre>
 
@@ -2824,7 +2824,7 @@ Collects results in the structure given by <code>acc</code>.</p>
                 </span>
                 <p class="doc">
                     <p>uses a module, i.e. imports the symbols inside that module into the current module.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(use MyModule)
 </code></pre>
 

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -174,7 +174,7 @@
                 </span>
                 <p class="doc">
                     <p>multiplies its two arguments.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(* 2 3) ; =&gt; 6
 </code></pre>
 
@@ -197,7 +197,7 @@
                 </span>
                 <p class="doc">
                     <p>adds its two arguments.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(+ 1 2) ; =&gt; 3
 </code></pre>
 
@@ -220,7 +220,7 @@
                 </span>
                 <p class="doc">
                     <p>subtracts its second argument from its first.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(- 1 2) ; =&gt; -1
 </code></pre>
 
@@ -243,7 +243,7 @@
                 </span>
                 <p class="doc">
                     <p>divides its first argument by its second.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(/ 4 2) ; =&gt; 2
 </code></pre>
 
@@ -266,7 +266,7 @@
                 </span>
                 <p class="doc">
                     <p>checks whether its first argument is less than its second.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(&lt; 1 2) ; =&gt; true
 </code></pre>
 
@@ -289,7 +289,7 @@
                 </span>
                 <p class="doc">
                     <p>compares its arguments for equality.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(= 1 2) ; =&gt; false
 </code></pre>
 
@@ -312,7 +312,7 @@
                 </span>
                 <p class="doc">
                     <p>checks whether its first argument is greater than its second.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(&gt; 1 2) ; =&gt; false
 </code></pre>
 
@@ -392,7 +392,7 @@
                 </span>
                 <p class="doc">
                     <p>gets all elements except for the last one of a list or array.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(all-but-last '(1 2 3)) ; =&gt; '(1 2)
 </code></pre>
 
@@ -462,7 +462,7 @@ function <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>appends two lists or arrays.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(append '(1 2) '(3 4)) ; =&gt; '(1 2 3 4)
 </code></pre>
 
@@ -506,7 +506,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>creates an array from a collection of elements.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(array 1 2 3) ; =&gt; [1 2 3]
 </code></pre>
 
@@ -529,7 +529,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>checks whether the arguments is an array.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(array? []) ; =&gt; true
 </code></pre>
 
@@ -552,7 +552,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>gets the bit width of the platform.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(bit-width) ; =&gt; your host machine’s bit width, e.g. 32 or 64
 </code></pre>
 
@@ -575,7 +575,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>builds the current code to an executable.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(build)
 </code></pre>
 
@@ -598,7 +598,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>prints the C code emitted for a binding.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(c '(+ 2 3)) ; =&gt; int _3 = Int__PLUS_(2, 3);
 </code></pre>
 
@@ -887,7 +887,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>gets the head of a list or array.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(car '(1 2 3)) ; =&gt; 1
 </code></pre>
 
@@ -910,7 +910,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>spits out the generated C code.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(cat)
 </code></pre>
 
@@ -1199,7 +1199,7 @@ in the list as an argument to the function.</p>
                 </span>
                 <p class="doc">
                     <p>gets the tail of a list or array.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(cdr '(1 2 3)) ; =&gt; '(2 3)
 </code></pre>
 
@@ -1326,7 +1326,7 @@ For exmaple:
                 </span>
                 <p class="doc">
                     <p>adds an element to the front of an array or list</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(cons 1 '(2 3)) ; =&gt; '(1 2 3)
 </code></pre>
 
@@ -1349,7 +1349,7 @@ For exmaple:
                 </span>
                 <p class="doc">
                     <p>adds an element to the back of an array or list</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(cons-last 3 '(1 2)) ; =&gt; '(1 2 3)
 </code></pre>
 
@@ -1701,7 +1701,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>lists all current bindings.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(env)
 </code></pre>
 
@@ -1785,7 +1785,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>expands a macro and prints the result.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(expand '(when true 1)) ; =&gt; (if true 1 ())
 </code></pre>
 
@@ -1885,7 +1885,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>prints help.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(help)
 </code></pre>
 
@@ -1950,7 +1950,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>gets the last element of a list or array.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(last '(1 2 3)) ; =&gt; 3
 </code></pre>
 
@@ -1973,7 +1973,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>returns the length of the argument (must be an array, string or list).</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(length '(1 2 3)) ; =&gt; 3
 </code></pre>
 
@@ -2019,7 +2019,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>creates an array from a collection of elements.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(list 1 2 3) ; =&gt; (1 2 3)
 </code></pre>
 
@@ -2061,7 +2061,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>checks whether the argument is a list.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(list? '()) ; =&gt; true
 </code></pre>
 
@@ -2084,7 +2084,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>loads a file into the current environment.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(load &quot;myfile.carp&quot;)
 </code></pre>
 
@@ -2107,7 +2107,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>loads a file and prevents it from being reloaded (see <code>reload</code>).</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(load-once &quot;myfile.carp&quot;)
 </code></pre>
 
@@ -2130,7 +2130,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>logs an error and errors out of a macro.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(macro-error &quot;this is wrong&quot;)
 </code></pre>
 
@@ -2153,7 +2153,7 @@ and then to the following argument.</p>
                 </span>
                 <p class="doc">
                     <p>logs a message in a macro.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(macro-log &quot;this will be printed at compile time&quot;)
 </code></pre>
 
@@ -2295,7 +2295,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>negates its boolean argument.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(not false) ; =&gt; true
 </code></pre>
 
@@ -2356,7 +2356,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>prints the operating system (as returned by the Haskell function <code>System.Info.os</code>).</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(os)
 </code></pre>
 
@@ -2379,7 +2379,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>prints the current project state.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(project)
 </code></pre>
 
@@ -2402,7 +2402,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>quits the program.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(quit)
 </code></pre>
 
@@ -2467,7 +2467,7 @@ applications.</p>
                 </span>
                 <p class="doc">
                     <p>reads a file into a string.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(read-file &quot;myfile.txt&quot;)
 </code></pre>
 
@@ -2557,7 +2557,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>adds a relative include, i.e. a C <code>include</code> with quotes. It also prepends the current directory.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(relative-include &quot;myheader.h&quot;)
 </code></pre>
 
@@ -2580,7 +2580,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>reloads all currently loaded files that weren’t marked as only loading once (see <code>load</code> and <code>load-once</code>).</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(reload)
 </code></pre>
 
@@ -2630,7 +2630,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>runs the built executable.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(run)
 </code></pre>
 
@@ -2653,7 +2653,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>is the internal companion command to <code>save-docs</code>. <code>save-docs</code> should be called instead.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(save-docs-internal 'Module)
 </code></pre>
 
@@ -2676,7 +2676,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>stringifies its arguments.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(str 1 &quot; &quot; 2 &quot; &quot; 3) ; =&gt; &quot;1 2 3&quot;
 </code></pre>
 
@@ -2699,7 +2699,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>checks whether the argument is a symbol.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(symbol? 'x) ; =&gt; true
 </code></pre>
 
@@ -2722,7 +2722,7 @@ value through successive applications of <code>f</code>.</p>
                 </span>
                 <p class="doc">
                     <p>adds a system include, i.e. a C <code>#include</code> with angle brackets (<code>&lt;&gt;</code>).</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(system-include &quot;stdint.h&quot;)
 </code></pre>
 
@@ -2847,7 +2847,7 @@ Collects results in the structure given by <code>acc</code>.</p>
                 </span>
                 <p class="doc">
                     <p>writes a string to a file.</p>
-<p>Example Usage</p>
+<p>Example Usage:</p>
 <pre><code>(write-file &quot;myfile&quot; &quot;hello there!&quot;)
 </code></pre>
 

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -173,7 +173,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>multiplies its two arguments.</p>
+<p>Example Usage</p>
+<pre><code>(* 2 3) ; =&gt; 6
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -192,7 +196,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>adds its two arguments.</p>
+<p>Example Usage</p>
+<pre><code>(+ 1 2) ; =&gt; 3
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -211,7 +219,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>subtracts its second argument from its first.</p>
+<p>Example Usage</p>
+<pre><code>(- 1 2) ; =&gt; -1
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -230,7 +242,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>divides its first argument by its second.</p>
+<p>Example Usage</p>
+<pre><code>(/ 4 2) ; =&gt; 2
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -249,7 +265,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>checks whether its first argument is less than its second.</p>
+<p>Example Usage</p>
+<pre><code>(&lt; 1 2) ; =&gt; true
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -268,7 +288,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>compares its arguments for equality.</p>
+<p>Example Usage</p>
+<pre><code>(= 1 2) ; =&gt; false
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -287,7 +311,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>checks whether its first argument is greater than its second.</p>
+<p>Example Usage</p>
+<pre><code>(&gt; 1 2) ; =&gt; false
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -363,7 +391,11 @@
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets all elements except for the last one of a list or array.</p>
+<p>Example Usage</p>
+<pre><code>(all-but-last '(1 2 3)) ; =&gt; '(1 2)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -429,7 +461,11 @@ function <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>appends two lists or arrays.</p>
+<p>Example Usage</p>
+<pre><code>(append '(1 2) '(3 4)) ; =&gt; '(1 2 3 4)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -469,7 +505,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>creates an array from a collection of elements.</p>
+<p>Example Usage</p>
+<pre><code>(array 1 2 3) ; =&gt; [1 2 3]
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -488,7 +528,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>checks whether the arguments is an array.</p>
+<p>Example Usage</p>
+<pre><code>(array? []) ; =&gt; true
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -507,7 +551,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the bit width of the platform.</p>
+<p>Example Usage</p>
+<pre><code>(bit-width) ; =&gt; your host machine’s bit width, e.g. 32 or 64
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -526,7 +574,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>builds the current code to an executable.</p>
+<p>Example Usage</p>
+<pre><code>(build)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -545,7 +597,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>prints the C code emitted for a binding.</p>
+<p>Example Usage</p>
+<pre><code>(c '(+ 2 3)) ; =&gt; int _3 = Int__PLUS_(2, 3);
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -830,7 +886,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the head of a list or array.</p>
+<p>Example Usage</p>
+<pre><code>(car '(1 2 3)) ; =&gt; 1
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -849,7 +909,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>spits out the generated C code.</p>
+<p>Example Usage</p>
+<pre><code>(cat)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1134,7 +1198,11 @@ in the list as an argument to the function.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the tail of a list or array.</p>
+<p>Example Usage</p>
+<pre><code>(cdr '(1 2 3)) ; =&gt; '(2 3)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1257,7 +1325,11 @@ For exmaple:
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>adds an element to the front of an array or list</p>
+<p>Example Usage</p>
+<pre><code>(cons 1 '(2 3)) ; =&gt; '(1 2 3)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1276,7 +1348,11 @@ For exmaple:
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>adds an element to the back of an array or list</p>
+<p>Example Usage</p>
+<pre><code>(cons-last 3 '(1 2)) ; =&gt; '(1 2 3)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1624,7 +1700,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>lists all current bindings.</p>
+<p>Example Usage</p>
+<pre><code>(env)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1704,7 +1784,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>expands a macro and prints the result.</p>
+<p>Example Usage</p>
+<pre><code>(expand '(when true 1)) ; =&gt; (if true 1 ())
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1800,7 +1884,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>prints help.</p>
+<p>Example Usage</p>
+<pre><code>(help)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1861,7 +1949,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the last element of a list or array.</p>
+<p>Example Usage</p>
+<pre><code>(last '(1 2 3)) ; =&gt; 3
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1880,7 +1972,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>returns the length of the argument (must be an array, string or list).</p>
+<p>Example Usage</p>
+<pre><code>(length '(1 2 3)) ; =&gt; 3
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1922,7 +2018,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>creates an array from a collection of elements.</p>
+<p>Example Usage</p>
+<pre><code>(list 1 2 3) ; =&gt; (1 2 3)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1960,7 +2060,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>checks whether the argument is a list.</p>
+<p>Example Usage</p>
+<pre><code>(list? '()) ; =&gt; true
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1979,7 +2083,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>loads a file into the current environment.</p>
+<p>Example Usage</p>
+<pre><code>(load &quot;myfile.carp&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -1998,7 +2106,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>loads a file and prevents it from being reloaded (see <code>reload</code>).</p>
+<p>Example Usage</p>
+<pre><code>(load-once &quot;myfile.carp&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2017,7 +2129,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>logs an error and errors out of a macro.</p>
+<p>Example Usage</p>
+<pre><code>(macro-error &quot;this is wrong&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2036,7 +2152,11 @@ and then to the following argument.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>logs a message in a macro.</p>
+<p>Example Usage</p>
+<pre><code>(macro-log &quot;this will be printed at compile time&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2174,7 +2294,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>negates its boolean argument.</p>
+<p>Example Usage</p>
+<pre><code>(not false) ; =&gt; true
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2231,7 +2355,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>prints the operating system (as returned by the Haskell function <code>System.Info.os</code>).</p>
+<p>Example Usage</p>
+<pre><code>(os)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2250,7 +2378,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>prints the current project state.</p>
+<p>Example Usage</p>
+<pre><code>(project)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2269,7 +2401,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>quits the program.</p>
+<p>Example Usage</p>
+<pre><code>(quit)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2330,7 +2466,11 @@ applications.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>reads a file into a string.</p>
+<p>Example Usage</p>
+<pre><code>(read-file &quot;myfile.txt&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2416,7 +2556,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>adds a relative include, i.e. a C <code>include</code> with quotes. It also prepends the current directory.</p>
+<p>Example Usage</p>
+<pre><code>(relative-include &quot;myheader.h&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2435,7 +2579,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>reloads all currently loaded files that weren’t marked as only loading once (see <code>load</code> and <code>load-once</code>).</p>
+<p>Example Usage</p>
+<pre><code>(reload)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2481,7 +2629,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>runs the built executable.</p>
+<p>Example Usage</p>
+<pre><code>(run)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2500,7 +2652,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>is the internal companion command to <code>save-docs</code>. <code>save-docs</code> should be called instead.</p>
+<p>Example Usage</p>
+<pre><code>(save-docs-internal 'Module)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2519,7 +2675,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>stringifies its arguments.</p>
+<p>Example Usage</p>
+<pre><code>(str 1 &quot; &quot; 2 &quot; &quot; 3) ; =&gt; &quot;1 2 3&quot;
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2538,7 +2698,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>checks whether the argument is a symbol.</p>
+<p>Example Usage</p>
+<pre><code>(symbol? 'x) ; =&gt; true
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2557,7 +2721,11 @@ value through successive applications of <code>f</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>adds a system include, i.e. a C <code>#include</code> with angle brackets (<code>&lt;&gt;</code>).</p>
+<p>Example Usage</p>
+<pre><code>(system-include &quot;stdint.h&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">
@@ -2678,7 +2846,11 @@ Collects results in the structure given by <code>acc</code>.</p>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>writes a string to a file.</p>
+<p>Example Usage</p>
+<pre><code>(write-file &quot;myfile&quot; &quot;hello there!&quot;)
+</code></pre>
+
                 </p>
             </div>
             <div class="binder">

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -62,7 +62,7 @@ addCommandConfigurable path maybeArity callback doc example =
               Just arity -> withArity arity
               Nothing -> callback
         docString = doc ++ "\n\n" ++ exampleUsage
-        exampleUsage = "Example Usage\n```\n" ++ example ++ "\n```\n"
+        exampleUsage = "Example Usage:\n```\n" ++ example ++ "\n```\n"
         withArity arity ctx args =
           if length args == arity
             then callback ctx args

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -59,7 +59,7 @@ makePrim' name maybeArity docString example callback =
             "The primitive `" ++ name ++ "` expected " ++ show a ++
             " arguments, but got " ++ show l ++ ".\n\n" ++ exampleUsage) (info x))
         doc = docString ++ "\n\n" ++ exampleUsage
-        exampleUsage = "Example Usage\n```\n" ++ example ++ "\n```\n"
+        exampleUsage = "Example Usage:\n```\n" ++ example ++ "\n```\n"
 
 primitiveFile :: Primitive
 primitiveFile x@(XObj _ i t) ctx [] =

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -296,49 +296,49 @@ dynamicModule = Env { envBindings = bindings
                     , envFunctionNestingLevel = 0 }
   where path = ["Dynamic"]
         bindings = Map.fromList $
-                    [ addCommand (SymPath path "list?") 1 commandIsList
-                    , addCommand (SymPath path "array?") 1 commandIsArray
-                    , addCommand (SymPath path "symbol?") 1 commandIsSymbol
-                    , addCommand (SymPath path "length") 1 commandLength
-                    , addCommand (SymPath path "car") 1 commandCar
-                    , addCommand (SymPath path "cdr") 1 commandCdr
-                    , addCommand (SymPath path "last") 1 commandLast
-                    , addCommand (SymPath path "all-but-last") 1 commandAllButLast
-                    , addCommand (SymPath path "cons") 2 commandCons
-                    , addCommand (SymPath path "cons-last") 2 commandConsLast
-                    , addCommand (SymPath path "append") 2 commandAppend
-                    , addCommandConfigurable (SymPath path "array") Nothing commandArray
-                    , addCommandConfigurable (SymPath path "list") Nothing commandList
-                    , addCommand (SymPath path "macro-error") 1 commandMacroError
-                    , addCommandConfigurable (SymPath path "macro-log") Nothing commandMacroLog
-                    , addCommandConfigurable (SymPath path "str") Nothing commandStr
-                    , addCommand (SymPath path "not") 1 commandNot
-                    , addCommand (SymPath path "=") 2 commandEq
-                    , addCommand (SymPath path "<") 2 commandLt
-                    , addCommand (SymPath path ">") 2 commandGt
-                    , addCommand (SymPath path "+") 2 commandPlus
-                    , addCommand (SymPath path "-") 2 commandMinus
-                    , addCommand (SymPath path "/") 2 commandDiv
-                    , addCommand (SymPath path "*") 2 commandMul
-                    , addCommand (SymPath path "c") 1 commandC
-                    , addCommand (SymPath path "quit") 0 commandQuit
-                    , addCommand (SymPath path "cat") 0 commandCat
-                    , addCommand (SymPath path "run") 0 commandRunExe
-                    , addCommand (SymPath path "build") 0 (commandBuild False)
-                    , addCommand (SymPath path "reload") 0 commandReload
-                    , addCommand (SymPath path "env") 0 commandListBindings
-                    , addCommandConfigurable (SymPath path "help") Nothing commandHelp
-                    , addCommand (SymPath path "project") 0 commandProject
-                    , addCommand (SymPath path "load") 1 commandLoad
-                    , addCommand (SymPath path "load-once") 1 commandLoadOnce
-                    , addCommand (SymPath path "expand") 1 commandExpand
-                    , addCommand (SymPath path "os") 0 commandOS
-                    , addCommand (SymPath path "system-include") 1 commandAddSystemInclude
-                    , addCommand (SymPath path "relative-include") 1 commandAddRelativeInclude
-                    , addCommand (SymPath path "save-docs-internal") 1 commandSaveDocsInternal
-                    , addCommand (SymPath path "read-file") 1 commandReadFile
-                    , addCommand (SymPath path "write-file") 2 commandWriteFile
-                    , addCommand (SymPath path "bit-width") 0 commandBitWidth
+                    [ addCommand (SymPath path "list?") 1 commandIsList "checks whether the argument is a list." "(list? '()) ; => true"
+                    , addCommand (SymPath path "array?") 1 commandIsArray "checks whether the arguments is an array." "(array? []) ; => true"
+                    , addCommand (SymPath path "symbol?") 1 commandIsSymbol "checks whether the argument is a symbol." "(symbol? 'x) ; => true"
+                    , addCommand (SymPath path "length") 1 commandLength "returns the length of the argument (must be an array, string or list)." "(length '(1 2 3)) ; => 3"
+                    , addCommand (SymPath path "car") 1 commandCar "gets the head of a list or array." "(car '(1 2 3)) ; => 1"
+                    , addCommand (SymPath path "cdr") 1 commandCdr "gets the tail of a list or array." "(cdr '(1 2 3)) ; => '(2 3)"
+                    , addCommand (SymPath path "last") 1 commandLast "gets the last element of a list or array." "(last '(1 2 3)) ; => 3"
+                    , addCommand (SymPath path "all-but-last") 1 commandAllButLast "gets all elements except for the last one of a list or array." "(all-but-last '(1 2 3)) ; => '(1 2)"
+                    , addCommand (SymPath path "cons") 2 commandCons "adds an element to the front of an array or list" "(cons 1 '(2 3)) ; => '(1 2 3)"
+                    , addCommand (SymPath path "cons-last") 2 commandConsLast "adds an element to the back of an array or list" "(cons-last 3 '(1 2)) ; => '(1 2 3)"
+                    , addCommand (SymPath path "append") 2 commandAppend "appends two lists or arrays." "(append '(1 2) '(3 4)) ; => '(1 2 3 4)"
+                    , addCommandConfigurable (SymPath path "array") Nothing commandArray "creates an array from a collection of elements." "(array 1 2 3) ; => [1 2 3]"
+                    , addCommandConfigurable (SymPath path "list") Nothing commandList "creates an array from a collection of elements." "(list 1 2 3) ; => (1 2 3)"
+                    , addCommand (SymPath path "macro-error") 1 commandMacroError "logs an error and errors out of a macro." "(macro-error \"this is wrong\")"
+                    , addCommandConfigurable (SymPath path "macro-log") Nothing commandMacroLog "logs a message in a macro." "(macro-log \"this will be printed at compile time\")"
+                    , addCommandConfigurable (SymPath path "str") Nothing commandStr "stringifies its arguments." "(str 1 \" \" 2 \" \" 3) ; => \"1 2 3\""
+                    , addCommand (SymPath path "not") 1 commandNot "negates its boolean argument." "(not false) ; => true"
+                    , addCommand (SymPath path "=") 2 commandEq "compares its arguments for equality." "(= 1 2) ; => false"
+                    , addCommand (SymPath path "<") 2 commandLt "checks whether its first argument is less than its second." "(< 1 2) ; => true"
+                    , addCommand (SymPath path ">") 2 commandGt "checks whether its first argument is greater than its second." "(> 1 2) ; => false"
+                    , addCommand (SymPath path "+") 2 commandPlus "adds its two arguments." "(+ 1 2) ; => 3"
+                    , addCommand (SymPath path "-") 2 commandMinus "subtracts its second argument from its first." "(- 1 2) ; => -1"
+                    , addCommand (SymPath path "/") 2 commandDiv "divides its first argument by its second." "(/ 4 2) ; => 2"
+                    , addCommand (SymPath path "*") 2 commandMul "multiplies its two arguments." "(* 2 3) ; => 6"
+                    , addCommand (SymPath path "c") 1 commandC "prints the C code emitted for a binding." "(c '(+ 2 3)) ; => int _3 = Int__PLUS_(2, 3);"
+                    , addCommand (SymPath path "quit") 0 commandQuit "quits the program." "(quit)"
+                    , addCommand (SymPath path "cat") 0 commandCat "spits out the generated C code." "(cat)"
+                    , addCommand (SymPath path "run") 0 commandRunExe "runs the built executable." "(run)"
+                    , addCommand (SymPath path "build") 0 (commandBuild False) "builds the current code to an executable." "(build)"
+                    , addCommand (SymPath path "reload") 0 commandReload "reloads all currently loaded files that weren’t marked as only loading once (see `load` and `load-once`)." "(reload)"
+                    , addCommand (SymPath path "env") 0 commandListBindings "lists all current bindings." "(env)"
+                    , addCommandConfigurable (SymPath path "help") Nothing commandHelp "prints help." "(help)"
+                    , addCommand (SymPath path "project") 0 commandProject "prints the current project state." "(project)"
+                    , addCommand (SymPath path "load") 1 commandLoad "loads a file into the current environment." "(load \"myfile.carp\")"
+                    , addCommand (SymPath path "load-once") 1 commandLoadOnce "loads a file and prevents it from being reloaded (see `reload`)." "(load-once \"myfile.carp\")"
+                    , addCommand (SymPath path "expand") 1 commandExpand "expands a macro and prints the result." "(expand '(when true 1)) ; => (if true 1 ())"
+                    , addCommand (SymPath path "os") 0 commandOS "prints the operating system (as returned by the Haskell function `System.Info.os`)." "(os)"
+                    , addCommand (SymPath path "system-include") 1 commandAddSystemInclude "adds a system include, i.e. a C `#include` with angle brackets (`<>`)." "(system-include \"stdint.h\")"
+                    , addCommand (SymPath path "relative-include") 1 commandAddRelativeInclude "adds a relative include, i.e. a C `include` with quotes. It also prepends the current directory." "(relative-include \"myheader.h\")"
+                    , addCommand (SymPath path "save-docs-internal") 1 commandSaveDocsInternal "is the internal companion command to `save-docs`. `save-docs` should be called instead." "(save-docs-internal 'Module)"
+                    , addCommand (SymPath path "read-file") 1 commandReadFile "reads a file into a string." "(read-file \"myfile.txt\")"
+                    , addCommand (SymPath path "write-file") 2 commandWriteFile "writes a string to a file." "(write-file \"myfile\" \"hello there!\")"
+                    , addCommand (SymPath path "bit-width") 0 commandBitWidth "gets the bit width of the platform." "(bit-width) ; => your host machine’s bit width, e.g. 32 or 64"
                     , makePrim "quote" 1 "quotes any value." "(quote x) ; where x is an actual symbol" (\_ ctx [x] -> return (ctx, Right x))
                     , makeVarPrim "file" "returns the file a symbol was defined in." "(file mysymbol)" primitiveFile
                     , makeVarPrim "line" "returns the line a symbol was defined on." "(line mysymbol)" primitiveLine
@@ -374,12 +374,12 @@ dynamicStringModule = Env { envBindings = bindings
                           , envMode = ExternalEnv
                           , envFunctionNestingLevel = 0 }
   where path = ["Dynamic", "String"]
-        bindings = Map.fromList [ addCommand (SymPath path "char-at") 2 commandCharAt
-                                , addCommand (SymPath path "index-of") 2 commandIndexOf
-                                , addCommand (SymPath path "slice") 3 commandSubstring
-                                , addCommand (SymPath path "length") 1 commandStringLength
-                                , addCommand (SymPath path "concat") 1 commandStringConcat
-                                , addCommand (SymPath path "directory") 1 commandStringDirectory
+        bindings = Map.fromList [ addCommand (SymPath path "char-at") 2 commandCharAt "gets the nth character of a string." "(String.char-at \"hi\" 1) ; => \\i"
+                                , addCommand (SymPath path "index-of") 2 commandIndexOf "gets the index of a character in a string (or returns `-1` if the character is not found)." "(index-of \"hi\" \\i) ; => 1"
+                                , addCommand (SymPath path "slice") 3 commandSubstring "creates a substring from a beginning index to an end index." "(String.slice \"hello\" 1 3) ; => \"ell\""
+                                , addCommand (SymPath path "length") 1 commandStringLength "gets the length of a string." "(String.length \"hi\") ; => 2"
+                                , addCommand (SymPath path "concat") 1 commandStringConcat "concatenates a list of strings together." "(String.concat [\"hi \" \"there\"]) ; => \"hi there\""
+                                , addCommand (SymPath path "directory") 1 commandStringDirectory "takes the basename of a string taken to be a filepath.\n\nHistorical note: this is a command because it used to power one of the `include` macros." "(String.directory \"dir/file\") ; => \"dir\""
                                 ]
 
 -- | A submodule of the Dynamic module. Contains functions for working with symbols in the repl or during compilation.
@@ -391,10 +391,10 @@ dynamicSymModule = Env { envBindings = bindings
                        , envMode = ExternalEnv
                        , envFunctionNestingLevel = 0 }
   where path = ["Dynamic", "Symbol"]
-        bindings = Map.fromList [ addCommand (SymPath path "concat") 1 commandSymConcat
-                                , addCommand (SymPath path "prefix") 2 commandSymPrefix
-                                , addCommand (SymPath path "from") 1 commandSymFrom
-                                , addCommand (SymPath path "str") 1 commandSymStr
+        bindings = Map.fromList [ addCommand (SymPath path "concat") 1 commandSymConcat "concatenates a list of symbols together." "(Symbol.concat ['x 'y 'z]) ; => 'xyz"
+                                , addCommand (SymPath path "prefix") 2 commandSymPrefix "prefixes a symbol with a module." "(Symbol.prefix 'Module 'fun) ; => Module.fun"
+                                , addCommand (SymPath path "from") 1 commandSymFrom "converts a variety of types to a symbol." "(Symbol.from true) ; => True"
+                                , addCommand (SymPath path "str") 1 commandSymStr "converts a symbol to a string." "(Symbol.str 'x) ; => \"x\""
                                 ]
 
 -- | A submodule of the Dynamic module. Contains functions for working with the active Carp project.
@@ -406,8 +406,8 @@ dynamicProjectModule = Env { envBindings = bindings
                            , envMode = ExternalEnv
                            , envFunctionNestingLevel = 0 }
   where path = ["Dynamic", "Project"]
-        bindings = Map.fromList [ addCommand (SymPath path "config") 2 commandProjectConfig
-                                , addCommand (SymPath path "get-config") 1 commandProjectGetConfig
+        bindings = Map.fromList [ addCommand (SymPath path "config") 2 commandProjectConfig "sets a project config key." "(Project.config \"paren-balance-hints\" false)"
+                                , addCommand (SymPath path "get-config") 1 commandProjectGetConfig "gets a project config value under a key." "(Project.get-config \"paren-balance-hints\")"
                                 ]
 
 -- | A hack-ish function for converting any enum to an int.


### PR DESCRIPTION
This PR adds documentation capabilities to commands and enforces creating docs during registration. It also documents all of them.

It will probably lightly interfer with #751, because it changes `addCommand` a bit, but it hopefully does not generate too much work.

Cheers