### PR TITLE
Graceful handling of invalid usages of `defmodule`.

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -553,6 +553,10 @@ primitiveDefmodule xobj ctx@(Context env i typeEnv pathStrings proj lastInput ex
                  case result of
                    Left err -> return (newCtx, Left err)
                    Right _ -> return (newCtx, r)
+primitiveDefmodule _ ctx (x:_) =
+  return (evalError ctx ("`defmodule` expects a Symbol, got '" ++ pretty x ++ "' instead.") (info x))
+primitiveDefmodule _ ctx [] =
+  return (evalError ctx "`defmodule` requires a Symbol and some expressions, received none." (Just dummyInfo))
 
 -- | "NORMAL" COMMANDS (just like the ones in Command.hs, but these need access to 'eval', etc.)
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -556,7 +556,7 @@ primitiveDefmodule xobj ctx@(Context env i typeEnv pathStrings proj lastInput ex
 primitiveDefmodule _ ctx (x:_) =
   return (evalError ctx ("`defmodule` expects a Symbol, got '" ++ pretty x ++ "' instead.") (info x))
 primitiveDefmodule _ ctx [] =
-  return (evalError ctx "`defmodule` requires a Symbol and some expressions, received none." (Just dummyInfo))
+  return (evalError ctx "`defmodule` requires at least a Symbol, received none." (Just dummyInfo))
 
 -- | "NORMAL" COMMANDS (just like the ones in Command.hs, but these need access to 'eval', etc.)
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -554,9 +554,9 @@ primitiveDefmodule xobj ctx@(Context env i typeEnv pathStrings proj lastInput ex
                    Left err -> return (newCtx, Left err)
                    Right _ -> return (newCtx, r)
 primitiveDefmodule _ ctx (x:_) =
-  return (evalError ctx ("`defmodule` expects a Symbol, got '" ++ pretty x ++ "' instead.") (info x))
+  return (evalError ctx ("`defmodule` expects a symbol, got '" ++ pretty x ++ "' instead.") (info x))
 primitiveDefmodule _ ctx [] =
-  return (evalError ctx "`defmodule` requires at least a Symbol, received none." (Just dummyInfo))
+  return (evalError ctx "`defmodule` requires at least a symbol, received none." (Just dummyInfo))
 
 -- | "NORMAL" COMMANDS (just like the ones in Command.hs, but these need access to 'eval', etc.)
 

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -622,7 +622,7 @@ primitiveDeftemplate _ ctx [XObj (Sym p@(SymPath _ name) _) pinfo _, ty, XObj (S
       return (evalError ctx ("I do not understand the type form in " ++ pretty ty) (info ty))
 primitiveDeftemplate _ ctx [XObj (Sym _ _) _ _, _, XObj (Str _) _ _, x] =
   argumentErr ctx "deftemplate" "a string" "fourth" x
-primitiveDeftemplate _ ctx [XObj _ _ _, _, x, _] =
+primitiveDeftemplate _ ctx [XObj (Sym _ _) _ _, _, x, _] =
   argumentErr ctx "deftemplate" "a string" "third" x
 primitiveDeftemplate _ ctx [x, _, _, _] =
   argumentErr ctx "deftemplate" "a symbol" "first" x

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -623,6 +623,6 @@ primitiveDeftemplate _ ctx [XObj (Sym p@(SymPath _ name) _) pinfo _, ty, XObj (S
     Nothing ->
       return (evalError ctx ("I do not understand the type form in " ++ pretty ty) (info ty))
 primitiveDeftemplate _ ctx [] =
-  return (evalError ctx "`deftemplate` requires a Symbol, a Type, two Strings." (Just dummyInfo))
+  return (evalError ctx "`deftemplate` requires a symbol, a type, two strings." (Just dummyInfo))
 primitiveDeftemplate _ ctx (x:_) =
   return (evalError ctx ("Invalid `deftemplate` call : " ++ pretty x) (info x))

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -618,11 +618,11 @@ primitiveDeftemplate _ ctx [XObj (Sym p@(SymPath _ name) _) pinfo _, ty, XObj (S
                 meta = existingMeta globalEnv registration
                 env' = envInsertAt globalEnv path (Binder meta registration)
             in return (ctx { contextGlobalEnv = env' }, dynamicNil)
-        (a, Binder _ b) -> trace ("Something weird happened :\n" ++ a ++ "\n" ++ show b) $
-          return (evalError ctx "I'm not sure :/" pinfo)
     Nothing ->
       return (evalError ctx ("I do not understand the type form in " ++ pretty ty) (info ty))
-primitiveDeftemplate _ ctx [] =
-  return (evalError ctx "`deftemplate` requires a symbol, a type, two strings." (Just dummyInfo))
-primitiveDeftemplate _ ctx (x:_) =
-  return (evalError ctx ("Invalid `deftemplate` call : " ++ pretty x) (info x))
+primitiveDeftemplate _ ctx [XObj (Sym _ _) _ _, _, XObj (Str _) _ _, x] =
+  argumentErr ctx "deftemplate" "a string" "fourth" x
+primitiveDeftemplate _ ctx [XObj _ _ _, _, x, _] =
+  argumentErr ctx "deftemplate" "a string" "third" x
+primitiveDeftemplate _ ctx [x, _, _, _] =
+  argumentErr ctx "deftemplate" "a symbol" "first" x


### PR DESCRIPTION
Before :

```
> (defmodule)
carp: src/Eval.hs:(515,1)-(555,48): Non-exhaustive patterns in function primitiveDefmodule

> (defmodule "abc")
carp: src/Eval.hs:(515,1)-(555,48): Non-exhaustive patterns in function primitiveDefmodule

> (defmodule 1)
carp: src/Eval.hs:(515,1)-(555,48): Non-exhaustive patterns in function primitiveDefmodule
```

After : 

```
> (defmodule)
`defmodule` requires at least a Symbol, received none. at dummy-file:0:0.

Traceback:
(defmodule) at REPL:1:1.

> (defmodule "abc")
`defmodule` expects a Symbol, got '"abc"' instead. at REPL:1:12.

Traceback:
(defmodule) at REPL:1:1.

> (defmodule 1)
`defmodule` expects a Symbol, got '1' instead. at REPL:1:12.

Traceback:
(defmodule 1) at REPL:1:1.
```