### PR TITLE
Make dynamic set! and let interplay nicely

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -153,7 +153,7 @@ eval ctx xobj@(XObj o i t) =
                    Right newCtx -> do
                           (finalCtx, evaledBody) <- eval newCtx body
                           let Just e = contextInternalEnv finalCtx
-                          return (finalCtx{contextInternalEnv=envParent (trace (show e) e)},
+                          return (finalCtx{contextInternalEnv=envParent e},
                                   do okBody <- evaledBody
                                      Right okBody)
          where unwrapVar [] acc = acc

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -152,8 +152,10 @@ eval ctx xobj@(XObj o i t) =
                    Left err -> return (ctx, Left err)
                    Right newCtx -> do
                           (finalCtx, evaledBody) <- eval newCtx body
-                          return (finalCtx{contextInternalEnv=i}, do okBody <- evaledBody
-                                                                     Right okBody)
+                          let Just e = contextInternalEnv finalCtx
+                          return (finalCtx{contextInternalEnv=envParent (trace (show e) e)},
+                                  do okBody <- evaledBody
+                                     Right okBody)
          where unwrapVar [] acc = acc
                unwrapVar ((XObj (Sym (SymPath [] x) _) _ _,y):xs) acc = unwrapVar xs ((x,y):acc)
                successiveEval (n, x) =
@@ -820,7 +822,7 @@ specialCommandSet ctx [x@(XObj (Sym path@(SymPath mod n) _) _ _), value] = do
         Nothing -> return (nctx, dynamicNil)
         Just env ->
           if contextPath nctx == mod
-          then return (nctx{contextInternalEnv=Just (envInsertAt env (SymPath [] n) binder)}, dynamicNil)
+          then return (nctx{contextInternalEnv=Just (envReplaceBinding (SymPath [] n) binder env)}, dynamicNil)
           else return (nctx, dynamicNil)
 specialCommandSet ctx [notName, body] =
   return (evalError ctx ("`set!` expected a name as first argument, but got " ++ pretty notName) (info notName))

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -230,6 +230,18 @@ keysInEnvEditDistance path@(SymPath (p : ps) name) env distance =
         Just parent -> keysInEnvEditDistance path parent distance
         Nothing -> []
 
+envReplaceBinding :: SymPath -> Binder -> Env -> Env
+envReplaceBinding s@(SymPath [] name) binder env =
+  case Map.lookup name (envBindings env) of
+    Just _ ->
+      envAddBinding env name binder
+    Nothing ->
+      case envParent env of
+        Just parent -> env {envParent = Just (envReplaceBinding s binder parent)}
+        Nothing -> env
+envReplaceBinding (SymPath p name) xobj e = error "TODO: cannot replace qualified bindings"
+
+
 bindingNames :: Env -> [String]
 bindingNames = concatMap select . envBindings
   where select :: Binder -> [String]

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -17,6 +17,11 @@
                    1))]
     (f 1)))
 
+; make sure let bindings get updated in the right scope
+(defmacro let-and-set []
+  (let-do [x 1]
+    (let [] (set! x 2))
+    (= x 2)))
 
 (use-all Test Vector2 Foo)
 
@@ -45,4 +50,7 @@
                 2
                 (nested-lambdas)
                 "test that nested lambdas can use captured values")
+  (assert-true test
+               (let-and-set)
+               "test that nested let bindings and set! interplay nicely")
 )


### PR DESCRIPTION
This PR fixes the behavior of bot `set!` and `let` in dynamic contexts. It turns out that both of them had subtle bugs that interplay in a fun way. Consider this piece of code

```clojure
(let-do [x 1]
   (let-do [y 2]
     (set! x 2)
     (macro-log x))
   (macro-log x))
```

Before this PR, the first `macro-log` would print `2`, the second one `1`. That is because `set!` actually updated the wrong internal environment, namely the one closest. I added a new environment function `envReplaceBinding` that will go up the environment chain and search for a binding to replace. It does not currently work for prefixed names and if it doesn’t find a value it does nothing. For `set!` this is fine, but it might not be generally desirable behavior.

This is not all we needed to fix, though, because it turns out that `let`, after it was finished, replaced the internal environment with the _old version_  of the internal parent environment. We thus need to get the new version from the new context, and push that in instead, because bindings might be updated through `set!`.

All in all, this was quite subtle, and I’m glad that `eval` is fresh in my mind.

Cheers