### PR TITLE
Mention backreferences in docs for Pattern.substitute

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -9,7 +9,8 @@ Returns `-1` if it doesn’t find a matching pattern.")
 
 Returns `[]` if it doesn’t find a matching pattern.")
   (register find-all (Fn [&Pattern &String] (Array Int)))
-  (doc match-groups "finds the match groups of the first match of a pattern in a string.
+  (doc match-groups "finds the match groups of the first match of a pattern in
+a string.
 
 Returns `[]` if it doesn’t find a matching pattern.")
   (register match-groups (Fn [&Pattern &String] (Array String)))
@@ -17,11 +18,16 @@ Returns `[]` if it doesn’t find a matching pattern.")
 
 Returns `[]` if it doesn’t find a matching pattern.")
   (register match-str (Fn [&Pattern &String] String))
-  (doc global-match "finds all matches of a pattern in a string as a nested array.
+  (doc global-match "finds all matches of a pattern in a string as a nested
+array.
 
 Returns `[]` if it doesn’t find a matching pattern.")
   (register global-match (Fn [&Pattern &String] (Array (Array String))))
-  (doc substitute "finds all matches of a pattern in a string and replaces it by another pattern `n` times.
+  (doc substitute "finds all matches of a pattern in a string and replaces it
+by another pattern `n` times.
+
+The substitute pattern can reference the original pattern by match group
+indices, such as `\1`. This means that backslashes need to be double escaped.
 
 If you want to replace all occurrences of the pattern, use `-1`.")
   (register substitute (Fn [&Pattern &String &String Int] String))
@@ -36,7 +42,8 @@ If you want to replace all occurrences of the pattern, use `-1`.")
   (register delete     (Fn [Pattern] ()))
   (register copy       (Fn [&Pattern] Pattern))
 
-  (doc from-chars "creates a pattern that matches a group of characters from a list of those characters.")
+  (doc from-chars "creates a pattern that matches a group of characters from a
+list of those characters.")
   (defn from-chars [chars]
     (Pattern.init &(str* @"[" (String.from-chars chars) @"]")))
 

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -252,7 +252,8 @@
                     (from-chars chars)
                 </pre>
                 <p class="doc">
-                    <p>creates a pattern that matches a group of characters from a list of those characters.</p>
+                    <p>creates a pattern that matches a group of characters from a
+list of those characters.</p>
 
                 </p>
             </div>
@@ -272,7 +273,8 @@
                     
                 </span>
                 <p class="doc">
-                    <p>finds all matches of a pattern in a string as a nested array.</p>
+                    <p>finds all matches of a pattern in a string as a nested
+array.</p>
 <p>Returns <code>[]</code> if it doesn’t find a matching pattern.</p>
 
                 </p>
@@ -331,7 +333,8 @@
                     
                 </span>
                 <p class="doc">
-                    <p>finds the match groups of the first match of a pattern in a string.</p>
+                    <p>finds the match groups of the first match of a pattern in
+a string.</p>
 <p>Returns <code>[]</code> if it doesn’t find a matching pattern.</p>
 
                 </p>
@@ -451,7 +454,10 @@
                     
                 </span>
                 <p class="doc">
-                    <p>finds all matches of a pattern in a string and replaces it by another pattern <code>n</code> times.</p>
+                    <p>finds all matches of a pattern in a string and replaces it
+by another pattern <code>n</code> times.</p>
+<p>The substitute pattern can reference the original pattern by match group
+indices, such as <code>\1</code>. This means that backslashes need to be double escaped.</p>
 <p>If you want to replace all occurrences of the pattern, use <code>-1</code>.</p>
 
                 </p>


### PR DESCRIPTION
As came up in the chat, the docs for `Pattern.substitute` did not mention the possibility to reference match groups. This PR fixes that.

Cheers