### PR TITLE
Cross-compiling via zig

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -548,26 +548,6 @@
 (defmacro update! [x f]
   (list 'set! x (list f x)))
 
-(defmacro mac-only [:rest forms]
-  (if (= "darwin" (os))
-    (eval (cons (quote do) forms))
-    ()))
-
-(defmacro linux-only [:rest forms]
-  (if (= "linux" (os))
-    (eval (cons (quote do) forms))
-    ()))
-
-(defmacro windows-only [:rest forms]
-  (if (or (= "windows" (os)) (= "mingw32" (os)))
-    (eval (cons (quote do) forms))
-    ()))
-
-(defmacro not-on-windows [:rest forms]
-  (if (not (or (= "windows" (os)) (= "mingw32" (os))))
-    (eval (cons (quote do) forms))
-    ()))
-
 (defndynamic use-all-fn [names]
   (if (= (length names) 0)
     (macro-error "Trying to call use-all without arguments")
@@ -713,3 +693,78 @@ The expression must be evaluable at compile time.")
 (doc inline-c "inlines some custom C code.")
 (defmacro inline-c [name defcode declcode]
   (list 'deftemplate name (list) (eval defcode) (eval declcode)))
+
+(defndynamic windows-target? []
+  (case (target)
+    "native" (or (= "windows" (os)) (= "mingw32" (os)))
+    "aarch64_be-windows-gnu" true
+    "aarch64-windows-gnu" true
+    "armeb-windows-gnu" true
+    "arm-windows-gnu" true
+    "i386-windows-gnu" true
+    "x86_64-windows-gnu" true
+    false))
+
+(defndynamic linux-target? []
+  (case (target)
+    "native" (= "linux" (os))
+    "aarch64_be-linux-gnu" true
+    "aarch64_be-linux-musl" true
+    "aarch64-linux-gnu" true
+    "aarch64-linux-musl" true
+    "armeb-linux-gnueabi" true
+    "armeb-linux-gnueabihf" true
+    "armeb-linux-musleabi" true
+    "armeb-linux-musleabihf" true
+    "arm-linux-gnueabi" true
+    "arm-linux-gnueabihf" true
+    "arm-linux-musleabi" true
+    "arm-linux-musleabihf" true
+    "i386-linux-gnu" true
+    "i386-linux-musl" true
+    "mips64el-linux-gnuabi64" true
+    "mips64el-linux-gnuabin32" true
+    "mips64el-linux-musl" true
+    "mips64-linux-gnuabi64" true
+    "mips64-linux-gnuabin32" true
+    "mips64-linux-musl" true
+    "mipsel-linux-gnu" true
+    "mipsel-linux-musl" true
+    "mips-linux-gnu" true
+    "mips-linux-musl" true
+    "powerpc64le-linux-gnu" true
+    "powerpc64le-linux-musl" true
+    "powerpc64-linux-gnu" true
+    "powerpc64-linux-musl" true
+    "powerpc-linux-gnu" true
+    "powerpc-linux-musl" true
+    "riscv64-linux-gnu" true
+    "riscv64-linux-musl" true
+    "s390x-linux-gnu" true
+    "s390x-linux-musl" true
+    "sparc-linux-gnu" true
+    "sparcv9-linux-gnu" true
+    "wasm32-freestanding-musl" true
+    "x86_64-linux-gnu" true
+    "x86_64-linux-gnux32" true
+    "x86_64-linux-musl" true
+    false))
+
+(defndynamic mac-target? []
+  (= "darwin" (os)))
+
+(defmacro mac-only [:rest forms]
+  (when (mac-target?)
+    (eval (cons (quote do) forms))))
+
+(defmacro linux-only [:rest forms]
+  (when (linux-target?)
+    (eval (cons (quote do) forms))))
+
+(defmacro windows-only [:rest forms]
+  (when (windows-target?)
+    (eval (cons (quote do) forms))))
+
+(defmacro not-on-windows [:rest forms]
+  (unless (windows-target?)
+    (eval (cons (quote do) forms))))

--- a/core/core.h
+++ b/core/core.h
@@ -1,7 +1,8 @@
-#if (defined WIN32 || defined _WIN32 || defined __WIN32) && \
-    !defined __CYGWIN__ && !defined __MINGW32__
+#if defined _WIN32
 #include <windows.h>
-typedef SSIZE_T ssize_t;
+#if !defined __CYGWIN__ && !defined __MINGW32__
+typedef intptr_t ssize_t;
+#endif
 #endif
 #ifndef _WIN32
 #include <unistd.h>

--- a/default.nix
+++ b/default.nix
@@ -67,7 +67,7 @@ in
 
   if pkgs.lib.inNixShell
   then drv.env.overrideAttrs (o: {
-    buildInputs = with pkgs; o.buildInputs ++ [ haskellPackages.cabal-install clang gdb ]
+    buildInputs = with pkgs; o.buildInputs ++ [ haskellPackages.cabal-install clang gdb zig ]
                   ++ linuxOnly [ flamegraph linuxPackages.perf ];
   })
   else drv

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -431,6 +431,7 @@ commandHelp ctx [] =
               putStrLn "--optimize                       - Removes safety checks and runs the C-compiler with the '-O3' flag."
               putStrLn "--check                          - Report all errors found in a machine readable way."
               putStrLn "--generate-only                  - Don't compile the C source."
+              putStrLn "--cross <target>                 - Cross-compile for target."
               return (ctx, dynamicNil)
 
 commandHelp ctx args =
@@ -446,6 +447,11 @@ commandProject ctx args = do
 commandOS :: CommandCallback
 commandOS ctx _ =
   return (ctx, (Right (XObj (Str os) (Just dummyInfo) (Just StringTy))))
+
+-- | Command for getting the name of the operating system you're on.
+commandTarget :: CommandCallback
+commandTarget ctx _ =
+  return (ctx, (Right (XObj (Str $ show $ projectTarget $ contextProj ctx) (Just dummyInfo) (Just StringTy))))
 
 -- | Command for adding a header file include to the project.
 commandAddInclude :: (String -> Includer) -> CommandCallback

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -625,7 +625,10 @@ showLoader :: (FilePath, ReloadMode) -> String
 showLoader (fp, DoesReload) = fp
 showLoader (fp, Frozen) = fp ++ " (frozen)"
 
-
+data Target = Native | Target String
+instance Show Target where
+  show Native = "native"
+  show (Target x) = x
 
 -- | Project (represents a lot of useful information for working at the REPL and building executables)
 data Project = Project { projectTitle :: String
@@ -648,6 +651,7 @@ data Project = Project { projectTitle :: String
                        , projectCarpSearchPaths :: [FilePath]
                        , projectPrintTypedAST :: Bool
                        , projectCompiler :: String
+                       , projectTarget :: Target
                        , projectCore :: Bool
                        , projectEchoCompilationCommand :: Bool
                        , projectCanExecute :: Bool
@@ -682,6 +686,7 @@ instance Show Project where
         searchPaths
         printTypedAST
         compiler
+        target
         core
         echoCompilationCommand
         canExecute
@@ -692,6 +697,7 @@ instance Show Project where
        ) =
     unlines [ "Title: " ++ title
             , "Compiler: " ++ compiler
+            , "Target: " ++ show target
             , "Includes:\n    " ++ joinWith "\n    " (map show incl)
             , "Cflags:\n    " ++ joinWith "\n    " cFlags
             , "Library flags:\n    " ++ joinWith "\n    " libFlags

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -333,6 +333,7 @@ dynamicModule = Env { envBindings = bindings
                     , addCommand (SymPath path "load-once") 1 commandLoadOnce "loads a file and prevents it from being reloaded (see `reload`)." "(load-once \"myfile.carp\")"
                     , addCommand (SymPath path "expand") 1 commandExpand "expands a macro and prints the result." "(expand '(when true 1)) ; => (if true 1 ())"
                     , addCommand (SymPath path "os") 0 commandOS "prints the operating system (as returned by the Haskell function `System.Info.os`)." "(os)"
+                    , addCommand (SymPath path "target") 0 commandTarget "prints the target platform." "(target)"
                     , addCommand (SymPath path "system-include") 1 commandAddSystemInclude "adds a system include, i.e. a C `#include` with angle brackets (`<>`)." "(system-include \"stdint.h\")"
                     , addCommand (SymPath path "relative-include") 1 commandAddRelativeInclude "adds a relative include, i.e. a C `include` with quotes. It also prepends the current directory." "(relative-include \"myheader.h\")"
                     , addCommand (SymPath path "save-docs-internal") 1 commandSaveDocsInternal "is the internal companion command to `save-docs`. `save-docs` should be called instead." "(save-docs-internal 'Module)"


### PR DESCRIPTION
This is an attempt to add cross-compiling support (in this case from Linux to Windows, but should be easy to extend to other directions) via zig.

The following command on Linux

```
./carp.sh --cross x86_64-windows-gnu -b examples/basics.carp
```

Generated a PE32 executable (haven't tried to execute it though).

