### PR TITLE
Fix the `inline-c` macro to avoid using a reserved keyword as parameter.

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -711,5 +711,5 @@ The expression must be evaluable at compile time.")
     (list 'fn [x] (comp-internal x fns))))
 
 (doc inline-c "inlines some custom C code.")
-(defmacro inline-c [name def decl]
-  (list 'deftemplate name (list) (eval def) (eval decl)))
+(defmacro inline-c [name defcode declcode]
+  (list 'deftemplate name (list) (eval defcode) (eval declcode)))


### PR DESCRIPTION
The title says it all. Tiny fix for `inline-c`.