### PR TITLE
Makes test bash script running on MSYS/Git Bash

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,8 +2,9 @@ name: Windows CI
 
 on:
   push:
-    branches-ignore:
-      - '**'
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
@@ -50,4 +51,5 @@ jobs:
         run: stack test
 
       - name: Run Carp Tests
-        run: ./run_carp_tests.ps1
+        shell: bash
+        run: ./run_carp_tests.sh --no_sdl

--- a/benchmarks.sh
+++ b/benchmarks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e; # will make the script stop if there are any errors
 

--- a/carp.sh
+++ b/carp.sh
@@ -2,9 +2,9 @@ if [ -z "$CARP" ]
 then
     if [ -z "$NIX_CC" ]
     then
-	CARP="stack exec carp --"
+	CARP="stack exec carp"
     else
-	CARP="cabal -v0 run carp --"
+	CARP="cabal -v0 run carp"
     fi
 fi
-$CARP $*
+$CARP "--" $*

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), (Ref (Array a) b)] Bool)
+                    (Fn [(Ref (Array a) b), (Ref (Array a) b)] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
@@ -186,7 +186,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (Array a) b)] Bool)
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (Array a) b)] Bool)
                 </p>
                 <pre class="args">
                     (all? f a)
@@ -206,7 +206,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [Int] (Array a))
+                    (Fn [Int] (Array a))
                 </p>
                 <span>
                     
@@ -226,7 +226,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (Array a) b)] Bool)
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (Array a) b)] Bool)
                 </p>
                 <pre class="args">
                     (any? f a)
@@ -246,7 +246,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Array a), Int, a] (Array a))
+                    (Fn [(Array a), Int, a] (Array a))
                 </p>
                 <span>
                     
@@ -266,7 +266,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int, a] ())
+                    (Fn [(Ref (Array a) b), Int, a] ())
                 </p>
                 <span>
                     
@@ -286,7 +286,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int, a] ())
+                    (Fn [(Ref (Array a) b), Int, a] ())
                 </p>
                 <span>
                     
@@ -306,7 +306,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Array a), Int, (Ref (λ [(Ref a b)] a c) d)] (Array a))
+                    (Fn [(Array a), Int, (Ref (Fn [(Ref a b)] a c) d)] (Array a))
                 </p>
                 <pre class="args">
                     (aupdate a i f)
@@ -326,7 +326,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int, (Ref (λ [(Ref a b)] a c) d)] ())
+                    (Fn [(Ref (Array a) b), Int, (Ref (Fn [(Ref a b)] a c) d)] ())
                 </p>
                 <pre class="args">
                     (aupdate! a i f)
@@ -346,7 +346,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array (Array a)) b)] (Array a))
+                    (Fn [(Ref (Array (Array a)) b)] (Array a))
                 </p>
                 <pre class="args">
                     (concat xs)
@@ -366,7 +366,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), (Ref a b)] Bool)
+                    (Fn [(Ref (Array a) b), (Ref a b)] Bool)
                 </p>
                 <pre class="args">
                     (contains? arr el)
@@ -386,7 +386,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] (Array a))
+                    (Fn [(Ref (Array a) b)] (Array a))
                 </p>
                 <span>
                     
@@ -406,7 +406,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (Array a) e)] (Array a))
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (Array a) e)] (Array a))
                 </p>
                 <pre class="args">
                     (copy-filter f a)
@@ -427,7 +427,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] c d) e), (Ref (Array a) b)] (Array c))
+                    (Fn [(Ref (Fn [(Ref a b)] c d) e), (Ref (Array a) b)] (Array c))
                 </p>
                 <pre class="args">
                     (copy-map f a)
@@ -448,7 +448,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Array a)] ())
+                    (Fn [(Array a)] ())
                 </p>
                 <span>
                     
@@ -468,7 +468,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), (Ref a b)] Int)
+                    (Fn [(Ref (Array a) b), (Ref a b)] Int)
                 </p>
                 <pre class="args">
                     (element-count a e)
@@ -488,7 +488,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] Bool)
+                    (Fn [(Ref (Array a) b)] Bool)
                 </p>
                 <pre class="args">
                     (empty? a)
@@ -508,7 +508,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Array a)] (Array a))
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Array a)] (Array a))
                 </p>
                 <span>
                     
@@ -528,7 +528,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [a] a b) c), (Array a)] (Array a))
+                    (Fn [(Ref (Fn [a] a b) c), (Array a)] (Array a))
                 </p>
                 <span>
                     
@@ -548,7 +548,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] (Array (Pair Int a)))
+                    (Fn [(Ref (Array a) b)] (Array (Pair Int a)))
                 </p>
                 <pre class="args">
                     (enumerated xs)
@@ -568,7 +568,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (Array a) b)] (Maybe a))
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (Array a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (find f a)
@@ -589,7 +589,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (Array a) b)] (Maybe Int))
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (Array a) b)] (Maybe Int))
                 </p>
                 <pre class="args">
                     (find-index f a)
@@ -610,7 +610,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] (Maybe a))
+                    (Fn [(Ref (Array a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (first a)
@@ -631,7 +631,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] (Array a))
+                    (Fn [(Ref (StaticArray a) b)] (Array a))
                 </p>
                 <pre class="args">
                     (from-static sarr)
@@ -651,7 +651,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), (Ref a b)] (Maybe Int))
+                    (Fn [(Ref (Array a) b), (Ref a b)] (Maybe Int))
                 </p>
                 <pre class="args">
                     (index-of a e)
@@ -672,7 +672,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] (Maybe a))
+                    (Fn [(Ref (Array a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (last a)
@@ -693,7 +693,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] Int)
+                    (Fn [(Ref (Array a) b)] Int)
                 </p>
                 <span>
                     
@@ -713,7 +713,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] (Maybe a))
+                    (Fn [(Ref (Array a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (maximum xs)
@@ -734,7 +734,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] (Maybe a))
+                    (Fn [(Ref (Array a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (minimum xs)
@@ -755,7 +755,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int] (Maybe a))
+                    (Fn [(Ref (Array a) b), Int] (Maybe a))
                 </p>
                 <pre class="args">
                     (nth xs index)
@@ -776,7 +776,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int] (Array (Array a)))
+                    (Fn [(Ref (Array a) b), Int] (Array (Array a)))
                 </p>
                 <pre class="args">
                     (partition arr n)
@@ -813,7 +813,7 @@ For example:
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Array a)] (Array a))
+                    (Fn [(Array a)] (Array a))
                 </p>
                 <span>
                     
@@ -833,7 +833,7 @@ For example:
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] a)
+                    (Fn [(Ref (Array a) b)] a)
                 </p>
                 <span>
                     
@@ -853,7 +853,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), (Ref (λ [(Ref a b)] Bool c) d)] Int)
+                    (Fn [(Ref (Array a) b), (Ref (Fn [(Ref a b)] Bool c) d)] Int)
                 </p>
                 <pre class="args">
                     (predicate-count a pred)
@@ -873,7 +873,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref a b), Int] a)
+                    (Fn [(Ref a b), Int] a)
                 </p>
                 <pre class="args">
                     (prefix xs end-index)
@@ -893,7 +893,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] String)
+                    (Fn [(Ref (Array a) b)] String)
                 </p>
                 <pre class="args">
                     (prn x)
@@ -912,7 +912,7 @@ For example:
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Array a), a] (Array a))
+                    (Fn [(Array a), a] (Array a))
                 </p>
                 <span>
                     
@@ -932,7 +932,7 @@ For example:
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), a] ())
+                    (Fn [(Ref (Array a) b), a] ())
                 </p>
                 <span>
                     
@@ -952,7 +952,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a, a, a] (Array a))
+                    (Fn [a, a, a] (Array a))
                 </p>
                 <pre class="args">
                     (range start end step)
@@ -972,7 +972,7 @@ For example:
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Array a)] (Ptr a))
+                    (Fn [(Array a)] (Ptr a))
                 </p>
                 <span>
                     
@@ -992,7 +992,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [a, (Ref b c)] a d) e), a, (Ref (Array b) c)] a)
+                    (Fn [(Ref (Fn [a, (Ref b c)] a d) e), a, (Ref (Array b) c)] a)
                 </p>
                 <pre class="args">
                     (reduce f x xs)
@@ -1017,7 +1017,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref a b), (Array a)] (Array a))
+                    (Fn [(Ref a b), (Array a)] (Array a))
                 </p>
                 <pre class="args">
                     (remove el arr)
@@ -1037,7 +1037,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, (Array a)] (Array a))
+                    (Fn [Int, (Array a)] (Array a))
                 </p>
                 <pre class="args">
                     (remove-nth i arr)
@@ -1057,7 +1057,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, (Ref (λ [] a b) c)] (Array a))
+                    (Fn [Int, (Ref (Fn [] a b) c)] (Array a))
                 </p>
                 <pre class="args">
                     (repeat n f)
@@ -1077,7 +1077,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, (λ [Int] a b)] (Array a))
+                    (Fn [Int, (Fn [Int] a b)] (Array a))
                 </p>
                 <pre class="args">
                     (repeat-indexed n f)
@@ -1098,7 +1098,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, (Ref a b)] (Array a))
+                    (Fn [Int, (Ref a b)] (Array a))
                 </p>
                 <pre class="args">
                     (replicate n e)
@@ -1118,7 +1118,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Array a)] (Array a))
+                    (Fn [(Array a)] (Array a))
                 </p>
                 <pre class="args">
                     (reverse a)
@@ -1138,7 +1138,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int, Int] (Array a))
+                    (Fn [(Ref (Array a) b), Int, Int] (Array a))
                 </p>
                 <pre class="args">
                     (slice xs start-index end-index)
@@ -1158,7 +1158,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Array a)] (Array a))
+                    (Fn [(Array a)] (Array a))
                 </p>
                 <pre class="args">
                     (sort arr)
@@ -1178,7 +1178,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] ())
+                    (Fn [(Ref (Array a) b)] ())
                 </p>
                 <pre class="args">
                     (sort! arr)
@@ -1198,7 +1198,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Array a), (Ref (λ [(Ref a b), (Ref a b)] Bool c) d)] (Array a))
+                    (Fn [(Array a), (Ref (Fn [(Ref a b), (Ref a b)] Bool c) d)] (Array a))
                 </p>
                 <pre class="args">
                     (sort-by arr f)
@@ -1218,7 +1218,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), (Ref (λ [(Ref a b), (Ref a b)] Bool c) d)] ())
+                    (Fn [(Ref (Array a) b), (Ref (Fn [(Ref a b), (Ref a b)] Bool c) d)] ())
                 </p>
                 <pre class="args">
                     (sort-by! arr f)
@@ -1238,7 +1238,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] (Array a))
+                    (Fn [(Ref (Array a) b)] (Array a))
                 </p>
                 <pre class="args">
                     (sorted arr)
@@ -1258,7 +1258,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), (Ref (λ [(Ref a c), (Ref a c)] Bool d) e)] (Array a))
+                    (Fn [(Ref (Array a) b), (Ref (Fn [(Ref a c), (Ref a c)] Bool d) e)] (Array a))
                 </p>
                 <pre class="args">
                     (sorted-by arr f)
@@ -1278,7 +1278,7 @@ For example:
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] String)
+                    (Fn [(Ref (Array a) b)] String)
                 </p>
                 <span>
                     
@@ -1298,7 +1298,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int] (Array a))
+                    (Fn [(Ref (Array a) b), Int] (Array a))
                 </p>
                 <pre class="args">
                     (suffix xs start-index)
@@ -1318,7 +1318,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] a)
+                    (Fn [(Ref (Array a) b)] a)
                 </p>
                 <pre class="args">
                     (sum xs)
@@ -1338,7 +1338,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array (Array a)) b)] Int)
+                    (Fn [(Ref (Array (Array a)) b)] Int)
                 </p>
                 <pre class="args">
                     (sum-length xs)
@@ -1358,7 +1358,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Array a), Int, Int] (Array a))
+                    (Fn [(Array a), Int, Int] (Array a))
                 </p>
                 <pre class="args">
                     (swap a i j)
@@ -1378,7 +1378,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int, Int] ())
+                    (Fn [(Ref (Array a) b), Int, Int] ())
                 </p>
                 <pre class="args">
                     (swap! a i j)
@@ -1398,7 +1398,7 @@ For example:
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a, (Ref (λ [a] Bool b) c), (Ref (λ [a] a b) d)] (Array a))
+                    (Fn [a, (Ref (Fn [a] Bool b) c), (Ref (Fn [a] a b) d)] (Array a))
                 </p>
                 <pre class="args">
                     (unreduce start test step)
@@ -1425,7 +1425,7 @@ no longer satisfy <code>test</code>. The initial value is <code>start</code>.</p
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] a)
+                    (Fn [(Ref (Array a) b)] a)
                 </p>
                 <pre class="args">
                     (unsafe-first a)
@@ -1446,7 +1446,7 @@ no longer satisfy <code>test</code>. The initial value is <code>start</code>.</p
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] a)
+                    (Fn [(Ref (Array a) b)] a)
                 </p>
                 <pre class="args">
                     (unsafe-last a)
@@ -1467,7 +1467,7 @@ no longer satisfy <code>test</code>. The initial value is <code>start</code>.</p
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b), Int] (Ref a b))
+                    (Fn [(Ref (Array a) b), Int] (Ref a b))
                 </p>
                 <span>
                     
@@ -1487,7 +1487,7 @@ no longer satisfy <code>test</code>. The initial value is <code>start</code>.</p
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref a (Array b))] (Ptr b))
+                    (Fn [(Ref a (Array b))] (Ptr b))
                 </p>
                 <span>
                     
@@ -1507,7 +1507,7 @@ no longer satisfy <code>test</code>. The initial value is <code>start</code>.</p
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Array a))
+                    (Fn [] (Array a))
                 </p>
                 <pre class="args">
                     (zero)
@@ -1527,7 +1527,7 @@ no longer satisfy <code>test</code>. The initial value is <code>start</code>.</p
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b), (Ref c d)] e f) g), (Ref (Array a) b), (Ref (Array c) d)] (Array e))
+                    (Fn [(Ref (Fn [(Ref a b), (Ref c d)] e f) g), (Ref (Array a) b), (Ref (Array c) d)] (Array e))
                 </p>
                 <pre class="args">
                     (zip f a b)

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [] a b)] ())
+                    (Fn [(Fn [] a b)] ())
                 </p>
                 <pre class="args">
                     (bench f)
@@ -186,7 +186,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] ())
+                    (Fn [Int] ())
                 </p>
                 <pre class="args">
                     (set-min-runs! n)

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Bool, Bool] Bool)
+                    (Fn [Bool, Bool] Bool)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Bool, Bool] Bool)
+                    (Fn [Bool, Bool] Bool)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Bool a)] Bool)
+                    (Fn [(Ref Bool a)] Bool)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Bool] String)
+                    (Fn [(Ref String a), Bool] String)
                 </p>
                 <span>
                     
@@ -242,7 +242,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Bool a)] Int)
+                    (Fn [(Ref Bool a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -261,7 +261,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Bool] Bool)
+                    (Fn [Bool] Bool)
                 </p>
                 <span>
                     
@@ -280,7 +280,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Bool, Bool] Bool)
+                    (Fn [Bool, Bool] Bool)
                 </p>
                 <span>
                     
@@ -299,7 +299,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Bool] String)
+                    (Fn [Bool] String)
                 </p>
                 <pre class="args">
                     (prn x)
@@ -318,7 +318,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Bool] String)
+                    (Fn [Bool] String)
                 </p>
                 <span>
                     

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -242,7 +242,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Bool)
+                    (Fn [Byte, Byte] Bool)
                 </p>
                 <span>
                     
@@ -261,7 +261,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Bool)
+                    (Fn [Byte, Byte] Bool)
                 </p>
                 <span>
                     
@@ -280,7 +280,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Bool)
+                    (Fn [Byte, Byte] Bool)
                 </p>
                 <span>
                     
@@ -299,7 +299,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Byte a), (Ref Byte b)] Byte)
+                    (Fn [(Ref Byte a), (Ref Byte b)] Byte)
                 </p>
                 <pre class="args">
                     (add-ref x y)
@@ -318,7 +318,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -337,7 +337,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte] Byte)
+                    (Fn [Byte] Byte)
                 </p>
                 <span>
                     
@@ -356,7 +356,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -375,7 +375,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -394,7 +394,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -413,7 +413,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -432,7 +432,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a, a, a] a)
+                    (Fn [a, a, a] a)
                 </p>
                 <pre class="args">
                     (clamp min max val)
@@ -451,7 +451,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Byte a)] Byte)
+                    (Fn [(Ref Byte a)] Byte)
                 </p>
                 <span>
                     
@@ -470,7 +470,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte] Byte)
+                    (Fn [Byte] Byte)
                 </p>
                 <span>
                     
@@ -489,7 +489,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Byte] Bool)
+                    (Fn [Byte] Bool)
                 </p>
                 <pre class="args">
                     (even? a)
@@ -508,7 +508,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Byte] String)
+                    (Fn [(Ref String a), Byte] String)
                 </p>
                 <span>
                     
@@ -527,7 +527,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Byte)
+                    (Fn [Int] Byte)
                 </p>
                 <span>
                     
@@ -546,7 +546,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Byte)
+                    (Fn [(Ref String a)] Byte)
                 </p>
                 <span>
                     
@@ -565,7 +565,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Byte a)] Int)
+                    (Fn [(Ref Byte a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -584,7 +584,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte] Byte)
+                    (Fn [Byte] Byte)
                 </p>
                 <span>
                     
@@ -603,7 +603,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <span>
                     
@@ -622,7 +622,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Byte] Bool)
+                    (Fn [Byte] Bool)
                 </p>
                 <pre class="args">
                     (odd? a)
@@ -641,7 +641,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <pre class="args">
                     (pow x y)
@@ -661,7 +661,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Byte] String)
+                    (Fn [Byte] String)
                 </p>
                 <pre class="args">
                     (prn x)
@@ -680,7 +680,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Byte)
+                    (Fn [] Byte)
                 </p>
                 <pre class="args">
                     (random)
@@ -699,7 +699,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Byte, Byte] Byte)
+                    (Fn [Byte, Byte] Byte)
                 </p>
                 <pre class="args">
                     (random-between lower upper)
@@ -718,7 +718,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte] String)
+                    (Fn [Byte] String)
                 </p>
                 <span>
                     
@@ -737,7 +737,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Byte] Int)
+                    (Fn [Byte] Int)
                 </p>
                 <span>
                     
@@ -756,7 +756,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Byte)
+                    (Fn [] Byte)
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Char, Char] Bool)
+                    (Fn [Char, Char] Bool)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Char, Char] Bool)
+                    (Fn [Char, Char] Bool)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Char, Char] Bool)
+                    (Fn [Char, Char] Bool)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Char] Bool)
+                    (Fn [Char] Bool)
                 </p>
                 <pre class="args">
                     (alpha? c)
@@ -243,7 +243,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Char] Bool)
+                    (Fn [Char] Bool)
                 </p>
                 <pre class="args">
                     (alphanum? c)
@@ -263,7 +263,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Char a)] Char)
+                    (Fn [(Ref Char a)] Char)
                 </p>
                 <span>
                     
@@ -282,7 +282,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Char] String)
+                    (Fn [(Ref String a), Char] String)
                 </p>
                 <span>
                     
@@ -301,7 +301,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Char)
+                    (Fn [Int] Char)
                 </p>
                 <span>
                     
@@ -320,7 +320,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Char a)] Int)
+                    (Fn [(Ref Char a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -339,7 +339,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Char] Bool)
+                    (Fn [Char] Bool)
                 </p>
                 <pre class="args">
                     (lower-case? c)
@@ -359,7 +359,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Char a)] Int)
+                    (Fn [(Ref Char a)] Int)
                 </p>
                 <pre class="args">
                     (meaning char-ref)
@@ -379,7 +379,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Char] Bool)
+                    (Fn [Char] Bool)
                 </p>
                 <pre class="args">
                     (num? c)
@@ -399,7 +399,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Char] String)
+                    (Fn [Char] String)
                 </p>
                 <span>
                     
@@ -418,7 +418,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Char)
+                    (Fn [] Char)
                 </p>
                 <pre class="args">
                     (random)
@@ -437,7 +437,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Char, Char] Char)
+                    (Fn [Char, Char] Char)
                 </p>
                 <pre class="args">
                     (random-between a b)
@@ -456,7 +456,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Char] String)
+                    (Fn [Char] String)
                 </p>
                 <span>
                     
@@ -475,7 +475,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Char] Int)
+                    (Fn [Char] Int)
                 </p>
                 <span>
                     
@@ -494,7 +494,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Char] Bool)
+                    (Fn [Char] Bool)
                 </p>
                 <pre class="args">
                     (upper-case? c)
@@ -514,7 +514,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Char)
+                    (Fn [] Char)
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -207,7 +207,7 @@ immediately, raising a <code>SIGABRT</code> if it fails.</p>
                     external
                 </div>
                 <p class="sig">
-                    (λ [a] ())
+                    (Fn [a] ())
                 </p>
                 <span>
                     
@@ -227,7 +227,7 @@ immediately, raising a <code>SIGABRT</code> if it fails.</p>
                     external
                 </div>
                 <p class="sig">
-                    (λ [Bool] ())
+                    (Fn [Bool] ())
                 </p>
                 <span>
                     
@@ -246,7 +246,7 @@ immediately, raising a <code>SIGABRT</code> if it fails.</p>
                     external
                 </div>
                 <p class="sig">
-                    (λ [] Long)
+                    (Fn [] Long)
                 </p>
                 <span>
                     
@@ -285,7 +285,7 @@ immediately, raising a <code>SIGABRT</code> if it fails.</p>
                     external
                 </div>
                 <p class="sig">
-                    (λ [] ())
+                    (Fn [] ())
                 </p>
                 <span>
                     

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <span>
                     
@@ -242,7 +242,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Bool)
+                    (Fn [Double, Double] Bool)
                 </p>
                 <span>
                     
@@ -261,7 +261,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Bool)
+                    (Fn [Double, Double] Bool)
                 </p>
                 <span>
                     
@@ -280,7 +280,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Bool)
+                    (Fn [Double, Double] Bool)
                 </p>
                 <span>
                     
@@ -318,7 +318,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -337,7 +337,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -356,7 +356,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Double a), (Ref Double b)] Double)
+                    (Fn [(Ref Double a), (Ref Double b)] Double)
                 </p>
                 <pre class="args">
                     (add-ref x y)
@@ -375,7 +375,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a, a] Bool)
+                    (Fn [a, a] Bool)
                 </p>
                 <pre class="args">
                     (approx x y)
@@ -396,7 +396,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -415,7 +415,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -434,7 +434,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <span>
                     
@@ -453,7 +453,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -472,7 +472,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Double a)] Double)
+                    (Fn [(Ref Double a)] Double)
                 </p>
                 <span>
                     
@@ -491,7 +491,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -510,7 +510,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -529,7 +529,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <pre class="args">
                     (dec x)
@@ -567,7 +567,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -586,7 +586,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -605,7 +605,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Double] String)
+                    (Fn [(Ref String a), Double] String)
                 </p>
                 <span>
                     
@@ -624,7 +624,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, (Ref Int a)] Double)
+                    (Fn [Double, (Ref Int a)] Double)
                 </p>
                 <span>
                     
@@ -643,7 +643,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Double)
+                    (Fn [Float] Double)
                 </p>
                 <span>
                     
@@ -662,7 +662,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Double)
+                    (Fn [Int] Double)
                 </p>
                 <span>
                     
@@ -681,7 +681,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] Double)
+                    (Fn [Long] Double)
                 </p>
                 <span>
                     
@@ -700,7 +700,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Double)
+                    (Fn [(Ref String a)] Double)
                 </p>
                 <span>
                     
@@ -719,7 +719,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Double a)] Int)
+                    (Fn [(Ref Double a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -738,7 +738,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <pre class="args">
                     (inc x)
@@ -757,7 +757,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Int] Double)
+                    (Fn [Double, Int] Double)
                 </p>
                 <span>
                     
@@ -776,7 +776,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -795,7 +795,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -814,7 +814,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <span>
                     
@@ -833,7 +833,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, (Ref Double a)] Double)
+                    (Fn [Double, (Ref Double a)] Double)
                 </p>
                 <span>
                     
@@ -852,7 +852,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -890,7 +890,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <span>
                     
@@ -909,7 +909,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Double)
+                    (Fn [] Double)
                 </p>
                 <pre class="args">
                     (random)
@@ -928,7 +928,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Double, Double] Double)
+                    (Fn [Double, Double] Double)
                 </p>
                 <pre class="args">
                     (random-between lower upper)
@@ -947,7 +947,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -966,7 +966,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -985,7 +985,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -1004,7 +1004,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] String)
+                    (Fn [Double] String)
                 </p>
                 <span>
                     
@@ -1023,7 +1023,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -1042,7 +1042,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Double)
+                    (Fn [Double] Double)
                 </p>
                 <span>
                     
@@ -1061,7 +1061,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Long)
+                    (Fn [Double] Long)
                 </p>
                 <span>
                     
@@ -1080,7 +1080,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Float)
+                    (Fn [Double] Float)
                 </p>
                 <span>
                     
@@ -1099,7 +1099,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Int)
+                    (Fn [Double] Int)
                 </p>
                 <span>
                     
@@ -1118,7 +1118,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Double] Long)
+                    (Fn [Double] Long)
                 </p>
                 <span>
                     
@@ -1137,7 +1137,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Double)
+                    (Fn [] Double)
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <span>
                     
@@ -242,7 +242,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Bool)
+                    (Fn [Float, Float] Bool)
                 </p>
                 <span>
                     
@@ -261,7 +261,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Bool)
+                    (Fn [Float, Float] Bool)
                 </p>
                 <span>
                     
@@ -280,7 +280,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Bool)
+                    (Fn [Float, Float] Bool)
                 </p>
                 <span>
                     
@@ -318,7 +318,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -337,7 +337,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -356,7 +356,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Float a), (Ref Float b)] Float)
+                    (Fn [(Ref Float a), (Ref Float b)] Float)
                 </p>
                 <pre class="args">
                     (add-ref x y)
@@ -375,7 +375,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a, a] Bool)
+                    (Fn [a, a] Bool)
                 </p>
                 <pre class="args">
                     (approx x y)
@@ -396,7 +396,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -415,7 +415,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -434,7 +434,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <span>
                     
@@ -453,7 +453,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -472,7 +472,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a, a, a] a)
+                    (Fn [a, a, a] a)
                 </p>
                 <pre class="args">
                     (clamp min max val)
@@ -491,7 +491,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Float a)] Float)
+                    (Fn [(Ref Float a)] Float)
                 </p>
                 <span>
                     
@@ -510,7 +510,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -529,7 +529,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -548,7 +548,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <pre class="args">
                     (dec x)
@@ -567,7 +567,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -586,7 +586,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -605,7 +605,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Float] String)
+                    (Fn [(Ref String a), Float] String)
                 </p>
                 <span>
                     
@@ -624,7 +624,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, (Ref Int a)] Float)
+                    (Fn [Float, (Ref Int a)] Float)
                 </p>
                 <span>
                     
@@ -643,7 +643,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Float)
+                    (Fn [Int] Float)
                 </p>
                 <span>
                     
@@ -662,7 +662,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Float)
+                    (Fn [(Ref String a)] Float)
                 </p>
                 <span>
                     
@@ -681,7 +681,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Float a)] Int)
+                    (Fn [(Ref Float a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -700,7 +700,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <pre class="args">
                     (inc x)
@@ -719,7 +719,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Int] Float)
+                    (Fn [Float, Int] Float)
                 </p>
                 <span>
                     
@@ -738,7 +738,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -757,7 +757,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -776,7 +776,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <span>
                     
@@ -795,7 +795,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, (Ref Float a)] Float)
+                    (Fn [Float, (Ref Float a)] Float)
                 </p>
                 <span>
                     
@@ -814,7 +814,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -852,7 +852,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <span>
                     
@@ -871,7 +871,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Float] String)
+                    (Fn [Float] String)
                 </p>
                 <pre class="args">
                     (prn x)
@@ -890,7 +890,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Float)
+                    (Fn [] Float)
                 </p>
                 <pre class="args">
                     (random)
@@ -909,7 +909,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Float, Float] Float)
+                    (Fn [Float, Float] Float)
                 </p>
                 <pre class="args">
                     (random-between lower upper)
@@ -928,7 +928,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -947,7 +947,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -966,7 +966,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -985,7 +985,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] String)
+                    (Fn [Float] String)
                 </p>
                 <span>
                     
@@ -1004,7 +1004,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -1023,7 +1023,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Float)
+                    (Fn [Float] Float)
                 </p>
                 <span>
                     
@@ -1042,7 +1042,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Int)
+                    (Fn [Float] Int)
                 </p>
                 <span>
                     
@@ -1061,7 +1061,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Float] Int)
+                    (Fn [Float] Int)
                 </p>
                 <span>
                     
@@ -1080,7 +1080,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Float)
+                    (Fn [] Float)
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a] a)
+                    (Fn [a] a)
                 </p>
                 <pre class="args">
                     (degree-to-radians n)
@@ -186,7 +186,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a] a)
+                    (Fn [a] a)
                 </p>
                 <pre class="args">
                     (radians-to-degree n)

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -243,7 +243,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Id] ())
+                    (Fn [Id] ())
                 </p>
                 <pre class="args">
                     (color cid)
@@ -263,7 +263,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Id, (Ref String a)] ())
+                    (Fn [Id, (Ref String a)] ())
                 </p>
                 <pre class="args">
                     (colorize cid s)
@@ -283,7 +283,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] ())
+                    (Fn [(Ref String a)] ())
                 </p>
                 <span>
                     
@@ -303,7 +303,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] ())
+                    (Fn [(Ref String a)] ())
                 </p>
                 <span>
                     
@@ -323,7 +323,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] a)
+                    (Fn [Int] a)
                 </p>
                 <span>
                     
@@ -343,7 +343,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr FILE)] ())
+                    (Fn [(Ptr FILE)] ())
                 </p>
                 <span>
                     
@@ -363,7 +363,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr FILE)] ())
+                    (Fn [(Ptr FILE)] ())
                 </p>
                 <span>
                     
@@ -383,7 +383,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr FILE)] Char)
+                    (Fn [(Ptr FILE)] Char)
                 </p>
                 <span>
                     
@@ -403,7 +403,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] (Ptr FILE))
+                    (Fn [(Ref String a), (Ref String b)] (Ptr FILE))
                 </p>
                 <span>
                     
@@ -423,7 +423,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [a, Int, Int, (Ptr FILE)] Int)
+                    (Fn [a, Int, Int, (Ptr FILE)] Int)
                 </p>
                 <span>
                     
@@ -443,7 +443,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr FILE), Int, Int] ())
+                    (Fn [(Ptr FILE), Int, Int] ())
                 </p>
                 <span>
                     
@@ -463,7 +463,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr FILE)] Int)
+                    (Fn [(Ptr FILE)] Int)
                 </p>
                 <span>
                     
@@ -483,7 +483,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [a, Int, Int, (Ptr FILE)] ())
+                    (Fn [a, Int, Int, (Ptr FILE)] ())
                 </p>
                 <span>
                     
@@ -503,7 +503,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [] Char)
+                    (Fn [] Char)
                 </p>
                 <span>
                     
@@ -523,7 +523,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [] String)
+                    (Fn [] String)
                 </p>
                 <span>
                     
@@ -543,7 +543,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [String] (Maybe String))
+                    (Fn [String] (Maybe String))
                 </p>
                 <pre class="args">
                     (getenv s)
@@ -562,7 +562,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] (Result (Ptr FILE) Int))
+                    (Fn [(Ref String a), (Ref String b)] (Result (Ptr FILE) Int))
                 </p>
                 <pre class="args">
                     (open-file filename mode)
@@ -582,7 +582,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] ())
+                    (Fn [(Ref String a)] ())
                 </p>
                 <span>
                     
@@ -602,7 +602,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] ())
+                    (Fn [(Ref String a)] ())
                 </p>
                 <span>
                     
@@ -622,7 +622,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] (Result String Int))
+                    (Fn [(Ref String a)] (Result String Int))
                 </p>
                 <pre class="args">
                     (read-&gt;EOF filename)
@@ -642,7 +642,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <span>
                     
@@ -662,7 +662,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr FILE)] ())
+                    (Fn [(Ptr FILE)] ())
                 </p>
                 <span>
                     
@@ -739,7 +739,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [String] ())
+                    (Fn [String] ())
                 </p>
                 <span>
                     

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -242,7 +242,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Bool)
+                    (Fn [Int, Int] Bool)
                 </p>
                 <span>
                     
@@ -261,7 +261,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Bool)
+                    (Fn [Int, Int] Bool)
                 </p>
                 <span>
                     
@@ -280,7 +280,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Bool)
+                    (Fn [Int, Int] Bool)
                 </p>
                 <span>
                     
@@ -337,7 +337,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Int)
+                    (Fn [Int] Int)
                 </p>
                 <span>
                     
@@ -357,7 +357,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Int a), (Ref Int b)] Int)
+                    (Fn [(Ref Int a), (Ref Int b)] Int)
                 </p>
                 <pre class="args">
                     (add-ref x y)
@@ -376,7 +376,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -395,7 +395,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Int)
+                    (Fn [Int] Int)
                 </p>
                 <span>
                     
@@ -414,7 +414,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -433,7 +433,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -452,7 +452,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -471,7 +471,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -490,7 +490,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a, a, a] a)
+                    (Fn [a, a, a] a)
                 </p>
                 <pre class="args">
                     (clamp min max val)
@@ -509,7 +509,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Int a)] Int)
+                    (Fn [(Ref Int a)] Int)
                 </p>
                 <span>
                     
@@ -528,7 +528,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Int)
+                    (Fn [Int] Int)
                 </p>
                 <span>
                     
@@ -547,7 +547,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] Bool)
+                    (Fn [Int] Bool)
                 </p>
                 <pre class="args">
                     (even? a)
@@ -566,7 +566,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Int] String)
+                    (Fn [(Ref String a), Int] String)
                 </p>
                 <span>
                     
@@ -585,7 +585,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a] a)
+                    (Fn [a] a)
                 </p>
                 <pre class="args">
                     (from-int a)
@@ -605,7 +605,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Int)
+                    (Fn [(Ref String a)] Int)
                 </p>
                 <span>
                     
@@ -624,7 +624,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Int a)] Int)
+                    (Fn [(Ref Int a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -643,7 +643,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Int)
+                    (Fn [Int] Int)
                 </p>
                 <span>
                     
@@ -662,7 +662,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <span>
                     
@@ -681,7 +681,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Int)
+                    (Fn [Int] Int)
                 </p>
                 <span>
                     
@@ -700,7 +700,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] Bool)
+                    (Fn [Int] Bool)
                 </p>
                 <pre class="args">
                     (odd? a)
@@ -719,7 +719,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <pre class="args">
                     (positive-mod k n)
@@ -739,7 +739,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <pre class="args">
                     (pow x y)
@@ -759,7 +759,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Int)
+                    (Fn [] Int)
                 </p>
                 <pre class="args">
                     (random)
@@ -778,73 +778,13 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] Int)
+                    (Fn [Int, Int] Int)
                 </p>
                 <pre class="args">
                     (random-between lower upper)
                 </pre>
                 <p class="doc">
                     
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#safe-add">
-                    <h3 id="safe-add">
-                        safe-add
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (λ [Int, Int, (Ref Int a)] Bool)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>Performs an addition and checks whether it overflowed.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#safe-mul">
-                    <h3 id="safe-mul">
-                        safe-mul
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (λ [Int, Int, (Ref Int a)] Bool)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>Performs an multiplication and checks whether it overflowed.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#safe-sub">
-                    <h3 id="safe-sub">
-                        safe-sub
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (λ [Int, Int, (Ref Int a)] Bool)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>Performs an substraction and checks whether it overflowed.</p>
-
                 </p>
             </div>
             <div class="binder">
@@ -857,7 +797,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] String)
+                    (Fn [Int] String)
                 </p>
                 <span>
                     
@@ -876,7 +816,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a] a)
+                    (Fn [a] a)
                 </p>
                 <pre class="args">
                     (to-int a)
@@ -896,7 +836,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Int)
+                    (Fn [] Int)
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -242,7 +242,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Bool)
+                    (Fn [Long, Long] Bool)
                 </p>
                 <span>
                     
@@ -261,7 +261,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Bool)
+                    (Fn [Long, Long] Bool)
                 </p>
                 <span>
                     
@@ -280,7 +280,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Bool)
+                    (Fn [Long, Long] Bool)
                 </p>
                 <span>
                     
@@ -337,7 +337,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] Long)
+                    (Fn [Long] Long)
                 </p>
                 <span>
                     
@@ -356,7 +356,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -375,7 +375,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] Long)
+                    (Fn [Long] Long)
                 </p>
                 <span>
                     
@@ -394,7 +394,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -413,7 +413,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -432,7 +432,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -451,7 +451,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -470,7 +470,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Long a)] Long)
+                    (Fn [(Ref Long a)] Long)
                 </p>
                 <span>
                     
@@ -489,7 +489,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] Long)
+                    (Fn [Long] Long)
                 </p>
                 <span>
                     
@@ -508,7 +508,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Long] Bool)
+                    (Fn [Long] Bool)
                 </p>
                 <pre class="args">
                     (even? a)
@@ -527,7 +527,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Long] String)
+                    (Fn [(Ref String a), Long] String)
                 </p>
                 <span>
                     
@@ -546,7 +546,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Long)
+                    (Fn [Int] Long)
                 </p>
                 <span>
                     
@@ -565,7 +565,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Long)
+                    (Fn [(Ref String a)] Long)
                 </p>
                 <span>
                     
@@ -584,7 +584,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Long a)] Int)
+                    (Fn [(Ref Long a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -603,7 +603,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] Long)
+                    (Fn [Long] Long)
                 </p>
                 <span>
                     
@@ -622,7 +622,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <span>
                     
@@ -641,7 +641,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] Long)
+                    (Fn [Long] Long)
                 </p>
                 <span>
                     
@@ -660,7 +660,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Long] Bool)
+                    (Fn [Long] Bool)
                 </p>
                 <pre class="args">
                     (odd? a)
@@ -679,7 +679,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Long] String)
+                    (Fn [Long] String)
                 </p>
                 <pre class="args">
                     (prn x)
@@ -698,7 +698,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Long)
+                    (Fn [] Long)
                 </p>
                 <pre class="args">
                     (random)
@@ -717,68 +717,11 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Long, Long] Long)
+                    (Fn [Long, Long] Long)
                 </p>
                 <pre class="args">
                     (random-between lower upper)
                 </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#safe-add">
-                    <h3 id="safe-add">
-                        safe-add
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (λ [Long, Long, (Ref Long a)] Bool)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#safe-mul">
-                    <h3 id="safe-mul">
-                        safe-mul
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (λ [Long, Long, (Ref Long a)] Bool)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#safe-sub">
-                    <h3 id="safe-sub">
-                        safe-sub
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (λ [Long, Long, (Ref Long a)] Bool)
-                </p>
-                <span>
-                    
-                </span>
                 <p class="doc">
                     
                 </p>
@@ -793,7 +736,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] ())
+                    (Fn [Long] ())
                 </p>
                 <span>
                     
@@ -812,7 +755,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] String)
+                    (Fn [Long] String)
                 </p>
                 <span>
                     
@@ -831,7 +774,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Long] Int)
+                    (Fn [Long] Int)
                 </p>
                 <span>
                     
@@ -850,7 +793,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] Long)
+                    (Fn [] Long)
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Ref (Map a b) c)] Bool)
+                    (Fn [(Ref (Map a b) c), (Ref (Map a b) c)] Bool)
                 </p>
                 <pre class="args">
                     (= m1 m2)
@@ -185,7 +185,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b), (Ref c b)] Bool d) e), (Ref (Map a c) b)] Bool)
+                    (Fn [(Ref (Fn [(Ref a b), (Ref c b)] Bool d) e), (Ref (Map a c) b)] Bool)
                 </p>
                 <pre class="args">
                     (all? pred m)
@@ -205,7 +205,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] (Ref (Array (Bucket a b)) c))
+                    (Fn [(Ref (Map a b) c)] (Ref (Array (Bucket a b)) c))
                 </p>
                 <span>
                     
@@ -225,7 +225,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Ref a c)] Bool)
+                    (Fn [(Ref (Map a b) c), (Ref a c)] Bool)
                 </p>
                 <pre class="args">
                     (contains? m k)
@@ -245,7 +245,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] (Map a b))
+                    (Fn [(Ref (Map a b) c)] (Map a b))
                 </p>
                 <span>
                     
@@ -265,7 +265,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Map a b))
+                    (Fn [] (Map a b))
                 </p>
                 <pre class="args">
                     (create)
@@ -285,7 +285,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] (Map a b))
+                    (Fn [Int] (Map a b))
                 </p>
                 <pre class="args">
                     (create-with-len len)
@@ -305,7 +305,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Map a b)] ())
+                    (Fn [(Map a b)] ())
                 </p>
                 <span>
                     
@@ -325,7 +325,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [a] Bool)
+                    (Fn [a] Bool)
                 </p>
                 <pre class="args">
                     (empty? m)
@@ -345,7 +345,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b), (Ref c b)] c d) e), (Map a c)] (Map a c))
+                    (Fn [(Ref (Fn [(Ref a b), (Ref c b)] c d) e), (Map a c)] (Map a c))
                 </p>
                 <pre class="args">
                     (endo-map f m)
@@ -365,7 +365,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Ref (λ [(Ref a c), (Ref b c)] () d) e)] ())
+                    (Fn [(Ref (Map a b) c), (Ref (Fn [(Ref a c), (Ref b c)] () d) e)] ())
                 </p>
                 <pre class="args">
                     (for-each m f)
@@ -385,7 +385,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array (Pair a b)) c)] (Map a b))
+                    (Fn [(Ref (Array (Pair a b)) c)] (Map a b))
                 </p>
                 <pre class="args">
                     (from-array a)
@@ -405,7 +405,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Ref a c)] b)
+                    (Fn [(Ref (Map a b) c), (Ref a c)] b)
                 </p>
                 <pre class="args">
                     (get m k)
@@ -425,7 +425,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Ref a c)] (Maybe b))
+                    (Fn [(Ref (Map a b) c), (Ref a c)] (Maybe b))
                 </p>
                 <pre class="args">
                     (get-maybe m k)
@@ -445,7 +445,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Ref a c), (Ref b d)] b)
+                    (Fn [(Ref (Map a b) c), (Ref a c), (Ref b d)] b)
                 </p>
                 <pre class="args">
                     (get-with-default m k default-value)
@@ -465,7 +465,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [Int, (Array (Bucket a b))] (Map a b))
+                    (Fn [Int, (Array (Bucket a b))] (Map a b))
                 </p>
                 <span>
                     
@@ -485,7 +485,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] (Array a))
+                    (Fn [(Ref (Map a b) c)] (Array a))
                 </p>
                 <pre class="args">
                     (keys m)
@@ -505,7 +505,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [a, (Ref b c), (Ref d c)] a e) f), a, (Ref (Map b d) c)] a)
+                    (Fn [(Ref (Fn [a, (Ref b c), (Ref d c)] a e) f), a, (Ref (Map b d) c)] a)
                 </p>
                 <pre class="args">
                     (kv-reduce f init m)
@@ -525,7 +525,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] Int)
+                    (Fn [(Ref (Map a b) c)] Int)
                 </p>
                 <pre class="args">
                     (length m)
@@ -545,7 +545,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] (Ref Int c))
+                    (Fn [(Ref (Map a b) c)] (Ref Int c))
                 </p>
                 <span>
                     
@@ -565,7 +565,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] String)
+                    (Fn [(Ref (Map a b) c)] String)
                 </p>
                 <span>
                     
@@ -585,7 +585,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), (Ref a c), (Ref b c)] (Map a b))
+                    (Fn [(Map a b), (Ref a c), (Ref b c)] (Map a b))
                 </p>
                 <pre class="args">
                     (put m k v)
@@ -605,7 +605,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Ref a c), (Ref b d)] ())
+                    (Fn [(Ref (Map a b) c), (Ref a c), (Ref b d)] ())
                 </p>
                 <pre class="args">
                     (put! m k v)
@@ -625,7 +625,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), (Ref a c)] (Map a b))
+                    (Fn [(Map a b), (Ref a c)] (Map a b))
                 </p>
                 <pre class="args">
                     (remove m k)
@@ -645,7 +645,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] (Map b a))
+                    (Fn [(Ref (Map a b) c)] (Map b a))
                 </p>
                 <pre class="args">
                     (reverse m)
@@ -665,7 +665,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), (Array (Bucket a b))] (Map a b))
+                    (Fn [(Map a b), (Array (Bucket a b))] (Map a b))
                 </p>
                 <span>
                     
@@ -685,7 +685,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), (Array (Bucket a b))] ())
+                    (Fn [(Ref (Map a b) c), (Array (Bucket a b))] ())
                 </p>
                 <span>
                     
@@ -705,7 +705,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), Int] (Map a b))
+                    (Fn [(Map a b), Int] (Map a b))
                 </p>
                 <span>
                     
@@ -725,7 +725,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c), Int] ())
+                    (Fn [(Ref (Map a b) c), Int] ())
                 </p>
                 <span>
                     
@@ -745,7 +745,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] String)
+                    (Fn [(Ref (Map a b) c)] String)
                 </p>
                 <pre class="args">
                     (str m)
@@ -765,7 +765,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] (Array (Pair a b)))
+                    (Fn [(Ref (Map a b) c)] (Array (Pair a b)))
                 </p>
                 <pre class="args">
                     (to-array m)
@@ -785,7 +785,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), (Ref a c), (Ref (λ [b] b d) c)] (Map a b))
+                    (Fn [(Map a b), (Ref a c), (Ref (Fn [b] b d) c)] (Map a b))
                 </p>
                 <pre class="args">
                     (update m k f)
@@ -805,7 +805,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), (Ref (λ [(Array (Bucket a b))] (Array (Bucket a b)) c) d)] (Map a b))
+                    (Fn [(Map a b), (Ref (Fn [(Array (Bucket a b))] (Array (Bucket a b)) c) d)] (Map a b))
                 </p>
                 <span>
                     
@@ -825,7 +825,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), (Ref (λ [Int] Int c) d)] (Map a b))
+                    (Fn [(Map a b), (Ref (Fn [Int] Int c) d)] (Map a b))
                 </p>
                 <span>
                     
@@ -845,7 +845,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Map a b), (Ref a c), (Ref (λ [b] b d) c), b] (Map a b))
+                    (Fn [(Map a b), (Ref a c), (Ref (Fn [b] b d) c), b] (Map a b))
                 </p>
                 <pre class="args">
                     (update-with-default m k f v)
@@ -865,7 +865,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Map a b) c)] (Array b))
+                    (Fn [(Ref (Map a b) c)] (Array b))
                 </p>
                 <pre class="args">
                     (vals m)

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b), (Ref (Maybe a) b)] Bool)
+                    (Fn [(Ref (Maybe a) b), (Ref (Maybe a) b)] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
@@ -186,7 +186,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [a] (Maybe a))
+                    (Fn [a] (Maybe a))
                 </p>
                 <span>
                     
@@ -206,7 +206,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [] (Maybe a))
+                    (Fn [] (Maybe a))
                 </p>
                 <span>
                     
@@ -226,7 +226,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Maybe a), (Ref (λ [a] b c) d)] (Maybe b))
+                    (Fn [(Maybe a), (Ref (Fn [a] b c) d)] (Maybe b))
                 </p>
                 <pre class="args">
                     (apply a f)
@@ -246,7 +246,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b)] (Maybe a))
+                    (Fn [(Ref (Maybe a) b)] (Maybe a))
                 </p>
                 <span>
                     
@@ -266,7 +266,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Maybe a)] ())
+                    (Fn [(Maybe a)] ())
                 </p>
                 <span>
                     
@@ -286,7 +286,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Maybe a), a] a)
+                    (Fn [(Maybe a), a] a)
                 </p>
                 <pre class="args">
                     (from a dflt)
@@ -306,7 +306,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a)] (Maybe a))
+                    (Fn [(Ptr a)] (Maybe a))
                 </p>
                 <pre class="args">
                     (from-ptr a)
@@ -327,7 +327,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b)] Int)
+                    (Fn [(Ref (Maybe a) b)] Int)
                 </p>
                 <span>
                     
@@ -347,7 +347,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b)] Bool)
+                    (Fn [(Ref (Maybe a) b)] Bool)
                 </p>
                 <pre class="args">
                     (just? a)
@@ -368,7 +368,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b)] Bool)
+                    (Fn [(Ref (Maybe a) b)] Bool)
                 </p>
                 <pre class="args">
                     (nothing? a)
@@ -389,7 +389,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Maybe a)] a)
+                    (Fn [(Maybe a)] a)
                 </p>
                 <pre class="args">
                     (or-zero a)
@@ -410,7 +410,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b)] String)
+                    (Fn [(Ref (Maybe a) b)] String)
                 </p>
                 <span>
                     
@@ -430,7 +430,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b)] String)
+                    (Fn [(Ref (Maybe a) b)] String)
                 </p>
                 <span>
                     
@@ -450,7 +450,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Maybe a), b] (Result a b))
+                    (Fn [(Maybe a), b] (Result a b))
                 </p>
                 <pre class="args">
                     (to-result a error)
@@ -471,7 +471,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Maybe a)] a)
+                    (Fn [(Maybe a)] a)
                 </p>
                 <pre class="args">
                     (unsafe-from a)
@@ -491,7 +491,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Maybe a) b)] (Ptr a))
+                    (Fn [(Ref (Maybe a) b)] (Ptr a))
                 </p>
                 <pre class="args">
                     (unsafe-ptr a)
@@ -512,7 +512,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Maybe a))
+                    (Fn [] (Maybe a))
                 </p>
                 <pre class="args">
                     (zero)
@@ -532,7 +532,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [a, b] c d) e), (Maybe a), (Maybe b)] (Maybe c))
+                    (Fn [(Ref (Fn [a, b] c d) e), (Maybe a), (Maybe b)] (Maybe c))
                 </p>
                 <pre class="args">
                     (zip f a b)
@@ -551,7 +551,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [a, b, c, d] e f) g), (Maybe a), (Maybe b), (Maybe c), (Maybe d)] (Maybe e))
+                    (Fn [(Ref (Fn [a, b, c, d] e f) g), (Maybe a), (Maybe b), (Maybe c), (Maybe d)] (Maybe e))
                 </p>
                 <pre class="args">
                     (zip4 f a b c d)
@@ -570,7 +570,7 @@ a value using <code>zero</code> if a <code>Nothing</code> is passed.</p>
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [a, b, c, d, e, f, g, h] i j) k), (Maybe a), (Maybe b), (Maybe c), (Maybe d), (Maybe e), (Maybe f), (Maybe g), (Maybe h)] (Maybe i))
+                    (Fn [(Ref (Fn [a, b, c, d, e, f, g, h] i j) k), (Maybe a), (Maybe b), (Maybe c), (Maybe d), (Maybe e), (Maybe f), (Maybe g), (Maybe h)] (Maybe i))
                 </p>
                 <pre class="args">
                     (zip8 f a b c d e a1 b1 c1)

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref Pattern b)] Bool)
+                    (Fn [(Ref Pattern a), (Ref Pattern b)] Bool)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a)] Pattern)
+                    (Fn [(Ref Pattern a)] Pattern)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] Int)
+                    (Fn [(Ref Pattern a), (Ref String b)] Int)
                 </p>
                 <span>
                     
@@ -225,7 +225,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] (Array Int))
+                    (Fn [(Ref Pattern a), (Ref String b)] (Array Int))
                 </p>
                 <span>
                     
@@ -246,7 +246,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Char) a)] Pattern)
+                    (Fn [(Ref (Array Char) a)] Pattern)
                 </p>
                 <pre class="args">
                     (from-chars chars)
@@ -266,7 +266,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] (Array (Array String)))
+                    (Fn [(Ref Pattern a), (Ref String b)] (Array (Array String)))
                 </p>
                 <span>
                     
@@ -287,7 +287,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] (Array String))
+                    (Fn [(Ref Pattern a), (Ref String b)] (Array String))
                 </p>
                 <pre class="args">
                     (global-match-str p s)
@@ -306,7 +306,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Pattern)
+                    (Fn [(Ref String a)] Pattern)
                 </p>
                 <span>
                     
@@ -325,7 +325,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] (Array String))
+                    (Fn [(Ref Pattern a), (Ref String b)] (Array String))
                 </p>
                 <span>
                     
@@ -346,7 +346,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] String)
+                    (Fn [(Ref Pattern a), (Ref String b)] String)
                 </p>
                 <span>
                     
@@ -367,7 +367,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] Bool)
+                    (Fn [(Ref Pattern a), (Ref String b)] Bool)
                 </p>
                 <pre class="args">
                     (matches? pat s)
@@ -387,7 +387,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a)] String)
+                    (Fn [(Ref Pattern a)] String)
                 </p>
                 <span>
                     
@@ -406,7 +406,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b)] (Array String))
+                    (Fn [(Ref Pattern a), (Ref String b)] (Array String))
                 </p>
                 <pre class="args">
                     (split p s)
@@ -426,7 +426,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a)] String)
+                    (Fn [(Ref Pattern a)] String)
                 </p>
                 <span>
                     
@@ -445,7 +445,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref Pattern a), (Ref String b), (Ref String c), Int] String)
+                    (Fn [(Ref Pattern a), (Ref String b), (Ref String c), Int] String)
                 </p>
                 <span>
                     

--- a/docs/core/Pointer.html
+++ b/docs/core/Pointer.html
@@ -166,7 +166,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a), Long] (Ptr a))
+                    (Fn [(Ptr a), Long] (Ptr a))
                 </p>
                 <span>
                     
@@ -186,7 +186,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Ptr a) b)] (Ptr a))
+                    (Fn [(Ref (Ptr a) b)] (Ptr a))
                 </p>
                 <span>
                     
@@ -206,7 +206,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a)] (Ptr a))
+                    (Fn [(Ptr a)] (Ptr a))
                 </p>
                 <pre class="args">
                     (dec a)
@@ -225,7 +225,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a), (Ptr a)] Bool)
+                    (Fn [(Ptr a), (Ptr a)] Bool)
                 </p>
                 <span>
                     
@@ -245,7 +245,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [Long] (Ptr a))
+                    (Fn [Long] (Ptr a))
                 </p>
                 <span>
                     
@@ -265,7 +265,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a)] (Ptr a))
+                    (Fn [(Ptr a)] (Ptr a))
                 </p>
                 <pre class="args">
                     (inc a)
@@ -284,7 +284,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a), Long] (Ptr a))
+                    (Fn [(Ptr a), Long] (Ptr a))
                 </p>
                 <span>
                     
@@ -304,7 +304,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a)] Long)
+                    (Fn [(Ptr a)] Long)
                 </p>
                 <span>
                     
@@ -324,7 +324,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a)] (Ref a StaticLifetime))
+                    (Fn [(Ptr a)] (Ref a StaticLifetime))
                 </p>
                 <span>
                     
@@ -344,7 +344,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a)] a)
+                    (Fn [(Ptr a)] a)
                 </p>
                 <span>
                     
@@ -364,7 +364,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ptr a)] Long)
+                    (Fn [(Ptr a)] Long)
                 </p>
                 <span>
                     

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Result a b) c), (Ref (Result a b) c)] Bool)
+                    (Fn [(Ref (Result a b) c), (Ref (Result a b) c)] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
@@ -186,7 +186,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [a] (Result b a))
+                    (Fn [a] (Result b a))
                 </p>
                 <span>
                     
@@ -206,7 +206,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [a] (Result a b))
+                    (Fn [a] (Result a b))
                 </p>
                 <span>
                     
@@ -226,7 +226,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (Ref (λ [a] (Result c b) d) e)] (Result c b))
+                    (Fn [(Result a b), (Ref (Fn [a] (Result c b) d) e)] (Result c b))
                 </p>
                 <pre class="args">
                     (and-then a f)
@@ -247,7 +247,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (Ref (λ [a] c d) e), (Ref (λ [b] f d) g)] (Result c f))
+                    (Fn [(Result a b), (Ref (Fn [a] c d) e), (Ref (Fn [b] f d) g)] (Result c f))
                 </p>
                 <pre class="args">
                     (apply a success-f error-f)
@@ -267,7 +267,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Result a b) c)] (Result a b))
+                    (Fn [(Ref (Result a b) c)] (Result a b))
                 </p>
                 <span>
                     
@@ -287,7 +287,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Result a b)] ())
+                    (Fn [(Result a b)] ())
                 </p>
                 <span>
                     
@@ -307,7 +307,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Result a b) c)] Bool)
+                    (Fn [(Ref (Result a b) c)] Bool)
                 </p>
                 <pre class="args">
                     (error? a)
@@ -326,7 +326,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), b] b)
+                    (Fn [(Result a b), b] b)
                 </p>
                 <pre class="args">
                     (from-error a dflt)
@@ -346,7 +346,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), a] a)
+                    (Fn [(Result a b), a] a)
                 </p>
                 <pre class="args">
                     (from-success a dflt)
@@ -366,7 +366,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Result a b) c)] Int)
+                    (Fn [(Ref (Result a b) c)] Int)
                 </p>
                 <span>
                     
@@ -386,7 +386,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (Ref (λ [a] c d) e)] (Result c b))
+                    (Fn [(Result a b), (Ref (Fn [a] c d) e)] (Result c b))
                 </p>
                 <pre class="args">
                     (map a f)
@@ -406,7 +406,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (Ref (λ [b] c d) e)] (Result a c))
+                    (Fn [(Result a b), (Ref (Fn [b] c d) e)] (Result a c))
                 </p>
                 <pre class="args">
                     (map-error a f)
@@ -426,7 +426,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (Ref (λ [b] (Result a c) d) e)] (Result a c))
+                    (Fn [(Result a b), (Ref (Fn [b] (Result a c) d) e)] (Result a c))
                 </p>
                 <pre class="args">
                     (or-else a f)
@@ -447,7 +447,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Result a b) c)] String)
+                    (Fn [(Ref (Result a b) c)] String)
                 </p>
                 <span>
                     
@@ -467,7 +467,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Result a b) c)] String)
+                    (Fn [(Ref (Result a b) c)] String)
                 </p>
                 <span>
                     
@@ -487,7 +487,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Result a b) c)] Bool)
+                    (Fn [(Ref (Result a b) c)] Bool)
                 </p>
                 <pre class="args">
                     (success? a)
@@ -508,7 +508,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b)] (Maybe a))
+                    (Fn [(Result a b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (to-maybe a)
@@ -529,7 +529,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b)] b)
+                    (Fn [(Result a b)] b)
                 </p>
                 <pre class="args">
                     (unsafe-from-error a)
@@ -549,7 +549,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b)] a)
+                    (Fn [(Result a b)] a)
                 </p>
                 <pre class="args">
                     (unsafe-from-success a)
@@ -569,7 +569,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b), (Ref (λ [b] a c) d)] a)
+                    (Fn [(Result a b), (Ref (Fn [b] a c) d)] a)
                 </p>
                 <pre class="args">
                     (unwrap-or-else a f)
@@ -589,7 +589,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Result a b)] a)
+                    (Fn [(Result a b)] a)
                 </p>
                 <pre class="args">
                     (unwrap-or-zero a)

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), (Ref (StaticArray a) b)] Bool)
+                    (Fn [(Ref (StaticArray a) b), (Ref (StaticArray a) b)] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
@@ -186,7 +186,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] Bool)
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] Bool)
                 </p>
                 <pre class="args">
                     (all? f a)
@@ -206,7 +206,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] Bool)
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] Bool)
                 </p>
                 <pre class="args">
                     (any? f a)
@@ -226,7 +226,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), Int, a] ())
+                    (Fn [(Ref (StaticArray a) b), Int, a] ())
                 </p>
                 <span>
                     
@@ -246,7 +246,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), Int, (Ref (λ [(Ref a b)] a c) d)] ())
+                    (Fn [(Ref (StaticArray a) b), Int, (Ref (Fn [(Ref a b)] a c) d)] ())
                 </p>
                 <pre class="args">
                     (aupdate! a i f)
@@ -266,7 +266,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), (Ref a b)] Bool)
+                    (Fn [(Ref (StaticArray a) b), (Ref a b)] Bool)
                 </p>
                 <pre class="args">
                     (contains? arr el)
@@ -286,7 +286,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(StaticArray a)] ())
+                    (Fn [(StaticArray a)] ())
                 </p>
                 <span>
                     
@@ -306,7 +306,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), (Ref a b)] Int)
+                    (Fn [(Ref (StaticArray a) b), (Ref a b)] Int)
                 </p>
                 <pre class="args">
                     (element-count a e)
@@ -326,7 +326,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] Bool)
+                    (Fn [(Ref (StaticArray a) b)] Bool)
                 </p>
                 <pre class="args">
                     (empty? a)
@@ -346,7 +346,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] (Maybe a))
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (find f a)
@@ -367,7 +367,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] (Maybe Int))
+                    (Fn [(Ref (Fn [(Ref a b)] Bool c) d), (Ref (StaticArray a) b)] (Maybe Int))
                 </p>
                 <pre class="args">
                     (find-index f a)
@@ -388,7 +388,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                    (Fn [(Ref (StaticArray a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (first a)
@@ -447,7 +447,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), (Ref a b)] (Maybe Int))
+                    (Fn [(Ref (StaticArray a) b), (Ref a b)] (Maybe Int))
                 </p>
                 <pre class="args">
                     (index-of a e)
@@ -468,7 +468,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                    (Fn [(Ref (StaticArray a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (last a)
@@ -489,7 +489,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] Int)
+                    (Fn [(Ref (StaticArray a) b)] Int)
                 </p>
                 <span>
                     
@@ -509,7 +509,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), (Ref (λ [(Ref a b)] a c) d)] ())
+                    (Fn [(Ref (StaticArray a) b), (Ref (Fn [(Ref a b)] a c) d)] ())
                 </p>
                 <pre class="args">
                     (map! xs f)
@@ -529,7 +529,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                    (Fn [(Ref (StaticArray a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (maximum xs)
@@ -550,7 +550,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] (Maybe a))
+                    (Fn [(Ref (StaticArray a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (minimum xs)
@@ -571,7 +571,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), Int] (Maybe a))
+                    (Fn [(Ref (StaticArray a) b), Int] (Maybe a))
                 </p>
                 <pre class="args">
                     (nth xs index)
@@ -592,7 +592,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), (Ref (λ [(Ref a b)] Bool c) d)] Int)
+                    (Fn [(Ref (StaticArray a) b), (Ref (Fn [(Ref a b)] Bool c) d)] Int)
                 </p>
                 <pre class="args">
                     (predicate-count a pred)
@@ -612,7 +612,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (λ [a, (Ref b c)] a d) e), a, (Ref (StaticArray b) c)] a)
+                    (Fn [(Ref (Fn [a, (Ref b c)] a d) e), a, (Ref (StaticArray b) c)] a)
                 </p>
                 <pre class="args">
                     (reduce f x xs)
@@ -631,7 +631,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] ())
+                    (Fn [(Ref (StaticArray a) b)] ())
                 </p>
                 <pre class="args">
                     (reverse! a)
@@ -651,7 +651,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] String)
+                    (Fn [(Ref (StaticArray a) b)] String)
                 </p>
                 <span>
                     
@@ -671,7 +671,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] a)
+                    (Fn [(Ref (StaticArray a) b)] a)
                 </p>
                 <pre class="args">
                     (sum xs)
@@ -691,7 +691,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), Int, Int] ())
+                    (Fn [(Ref (StaticArray a) b), Int, Int] ())
                 </p>
                 <pre class="args">
                     (swap! a i j)
@@ -711,7 +711,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] a)
+                    (Fn [(Ref (StaticArray a) b)] a)
                 </p>
                 <pre class="args">
                     (unsafe-first a)
@@ -732,7 +732,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b)] a)
+                    (Fn [(Ref (StaticArray a) b)] a)
                 </p>
                 <pre class="args">
                     (unsafe-last a)
@@ -753,7 +753,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (StaticArray a) b), Int] (Ref a b))
+                    (Fn [(Ref (StaticArray a) b), Int] (Ref a b))
                 </p>
                 <span>
                     

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -185,7 +185,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a), Int] Double)
+                    (Fn [(Ref (Array Double) a), Int] Double)
                 </p>
                 <pre class="args">
                     (grouped-median data interval)
@@ -205,7 +205,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (high-median data)
@@ -225,7 +225,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (iqr data)
@@ -245,7 +245,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (low-median data)
@@ -265,7 +265,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array a) b)] a)
+                    (Fn [(Ref (Array a) b)] a)
                 </p>
                 <pre class="args">
                     (mean data)
@@ -285,7 +285,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (median data)
@@ -305,7 +305,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (pstdev data)
@@ -345,7 +345,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (pvariance data)
@@ -365,7 +365,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] (Array Double))
+                    (Fn [(Ref (Array Double) a)] (Array Double))
                 </p>
                 <pre class="args">
                     (quartiles data)
@@ -385,7 +385,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (stdev data)
@@ -405,7 +405,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (stdev-pct data)
@@ -424,7 +424,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Summary)
+                    (Fn [(Ref (Array Double) a)] Summary)
                 </p>
                 <pre class="args">
                     (summary samples)
@@ -444,7 +444,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Double) a)] Double)
+                    (Fn [(Ref (Array Double) a)] Double)
                 </p>
                 <pre class="args">
                     (variance data)

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -166,7 +166,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] Bool)
+                    (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <span>
                     
@@ -185,7 +185,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] Bool)
+                    (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <span>
                     
@@ -204,7 +204,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] Bool)
+                    (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <span>
                     
@@ -223,7 +223,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Char] String)
+                    (Fn [Int, Char] String)
                 </p>
                 <span>
                     
@@ -242,7 +242,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Bool)
+                    (Fn [(Ref String a)] Bool)
                 </p>
                 <pre class="args">
                     (alpha? s)
@@ -262,7 +262,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Bool)
+                    (Fn [(Ref String a)] Bool)
                 </p>
                 <pre class="args">
                     (alphanum? s)
@@ -282,7 +282,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] String)
+                    (Fn [(Ref String a), (Ref String b)] String)
                 </p>
                 <span>
                     
@@ -301,7 +301,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Int] Char)
+                    (Fn [(Ref String a), Int] Char)
                 </p>
                 <span>
                     
@@ -320,7 +320,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] (Array Char))
+                    (Fn [(Ref String a)] (Array Char))
                 </p>
                 <span>
                     
@@ -339,7 +339,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <pre class="args">
                     (chomp s)
@@ -359,7 +359,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <pre class="args">
                     (collapse-whitespace s)
@@ -379,7 +379,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array String) a)] String)
+                    (Fn [(Ref (Array String) a)] String)
                 </p>
                 <pre class="args">
                     (concat strings)
@@ -398,7 +398,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Char] Bool)
+                    (Fn [(Ref String a), Char] Bool)
                 </p>
                 <pre class="args">
                     (contains? s c)
@@ -418,7 +418,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Char] Int)
+                    (Fn [(Ref String a), Char] Int)
                 </p>
                 <pre class="args">
                     (count-char s c)
@@ -438,7 +438,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] (Ptr Char))
+                    (Fn [(Ref String a)] (Ptr Char))
                 </p>
                 <span>
                     
@@ -457,7 +457,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Bool)
+                    (Fn [(Ref String a)] Bool)
                 </p>
                 <pre class="args">
                     (empty? s)
@@ -477,7 +477,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] Bool)
+                    (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <pre class="args">
                     (ends-with? s sub)
@@ -497,7 +497,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] String)
+                    (Fn [(Ref String a), (Ref String b)] String)
                 </p>
                 <span>
                     
@@ -516,7 +516,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array Char) a)] String)
+                    (Fn [(Ref (Array Char) a)] String)
                 </p>
                 <span>
                     
@@ -535,7 +535,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr Char)] String)
+                    (Fn [(Ptr Char)] String)
                 </p>
                 <span>
                     
@@ -554,7 +554,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Int)
+                    (Fn [(Ref String a)] Int)
                 </p>
                 <pre class="args">
                     (hash k)
@@ -573,7 +573,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Char)
+                    (Fn [(Ref String a)] Char)
                 </p>
                 <pre class="args">
                     (head s)
@@ -593,7 +593,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Bool)
+                    (Fn [(Ref String a)] Bool)
                 </p>
                 <pre class="args">
                     (hex? s)
@@ -613,7 +613,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] Bool)
+                    (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <pre class="args">
                     (in? s sub)
@@ -633,7 +633,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Char] Int)
+                    (Fn [(Ref String a), Char] Int)
                 </p>
                 <span>
                     
@@ -652,7 +652,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Char, Int] Int)
+                    (Fn [(Ref String a), Char, Int] Int)
                 </p>
                 <span>
                     
@@ -671,7 +671,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref (Array String) b)] String)
+                    (Fn [(Ref String a), (Ref (Array String) b)] String)
                 </p>
                 <pre class="args">
                     (join sep strings)
@@ -691,7 +691,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Char, (Ref (Array String) a)] String)
+                    (Fn [Char, (Ref (Array String) a)] String)
                 </p>
                 <pre class="args">
                     (join-with-char sep strings)
@@ -711,7 +711,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Int)
+                    (Fn [(Ref String a)] Int)
                 </p>
                 <span>
                     
@@ -730,7 +730,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] (Array String))
+                    (Fn [(Ref String a)] (Array String))
                 </p>
                 <pre class="args">
                     (lines s)
@@ -750,7 +750,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Bool)
+                    (Fn [(Ref String a)] Bool)
                 </p>
                 <pre class="args">
                     (lower? s)
@@ -770,7 +770,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Bool)
+                    (Fn [(Ref String a)] Bool)
                 </p>
                 <pre class="args">
                     (num? s)
@@ -790,7 +790,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, Char, (Ref String a)] String)
+                    (Fn [Int, Char, (Ref String a)] String)
                 </p>
                 <pre class="args">
                     (pad-left len pad s)
@@ -810,7 +810,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, Char, (Ref String a)] String)
+                    (Fn [Int, Char, (Ref String a)] String)
                 </p>
                 <pre class="args">
                     (pad-right len pad s)
@@ -830,7 +830,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Int] String)
+                    (Fn [(Ref String a), Int] String)
                 </p>
                 <pre class="args">
                     (prefix s a)
@@ -849,7 +849,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <span>
                     
@@ -868,7 +868,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] String)
+                    (Fn [Int] String)
                 </p>
                 <pre class="args">
                     (random-sized n)
@@ -887,7 +887,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int, (Ref String a)] String)
+                    (Fn [Int, (Ref String a)] String)
                 </p>
                 <pre class="args">
                     (repeat n inpt)
@@ -907,7 +907,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <pre class="args">
                     (reverse s)
@@ -927,7 +927,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Int, Int] String)
+                    (Fn [(Ref String a), Int, Int] String)
                 </p>
                 <pre class="args">
                     (slice s a b)
@@ -946,7 +946,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref (Array Char) b)] (Array String))
+                    (Fn [(Ref String a), (Ref (Array Char) b)] (Array String))
                 </p>
                 <pre class="args">
                     (split-by s separators)
@@ -966,7 +966,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), (Ref String b)] Bool)
+                    (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <pre class="args">
                     (starts-with? s sub)
@@ -986,7 +986,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <span>
                     
@@ -1005,7 +1005,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Int, Char] ())
+                    (Fn [(Ref String a), Int, Char] ())
                 </p>
                 <span>
                     
@@ -1024,7 +1024,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Int, (Ref String b)] ())
+                    (Fn [(Ref String a), Int, (Ref String b)] ())
                 </p>
                 <span>
                     
@@ -1043,7 +1043,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a), Int] String)
+                    (Fn [(Ref String a), Int] String)
                 </p>
                 <pre class="args">
                     (suffix s b)
@@ -1062,7 +1062,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Array String) a)] Int)
+                    (Fn [(Ref (Array String) a)] Int)
                 </p>
                 <pre class="args">
                     (sum-length strings)
@@ -1082,7 +1082,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <span>
                     
@@ -1101,7 +1101,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <pre class="args">
                     (trim s)
@@ -1121,7 +1121,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <pre class="args">
                     (trim-left s)
@@ -1141,7 +1141,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] String)
+                    (Fn [(Ref String a)] String)
                 </p>
                 <pre class="args">
                     (trim-right s)
@@ -1161,7 +1161,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] Bool)
+                    (Fn [(Ref String a)] Bool)
                 </p>
                 <pre class="args">
                     (upper? s)
@@ -1181,7 +1181,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] (Array String))
+                    (Fn [(Ref String a)] (Array String))
                 </p>
                 <pre class="args">
                     (words s)
@@ -1201,7 +1201,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] String)
+                    (Fn [] String)
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -489,7 +489,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [] ())
+                    (Fn [] ())
                 </p>
                 <span>
                     
@@ -508,7 +508,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, Int] ())
+                    (Fn [Int, Int] ())
                 </p>
                 <span>
                     
@@ -547,7 +547,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [Int] a)
+                    (Fn [Int] a)
                 </p>
                 <span>
                     
@@ -567,7 +567,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [] Int)
+                    (Fn [] Int)
                 </p>
                 <span>
                     
@@ -586,7 +586,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [a] ())
+                    (Fn [a] ())
                 </p>
                 <span>
                     
@@ -606,7 +606,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] (Ref String a))
+                    (Fn [Int] (Ref String a))
                 </p>
                 <span>
                     
@@ -626,7 +626,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [] Int)
+                    (Fn [] Int)
                 </p>
                 <span>
                     
@@ -646,7 +646,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] Int)
+                    (Fn [Int] Int)
                 </p>
                 <span>
                     
@@ -665,7 +665,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [] Long)
+                    (Fn [] Long)
                 </p>
                 <span>
                     
@@ -685,7 +685,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int, (λ [Int] ())] ())
+                    (Fn [Int, (Fn [Int] ())] ())
                 </p>
                 <span>
                     
@@ -818,7 +818,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] ())
+                    (Fn [Int] ())
                 </p>
                 <span>
                     
@@ -837,7 +837,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [Int] ())
+                    (Fn [Int] ())
                 </p>
                 <span>
                     
@@ -857,7 +857,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ref String a)] ())
+                    (Fn [(Ref String a)] ())
                 </p>
                 <span>
                     
@@ -877,7 +877,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [] Int)
+                    (Fn [] Int)
                 </p>
                 <span>
                     
@@ -897,7 +897,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (λ [(Ptr Int)] Int)
+                    (Fn [(Ptr Int)] Int)
                 </p>
                 <span>
                     

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -185,7 +185,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a), b, b, (Ref c d)] State)
+                    (Fn [(Ref State a), b, b, (Ref c d)] State)
                 </p>
                 <pre class="args">
                     (assert-equal state x y descr)
@@ -202,17 +202,16 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    dynamic
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a), Int, (λ [] () b), (Ref c d)] State)
+                    Dynamic
                 </p>
                 <pre class="args">
                     (assert-exit state exit-code f descr)
                 </pre>
                 <p class="doc">
-                    <p>Assert that function f exits with exit code exit-code.</p>
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -225,7 +224,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a), Bool, (Ref b c)] State)
+                    (Fn [(Ref State a), Bool, (Ref b c)] State)
                 </p>
                 <pre class="args">
                     (assert-false state x descr)
@@ -245,7 +244,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a), b, b, (Ref c d)] State)
+                    (Fn [(Ref State a), b, b, (Ref c d)] State)
                 </p>
                 <pre class="args">
                     (assert-not-equal state x y descr)
@@ -265,7 +264,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a), b, c, (Ref d e), (λ [b, c] Bool f)] State)
+                    (Fn [(Ref State a), b, c, (Ref d e), (Fn [b, c] Bool f)] State)
                 </p>
                 <pre class="args">
                     (assert-op state x y descr op)
@@ -282,17 +281,16 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    dynamic
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a), Int, (λ [] () b), (Ref c d)] State)
+                    Dynamic
                 </p>
                 <pre class="args">
                     (assert-signal state signal x descr)
                 </pre>
                 <p class="doc">
-                    <p>Assert that function f aborts with OS signal signal.</p>
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -305,7 +303,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a), Bool, (Ref b c)] State)
+                    (Fn [(Ref State a), Bool, (Ref b c)] State)
                 </p>
                 <pre class="args">
                     (assert-true state x descr)
@@ -325,7 +323,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref State a)] ())
+                    (Fn [(Ref State a)] ())
                 </p>
                 <pre class="args">
                     (print-test-results state)
@@ -345,7 +343,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [State] State)
+                    (Fn [State] State)
                 </p>
                 <pre class="args">
                     (reset state)

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
@@ -185,7 +185,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] (Vector2 a))
                 </p>
                 <pre class="args">
                     (add a b)
@@ -204,7 +204,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] a)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] a)
                 </p>
                 <pre class="args">
                     (angle-between a b)
@@ -224,7 +224,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (anti-parallel? a b)
@@ -244,7 +244,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b)] (Vector2 a))
                 </p>
                 <span>
                     
@@ -264,7 +264,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Vector2 a)] ())
+                    (Fn [(Vector2 a)] ())
                 </p>
                 <span>
                     
@@ -284,7 +284,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] a)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] a)
                 </p>
                 <pre class="args">
                     (dist a b)
@@ -304,7 +304,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), a] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b), a] (Vector2 a))
                 </p>
                 <pre class="args">
                     (div a n)
@@ -323,7 +323,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] a)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] a)
                 </p>
                 <pre class="args">
                     (dot a b)
@@ -343,7 +343,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] a)
+                    (Fn [(Ref (Vector2 a) b)] a)
                 </p>
                 <pre class="args">
                     (heading a)
@@ -363,7 +363,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [a, a] (Vector2 a))
+                    (Fn [a, a] (Vector2 a))
                 </p>
                 <span>
                     
@@ -383,7 +383,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] a)
+                    (Fn [(Ref (Vector2 a) b)] a)
                 </p>
                 <pre class="args">
                     (mag o)
@@ -403,7 +403,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] a)
+                    (Fn [(Ref (Vector2 a) b)] a)
                 </p>
                 <pre class="args">
                     (mag-sq o)
@@ -423,7 +423,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a] b c), (Ref (Vector2 a) d)] (Vector2 b))
+                    (Fn [(Fn [a] b c), (Ref (Vector2 a) d)] (Vector2 b))
                 </p>
                 <pre class="args">
                     (map f v)
@@ -442,7 +442,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), a] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b), a] (Vector2 a))
                 </p>
                 <pre class="args">
                     (mul a n)
@@ -461,7 +461,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b)] (Vector2 a))
                 </p>
                 <pre class="args">
                     (normalize o)
@@ -481,7 +481,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (parallel? a b)
@@ -501,7 +501,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (perpendicular? a b)
@@ -521,7 +521,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] String)
+                    (Fn [(Ref (Vector2 a) b)] String)
                 </p>
                 <span>
                     
@@ -541,7 +541,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Vector2 a))
+                    (Fn [] (Vector2 a))
                 </p>
                 <pre class="args">
                     (random)
@@ -560,7 +560,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), a] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b), a] (Vector2 a))
                 </p>
                 <pre class="args">
                     (rotate a n)
@@ -580,7 +580,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Vector2 a), a] (Vector2 a))
+                    (Fn [(Vector2 a), a] (Vector2 a))
                 </p>
                 <span>
                     
@@ -600,7 +600,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), a] ())
+                    (Fn [(Ref (Vector2 a) b), a] ())
                 </p>
                 <span>
                     
@@ -620,7 +620,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Vector2 a), a] (Vector2 a))
+                    (Fn [(Vector2 a), a] (Vector2 a))
                 </p>
                 <span>
                     
@@ -640,7 +640,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), a] ())
+                    (Fn [(Ref (Vector2 a) b), a] ())
                 </p>
                 <span>
                     
@@ -660,7 +660,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] String)
+                    (Fn [(Ref (Vector2 a) b)] String)
                 </p>
                 <span>
                     
@@ -680,7 +680,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] (Vector2 a))
                 </p>
                 <pre class="args">
                     (sub a b)
@@ -699,7 +699,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] a)
+                    (Fn [(Ref (Vector2 a) b)] a)
                 </p>
                 <pre class="args">
                     (sum o)
@@ -718,7 +718,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Vector2 a), (Ref (λ [a] a b) c)] (Vector2 a))
+                    (Fn [(Vector2 a), (Ref (Fn [a] a b) c)] (Vector2 a))
                 </p>
                 <span>
                     
@@ -738,7 +738,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Vector2 a), (Ref (λ [a] a b) c)] (Vector2 a))
+                    (Fn [(Vector2 a), (Ref (Fn [a] a b) c)] (Vector2 a))
                 </p>
                 <span>
                     
@@ -758,7 +758,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (vapprox a b)
@@ -778,7 +778,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b), (Ref (Vector2 a) c), a] (Vector2 a))
+                    (Fn [(Ref (Vector2 a) b), (Ref (Vector2 a) c), a] (Vector2 a))
                 </p>
                 <pre class="args">
                     (vlerp a b amnt)
@@ -798,7 +798,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, b] a c), a, (Ref (Vector2 b) d)] a)
+                    (Fn [(Fn [a, b] a c), a, (Ref (Vector2 b) d)] a)
                 </p>
                 <pre class="args">
                     (vreduce f i v)
@@ -817,7 +817,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] (Ref a b))
+                    (Fn [(Ref (Vector2 a) b)] (Ref a b))
                 </p>
                 <span>
                     
@@ -837,7 +837,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector2 a) b)] (Ref a b))
+                    (Fn [(Ref (Vector2 a) b)] (Ref a b))
                 </p>
                 <span>
                     
@@ -857,7 +857,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Vector2 a))
+                    (Fn [] (Vector2 a))
                 </p>
                 <pre class="args">
                     (zero)
@@ -876,7 +876,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, b] c d), (Ref (Vector2 a) e), (Ref (Vector2 b) f)] (Vector2 c))
+                    (Fn [(Fn [a, b] c d), (Ref (Vector2 a) e), (Ref (Vector2 b) f)] (Vector2 c))
                 </p>
                 <pre class="args">
                     (zip f a b)

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
@@ -185,7 +185,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
                 </p>
                 <pre class="args">
                     (add a b)
@@ -204,7 +204,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] a)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] a)
                 </p>
                 <pre class="args">
                     (angle-between a b)
@@ -224,7 +224,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (anti-parallel? a b)
@@ -244,7 +244,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
                 </p>
                 <pre class="args">
                     (cmul a b)
@@ -263,7 +263,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b)] (Vector3 a))
                 </p>
                 <span>
                     
@@ -283,7 +283,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
                 </p>
                 <pre class="args">
                     (cross a b)
@@ -303,7 +303,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Vector3 a)] ())
+                    (Fn [(Vector3 a)] ())
                 </p>
                 <span>
                     
@@ -323,7 +323,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] a)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] a)
                 </p>
                 <pre class="args">
                     (dist a b)
@@ -343,7 +343,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), a] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b), a] (Vector3 a))
                 </p>
                 <pre class="args">
                     (div v n)
@@ -362,7 +362,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] a)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] a)
                 </p>
                 <pre class="args">
                     (dot a b)
@@ -382,7 +382,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [a, a, a] (Vector3 a))
+                    (Fn [a, a, a] (Vector3 a))
                 </p>
                 <span>
                     
@@ -402,7 +402,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] a)
+                    (Fn [(Ref (Vector3 a) b)] a)
                 </p>
                 <pre class="args">
                     (mag o)
@@ -422,7 +422,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] a)
+                    (Fn [(Ref (Vector3 a) b)] a)
                 </p>
                 <pre class="args">
                     (mag-sq o)
@@ -442,7 +442,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a] b c), (Ref (Vector3 a) d)] (Vector3 b))
+                    (Fn [(Fn [a] b c), (Ref (Vector3 a) d)] (Vector3 b))
                 </p>
                 <pre class="args">
                     (map f v)
@@ -461,7 +461,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), a] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b), a] (Vector3 a))
                 </p>
                 <pre class="args">
                     (mul v n)
@@ -480,7 +480,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b)] (Vector3 a))
                 </p>
                 <pre class="args">
                     (neg a)
@@ -499,7 +499,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b)] (Vector3 a))
                 </p>
                 <pre class="args">
                     (normalize o)
@@ -519,7 +519,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (parallel? a b)
@@ -539,7 +539,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (perpendicular? a b)
@@ -559,7 +559,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] String)
+                    (Fn [(Ref (Vector3 a) b)] String)
                 </p>
                 <span>
                     
@@ -579,7 +579,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Vector3 a))
+                    (Fn [] (Vector3 a))
                 </p>
                 <pre class="args">
                     (random)
@@ -598,7 +598,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Vector3 a), a] (Vector3 a))
+                    (Fn [(Vector3 a), a] (Vector3 a))
                 </p>
                 <span>
                     
@@ -618,7 +618,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), a] ())
+                    (Fn [(Ref (Vector3 a) b), a] ())
                 </p>
                 <span>
                     
@@ -638,7 +638,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Vector3 a), a] (Vector3 a))
+                    (Fn [(Vector3 a), a] (Vector3 a))
                 </p>
                 <span>
                     
@@ -658,7 +658,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), a] ())
+                    (Fn [(Ref (Vector3 a) b), a] ())
                 </p>
                 <span>
                     
@@ -678,7 +678,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Vector3 a), a] (Vector3 a))
+                    (Fn [(Vector3 a), a] (Vector3 a))
                 </p>
                 <span>
                     
@@ -698,7 +698,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), a] ())
+                    (Fn [(Ref (Vector3 a) b), a] ())
                 </p>
                 <span>
                     
@@ -718,7 +718,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] String)
+                    (Fn [(Ref (Vector3 a) b)] String)
                 </p>
                 <span>
                     
@@ -738,7 +738,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] (Vector3 a))
                 </p>
                 <pre class="args">
                     (sub a b)
@@ -757,7 +757,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] a)
+                    (Fn [(Ref (Vector3 a) b)] a)
                 </p>
                 <pre class="args">
                     (sum o)
@@ -776,7 +776,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Vector3 a), (Ref (λ [a] a b) c)] (Vector3 a))
+                    (Fn [(Vector3 a), (Ref (Fn [a] a b) c)] (Vector3 a))
                 </p>
                 <span>
                     
@@ -796,7 +796,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Vector3 a), (Ref (λ [a] a b) c)] (Vector3 a))
+                    (Fn [(Vector3 a), (Ref (Fn [a] a b) c)] (Vector3 a))
                 </p>
                 <span>
                     
@@ -816,7 +816,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Vector3 a), (Ref (λ [a] a b) c)] (Vector3 a))
+                    (Fn [(Vector3 a), (Ref (Fn [a] a b) c)] (Vector3 a))
                 </p>
                 <span>
                     
@@ -836,7 +836,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c)] Bool)
                 </p>
                 <pre class="args">
                     (vapprox a b)
@@ -856,7 +856,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b), (Ref (Vector3 a) c), a] (Vector3 a))
+                    (Fn [(Ref (Vector3 a) b), (Ref (Vector3 a) c), a] (Vector3 a))
                 </p>
                 <pre class="args">
                     (vlerp a b amnt)
@@ -876,7 +876,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, b] a c), a, (Ref (Vector3 b) d)] a)
+                    (Fn [(Fn [a, b] a c), a, (Ref (Vector3 b) d)] a)
                 </p>
                 <pre class="args">
                     (vreduce f i v)
@@ -895,7 +895,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] (Ref a b))
+                    (Fn [(Ref (Vector3 a) b)] (Ref a b))
                 </p>
                 <span>
                     
@@ -915,7 +915,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] (Ref a b))
+                    (Fn [(Ref (Vector3 a) b)] (Ref a b))
                 </p>
                 <span>
                     
@@ -935,7 +935,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (Vector3 a) b)] (Ref a b))
+                    (Fn [(Ref (Vector3 a) b)] (Ref a b))
                 </p>
                 <span>
                     
@@ -955,7 +955,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [] (Vector3 a))
+                    (Fn [] (Vector3 a))
                 </p>
                 <pre class="args">
                     (zero)
@@ -974,7 +974,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, b] c d), (Ref (Vector3 a) e), (Ref (Vector3 b) f)] (Vector3 c))
+                    (Fn [(Fn [a, b] c d), (Ref (Vector3 a) e), (Ref (Vector3 b) f)] (Vector3 c))
                 </p>
                 <pre class="args">
                     (zip f a b)

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -166,7 +166,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) b)] Bool)
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) b)] Bool)
                 </p>
                 <pre class="args">
                     (= a b)
@@ -185,7 +185,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe (VectorN a)))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe (VectorN a)))
                 </p>
                 <pre class="args">
                     (add a b)
@@ -204,7 +204,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe a))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe a))
                 </p>
                 <pre class="args">
                     (angle-between a b)
@@ -224,7 +224,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe Bool))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe Bool))
                 </p>
                 <pre class="args">
                     (anti-parallel? a b)
@@ -244,7 +244,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] (VectorN a))
+                    (Fn [(Ref (VectorN a) b)] (VectorN a))
                 </p>
                 <span>
                     
@@ -264,7 +264,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(VectorN a)] ())
+                    (Fn [(VectorN a)] ())
                 </p>
                 <span>
                     
@@ -284,7 +284,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe a))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe a))
                 </p>
                 <pre class="args">
                     (dist a b)
@@ -304,7 +304,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), a] (VectorN a))
+                    (Fn [(Ref (VectorN a) b), a] (VectorN a))
                 </p>
                 <pre class="args">
                     (div a n)
@@ -323,7 +323,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe a))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe a))
                 </p>
                 <pre class="args">
                     (dot x y)
@@ -343,7 +343,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [Int, (Array a)] (VectorN a))
+                    (Fn [Int, (Array a)] (VectorN a))
                 </p>
                 <span>
                     
@@ -363,7 +363,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] a)
+                    (Fn [(Ref (VectorN a) b)] a)
                 </p>
                 <pre class="args">
                     (mag o)
@@ -383,7 +383,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] a)
+                    (Fn [(Ref (VectorN a) b)] a)
                 </p>
                 <pre class="args">
                     (mag-sq o)
@@ -403,7 +403,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), a] (VectorN a))
+                    (Fn [(Ref (VectorN a) b), a] (VectorN a))
                 </p>
                 <pre class="args">
                     (mul a n)
@@ -422,7 +422,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] (Ref Int b))
+                    (Fn [(Ref (VectorN a) b)] (Ref Int b))
                 </p>
                 <span>
                     
@@ -442,7 +442,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] (VectorN a))
+                    (Fn [(Ref (VectorN a) b)] (VectorN a))
                 </p>
                 <pre class="args">
                     (normalize o)
@@ -462,7 +462,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe Bool))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe Bool))
                 </p>
                 <pre class="args">
                     (parallel? a b)
@@ -482,7 +482,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe Bool))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) b)] (Maybe Bool))
                 </p>
                 <pre class="args">
                     (perpendicular? a b)
@@ -502,7 +502,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] String)
+                    (Fn [(Ref (VectorN a) b)] String)
                 </p>
                 <span>
                     
@@ -522,7 +522,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] (VectorN a))
+                    (Fn [Int] (VectorN a))
                 </p>
                 <pre class="args">
                     (random-sized n)
@@ -541,7 +541,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(VectorN a), Int] (VectorN a))
+                    (Fn [(VectorN a), Int] (VectorN a))
                 </p>
                 <span>
                     
@@ -561,7 +561,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), Int] ())
+                    (Fn [(Ref (VectorN a) b), Int] ())
                 </p>
                 <span>
                     
@@ -581,7 +581,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(VectorN a), (Array a)] (VectorN a))
+                    (Fn [(VectorN a), (Array a)] (VectorN a))
                 </p>
                 <span>
                     
@@ -601,7 +601,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Array a)] ())
+                    (Fn [(Ref (VectorN a) b), (Array a)] ())
                 </p>
                 <span>
                     
@@ -621,7 +621,7 @@
                     template
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] String)
+                    (Fn [(Ref (VectorN a) b)] String)
                 </p>
                 <span>
                     
@@ -641,7 +641,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe (VectorN a)))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) c)] (Maybe (VectorN a)))
                 </p>
                 <pre class="args">
                     (sub a b)
@@ -660,7 +660,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(VectorN a), (Ref (λ [Int] Int b) c)] (VectorN a))
+                    (Fn [(VectorN a), (Ref (Fn [Int] Int b) c)] (VectorN a))
                 </p>
                 <span>
                     
@@ -680,7 +680,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(VectorN a), (Ref (λ [(Array a)] (Array a) b) c)] (VectorN a))
+                    (Fn [(VectorN a), (Ref (Fn [(Array a)] (Array a) b) c)] (VectorN a))
                 </p>
                 <span>
                     
@@ -700,7 +700,7 @@
                     instantiate
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b)] (Ref (Array a) b))
+                    (Fn [(Ref (VectorN a) b)] (Ref (Array a) b))
                 </p>
                 <span>
                     
@@ -720,7 +720,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(Ref (VectorN a) b), (Ref (VectorN a) c), a] (Maybe (VectorN a)))
+                    (Fn [(Ref (VectorN a) b), (Ref (VectorN a) c), a] (Maybe (VectorN a)))
                 </p>
                 <pre class="args">
                     (vlerp a b amnt)
@@ -740,7 +740,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [Int] (VectorN a))
+                    (Fn [Int] (VectorN a))
                 </p>
                 <pre class="args">
                     (zero-sized n)
@@ -759,7 +759,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, b] c d), (Ref (VectorN a) e), (Ref (VectorN b) f)] (Maybe (VectorN c)))
+                    (Fn [(Fn [a, b] c d), (Ref (VectorN a) e), (Ref (VectorN b) f)] (Maybe (VectorN c)))
                 </p>
                 <pre class="args">
                     (zip f a b)
@@ -778,7 +778,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (λ [(λ [a, b] c d), (Ref (Array a) e), (Ref (Array b) f)] (VectorN c))
+                    (Fn [(Fn [a, b] c d), (Ref (Array a) e), (Ref (Array b) f)] (VectorN c))
                 </p>
                 <pre class="args">
                     (zip- f a b)

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e;
 
 name=$1

--- a/run_carp_tests.sh
+++ b/run_carp_tests.sh
@@ -56,6 +56,10 @@ fi
 
 # Generate docs
 ./carp.sh ./docs/core/generate_core_docs.carp
-./carp.sh ./docs/sdl/generate_sdl_docs.carp
+
+# Generate SDL docs unless the `--no_sdl` argument was passed in
+if [[ ${NO_SDL} -eq 0 ]]; then
+  ./carp.sh ./docs/sdl/generate_sdl_docs.carp
+fi
 
 echo "ALL TESTS DONE."

--- a/run_carp_tests.sh
+++ b/run_carp_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e; # will make the script stop if there are any errors
 set -u; # will make the script stop if there is use of undefined

--- a/test/check.sh
+++ b/test/check.sh
@@ -1,10 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Checks the code (using --check) and compares the output to the .expected file
-
 ./carp.sh $1 --log-memory --check > test/output/$1.output.actual 2>&1
 
-if ! diff test/output/$1.output.actual test/output/$1.output.expected; then
+if ! diff --strip-trailing-cr test/output/$1.output.actual test/output/$1.output.expected; then
   echo "$1 failed."
   exit 1
 else

--- a/test/execute.sh
+++ b/test/execute.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Runs the executable and compares its output to the .expected file
-
+./carp.sh $1 --log-memory -b && \
+  ./out/Untitled > test/output/$1.output.actual 2>&1
 echo $1
-./carp.sh $1 --log-memory -x > test/output/$1.output.actual 2>&1
 
-if ! diff test/output/$1.output.actual test/output/$1.output.expected; then
+if ! diff --strip-trailing-cr test/output/$1.output.actual test/output/$1.output.expected; then
   echo "$1 failed."
   exit 1
 else

--- a/test/output/test-for-errors/no_matching_instance.carp.output.expected
+++ b/test/output/test-for-errors/no_matching_instance.carp.output.expected
@@ -1,3 +1,3 @@
-no_matching_instance.carp:10:14 Can't find matching lookup for symbol 'some-interface' of type (λ [Float] Bool)
+no_matching_instance.carp:10:14 Can't find matching lookup for symbol 'some-interface' of type (Fn [Float] Bool)
 None of the possibilities have the correct signature:
-    A.some-interface : (λ [Int] Bool)
+    A.some-interface : (Fn [Int] Bool)

--- a/test/output/test-for-errors/trick_resolution.carp.output.expected
+++ b/test/output/test-for-errors/trick_resolution.carp.output.expected
@@ -1,4 +1,4 @@
-trick_resolution.carp:7:14 Can't find matching lookup for symbol 'blurgh' of type (λ [(Ref String t3)] Bool)
+trick_resolution.carp:7:14 Can't find matching lookup for symbol 'blurgh' of type (Fn [(Ref String t3)] Bool)
 None of the possibilities have the correct signature:
-    A.blurgh : (λ [Int] Bool)
-    B.blurgh : (λ [Float] Bool)
+    A.blurgh : (Fn [Int] Bool)
+    B.blurgh : (Fn [Float] Bool)

--- a/test/output/test-for-errors/wrong_sig_for_defn.carp.output.expected
+++ b/test/output/test-for-errors/wrong_sig_for_defn.carp.output.expected
@@ -1,2 +1,2 @@
- Inferred Macro, can't unify with (λ [] Bool).
-wrong_sig_for_defn.carp:4:1 Inferred (λ [] Bool), can't unify with (λ [Int] Float).
+ Inferred Macro, can't unify with (Fn [] Bool).
+wrong_sig_for_defn.carp:4:1 Inferred (Fn [] Bool), can't unify with (Fn [Int] Float).

--- a/test/record.sh
+++ b/test/record.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 carp $1 --log-memory -x > test/output/$1.output.expected 2>&1


### PR DESCRIPTION
It all works except some for some logging from the C compiler/linker `Creating library out\Untitled.lib and object out\Untitled.exp` seems to be related to [this](https://stackoverflow.com/questions/2820694/why-does-my-visual-c-exe-project-build-create-lib-and-exp-files) but I'm not sure how to disable the logging.

It uses the dos2unix binary to turn the output of the run so it matches the expected ouput. I think it comes by default with MSYS but will need to check, sed could be used instead.

Not sure why this check is different as well:
```
<     A.some-interface : (Fn [Int] Bool)
---
>     A.some-interface : (λ [Int] Bool)
```