### PR TITLE
Makes enumerated work with empty arrays

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -315,9 +315,11 @@ The trailing elements of the longer array will be discarded.")
 
   (doc enumerated "creates a new array of `Pair`s where the first position is the index and the second position is the element from the original array `xs`.")
   (defn enumerated [xs]
-    (zip &Pair.init-from-refs
-         &(range 0 (length xs) 1) ; Inefficient, creates a temporary array.
-         xs))
+    (if (Array.empty? xs) ; Only there because range will crash with a length of 0
+      []
+      (zip &Pair.init-from-refs
+           &(range 0 (length xs) 1) ; Inefficient, creates a temporary array.
+           xs)))
 
   (doc nth "gets a reference to the `n`th element from an array `arr` wrapped on a `Maybe`.
 

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -315,11 +315,13 @@ The trailing elements of the longer array will be discarded.")
 
   (doc enumerated "creates a new array of `Pair`s where the first position is the index and the second position is the element from the original array `xs`.")
   (defn enumerated [xs]
-    (if (Array.empty? xs) ; Only there because range will crash with a length of 0
-      []
-      (zip &Pair.init-from-refs
-           &(range 0 (length xs) 1) ; Inefficient, creates a temporary array.
-           xs)))
+    (let-do [arr (allocate (length xs))]
+      (for [i 0 (length xs)]
+        (aset-uninitialized!
+          &arr
+          i
+          (Pair.init-from-refs &i (unsafe-nth xs i))))
+      arr))
 
   (doc nth "gets a reference to the `n`th element from an array `arr` wrapped on a `Maybe`.
 

--- a/test/array.carp
+++ b/test/array.carp
@@ -192,8 +192,8 @@
                 &(str &(Array.enumerated &[@"a" @"b" @"c"]))
                 "enumerated works as expected")
   (assert-equal test
-                "[]"
-                &(str &(Array.enumerated &(the (Array Int) [])))
+                &[]
+                &(Array.enumerated &(the (Array Int) []))
                 "enumerated works with empty arrays")
   (let-do [arr [1 2 3 4 5 6]
            exp [1 2 3 4 5 6 7]

--- a/test/array.carp
+++ b/test/array.carp
@@ -191,6 +191,10 @@
                 "[(Pair 0 @\"a\") (Pair 1 @\"b\") (Pair 2 @\"c\")]"
                 &(str &(Array.enumerated &[@"a" @"b" @"c"]))
                 "enumerated works as expected")
+  (assert-equal test
+                "[]"
+                &(str &(Array.enumerated &(the (Array Int) [])))
+                "enumerated works with empty arrays")
   (let-do [arr [1 2 3 4 5 6]
            exp [1 2 3 4 5 6 7]
            new (Array.push-back arr 7)]


### PR DESCRIPTION
This is a work around for https://github.com/carp-lang/Carp/issues/776 the proper fix would be to allow range to take `(range 0 0 1)` inputs but the decision about what the correct behavior should be hasn't been made.