### PR TITLE
Add assert-ref-equal, assert-just, and assert-nothing

### DIFF
--- a/core/Test.carp
+++ b/core/Test.carp
@@ -38,6 +38,27 @@
   (defn assert-false [state x descr]
     (assert-equal state false x descr))
 
+
+  (doc assert-ref-equal "Assert that x and y are equal by reference. Reference equality needs to be implemented for their type.")
+  (defn assert-ref-equal [state x y descr]
+    (handler state &x &y descr "value" =))
+
+  (doc assert-just "Assert that x is a `Just`.")
+  (defn assert-just [state x descr]
+    (assert-true state (Maybe.just? x) descr))
+
+  (doc assert-nothing "Assert that x is a `Nothing`.")
+  (defn assert-nothing [state x descr]
+    (assert-true state (Maybe.nothing? x) descr))
+
+  (doc assert-success "Assert that x is a `Success`.")
+  (defn assert-success [state x descr]
+    (assert-true state (Result.success? x) descr))
+
+  (doc assert-error "Assert that x is an `Error`.")
+  (defn assert-error [state x descr]
+    (assert-true state (Result.error? x) descr))
+
   (doc reset "Reset test state.")
   (defn reset [state]
     (State.set-failed (State.set-passed state 0) 0))

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -196,6 +196,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#assert-error">
+                    <h3 id="assert-error">
+                        assert-error
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (Fn [(Ref State a), (Ref (Result b c) d), (Ref e f)] State)
+                </p>
+                <pre class="args">
+                    (assert-error state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is an <code>Error</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#assert-exit">
                     <h3 id="assert-exit">
                         assert-exit
@@ -236,6 +256,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#assert-just">
+                    <h3 id="assert-just">
+                        assert-just
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (Fn [(Ref State a), (Ref (Maybe b) c), (Ref d e)] State)
+                </p>
+                <pre class="args">
+                    (assert-just state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is a <code>Just</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#assert-not-equal">
                     <h3 id="assert-not-equal">
                         assert-not-equal
@@ -252,6 +292,26 @@
                 </pre>
                 <p class="doc">
                     <p>Assert that x and y are not equal. Equality needs to be implemented for their type.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-nothing">
+                    <h3 id="assert-nothing">
+                        assert-nothing
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (Fn [(Ref State a), (Ref (Maybe b) c), (Ref d e)] State)
+                </p>
+                <pre class="args">
+                    (assert-nothing state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is a <code>Nothing</code>.</p>
 
                 </p>
             </div>
@@ -276,6 +336,26 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#assert-ref-equal">
+                    <h3 id="assert-ref-equal">
+                        assert-ref-equal
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (Fn [(Ref State a), b, b, (Ref c d)] State)
+                </p>
+                <pre class="args">
+                    (assert-ref-equal state x y descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x and y are equal by reference. Reference equality needs to be implemented for their type.</p>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#assert-signal">
                     <h3 id="assert-signal">
                         assert-signal
@@ -292,6 +372,26 @@
                 </pre>
                 <p class="doc">
                     <p>Assert that function f aborts with OS signal signal.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#assert-success">
+                    <h3 id="assert-success">
+                        assert-success
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (Fn [(Ref State a), (Ref (Result b c) d), (Ref e f)] State)
+                </p>
+                <pre class="args">
+                    (assert-success state x descr)
+                </pre>
+                <p class="doc">
+                    <p>Assert that x is a <code>Success</code>.</p>
 
                 </p>
             </div>

--- a/test/array.carp
+++ b/test/array.carp
@@ -35,94 +35,90 @@
   (assert-true test
                (/= &[1 2 4] &[1 2 3])
                "/= works as expected II")
-  (assert-equal test
-                &[0 0 0 0]
-                &(replicate 4 &0)
-                "replicate works as expected")
-  (assert-equal test
-                &[0 0 0 0]
-                &(repeat 4 &make-zero)
-                "repeat works as expected")
-  (assert-equal test
-                &[0 1 2 3]
-                &(repeat-indexed 4 make-idx)
-                "repeat-indexed works as expected")
+  (assert-ref-equal test
+                    [0 0 0 0]
+                    (replicate 4 &0)
+                    "replicate works as expected")
+  (assert-ref-equal test
+                    [0 0 0 0]
+                    (repeat 4 &make-zero)
+                    "repeat works as expected")
+  (assert-ref-equal test
+                    [0 1 2 3]
+                    (repeat-indexed 4 make-idx)
+                    "repeat-indexed works as expected")
   (assert-equal test
                 1
                 (unsafe-first &[1 2 3])
                 "unsafe-first works as expected")
-  (assert-equal test
-                &(Maybe.Just 1)
-                &(first &[1 2 3])
-                "first works as expected")
-  (assert-equal test
-                &(the (Maybe Int) (Maybe.Nothing))
-                &(first &[])
-                "first works as expected on empty array")
+  (assert-ref-equal test
+                    (Maybe.Just 1)
+                    (first &[1 2 3])
+                    "first works as expected")
+  (assert-nothing test
+                  &(first &(the (Array Int) []))
+                  "first works as expected on empty array")
   (assert-equal test
                 \c
                 (unsafe-last &[\a \b \c])
                 "unsafe-last works as expected")
-  (assert-equal test
-                &(Maybe.Just \c)
-                &(last &[\a \b \c])
-                "last works as expected")
-  (assert-equal test
-                &(the (Maybe Char) (Maybe.Nothing))
-                &(last &[])
-                "last works as expected on empty array")
-  (assert-equal test
-                &[3 2 1]
-                &(reverse [1 2 3])
-                "reverse works as expected")
-  (assert-equal test
-                &(Maybe.Just 10)
-                &(maximum &(range 1 10 1))
-                "maximum works as expected")
-  (assert-equal test
-                &(Maybe.Just 1)
-                &(minimum &(range 1 10 1))
-                "minimum works as expected")
-  (assert-equal test
-                &(Maybe.Just (Pair.init 2 1))
-                &(maximum &[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
-                "maximum works on pairs")
-  (assert-equal test
-                &(Maybe.Just (Pair.init 1 3))
-                &(minimum &[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
-                "minimum works on pairs")
-  (assert-equal test
-                &(Maybe.Just 3)
-                &(index-of &[1 2 3 4] &4)
-                "index-of works as expected when element is in the array")
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(index-of &[1 2 3 4] &7)
-                "index-of works as expected when element is not in the array")
+  (assert-ref-equal test
+                    (Maybe.Just \c)
+                    (last &[\a \b \c])
+                    "last works as expected")
+  (assert-nothing test
+                  &(last &(the (Array Int) []))
+                  "last works as expected on empty array")
+  (assert-ref-equal test
+                    [3 2 1]
+                    (reverse [1 2 3])
+                    "reverse works as expected")
+  (assert-ref-equal test
+                    (Maybe.Just 10)
+                    (maximum &(range 1 10 1))
+                    "maximum works as expected")
+  (assert-ref-equal test
+                    (Maybe.Just 1)
+                    (minimum &(range 1 10 1))
+                    "minimum works as expected")
+  (assert-ref-equal test
+                    (Maybe.Just (Pair.init 2 1))
+                    (maximum &[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
+                    "maximum works on pairs")
+  (assert-ref-equal test
+                    (Maybe.Just (Pair.init 1 3))
+                    (minimum &[(Pair.init 1 3) (Pair.init 2 1) (Pair.init 2 0)])
+                    "minimum works on pairs")
+  (assert-ref-equal test
+                    (Maybe.Just 3)
+                    (index-of &[1 2 3 4] &4)
+                    "index-of works as expected when element is in the array")
+  (assert-nothing test
+                  &(index-of &[1 2 3 4] &7)
+                  "index-of works as expected when element is not in the array")
   (assert-equal test
                 55
                 (sum &(range 1 10 1))
                 "sum works as expected")
-  (assert-equal test
-                &[2 3]
-                &(slice &(range 1 10 1) 1 3)
-                "slice works as expected")
-  (assert-equal test
-                &[1 2 3]
-                &(prefix &(range 1 10 1) 3)
-                "prefix works as expected")
-  (assert-equal test
-                &[8 9 10]
-                &(suffix &(range 1 10 1) 7)
-                "suffix works as expected")
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(nth &a 100)
-                "nth works as expected")
-  (assert-equal test
-                &(Maybe.Just 0)
-                &(nth &a 0)
-                "nth works as expected")
+  (assert-ref-equal test
+                    [2 3]
+                    (slice &(range 1 10 1) 1 3)
+                    "slice works as expected")
+  (assert-ref-equal test
+                    [1 2 3]
+                    (prefix &(range 1 10 1) 3)
+                    "prefix works as expected")
+  (assert-ref-equal test
+                    [8 9 10]
+                    (suffix &(range 1 10 1) 7)
+                    "suffix works as expected")
+  (assert-nothing test
+                  &(nth &a 100)
+                  "nth works as expected")
+  (assert-ref-equal test
+                    (Maybe.Just 0)
+                    (nth &a 0)
+                    "nth works as expected")
   (assert-equal test
                 5
                 @(unsafe-nth &a 5)
@@ -131,62 +127,62 @@
                 &[1 2 3]
                 (unsafe-nth &(nested) 0)
                 "unsafe-nth works as expected")
-  (assert-equal test
-                &[10 11 12 13 14 15]
-                &(range 10 15 1)
-                "range works as expected")
-  (assert-equal test
-                &[10.0 10.5 11.0 11.5 12.0]
-                &(range 10.0 12.0 0.5)
-                "range works as expected on non-integers")
-  (assert-equal test
-                &[10 9 8 7 6 5 4 3 2 1 0]
-                &(range 10 0 -1)
-                "range backwards works as expected")
-  (assert-equal test
-                &[1 3 5 7 9]
-                &(range 1 10 2)
-                "range works as expected if we dont exactly hit")
-  (assert-equal test
-                &[10 8 6 4 2]
-                &(range 10 1 -2)
-                "range backwards works as expected if we dont exactly hit")
-  (assert-equal test
-                &[@"Hi!" @"Hi!" @"Hi!" @"Hi!" @"Hi!"]
-                &(copy-map &excl-ref &b)
-                "copy-map works as expected")
-  (assert-equal test
-                &[@"Hi!" @"Hi!" @"Hi!" @"Hi!" @"Hi!"]
-                &(endo-map &excl @&b)
-                "endo-map works as expected")
-  (assert-equal test
-                &[1 2]
-                &(swap [2 1] 0 1)
-                "swap works as expected")
-  (assert-equal test
-                &[2 1]
-                &(let-do [arr [1 2]]
-                   (Array.swap! &arr 0 1)
-                   arr)
-                "swap! works as expected")
-  (assert-equal test
-                &[1 3]
-                &(aupdate [1 2] 1 &inc-ref)
-                "aupdate works as expected")
-  (assert-equal test
-                &[1 3]
-                &(let-do [arr [1 2]]
-                   (aupdate! &arr 1 &inc-ref)
-                   arr)
-                "aupdate! works as expected")
-  (assert-equal test
-                &[1 2 3 4 5 6 7 8]
-                &(concat &[[1] [2 3] [4 5 6] [7 8]])
-                "concat works as expected")
-  (assert-equal test
-                &[11 22 33]
-                &(zip &add-ref &[1 2 3 4 5 6 7] &[10 20 30])
-                "zip works as expected")
+  (assert-ref-equal test
+                    [10 11 12 13 14 15]
+                    (range 10 15 1)
+                    "range works as expected")
+  (assert-ref-equal test
+                    [10.0 10.5 11.0 11.5 12.0]
+                    (range 10.0 12.0 0.5)
+                    "range works as expected on non-integers")
+  (assert-ref-equal test
+                    [10 9 8 7 6 5 4 3 2 1 0]
+                    (range 10 0 -1)
+                    "range backwards works as expected")
+  (assert-ref-equal test
+                    [1 3 5 7 9]
+                    (range 1 10 2)
+                    "range works as expected if we dont exactly hit")
+  (assert-ref-equal test
+                    [10 8 6 4 2]
+                    (range 10 1 -2)
+                    "range backwards works as expected if we dont exactly hit")
+  (assert-ref-equal test
+                    [@"Hi!" @"Hi!" @"Hi!" @"Hi!" @"Hi!"]
+                    (copy-map &excl-ref &b)
+                    "copy-map works as expected")
+  (assert-ref-equal test
+                    [@"Hi!" @"Hi!" @"Hi!" @"Hi!" @"Hi!"]
+                    (endo-map &excl @&b)
+                    "endo-map works as expected")
+  (assert-ref-equal test
+                    [1 2]
+                    (swap [2 1] 0 1)
+                    "swap works as expected")
+  (assert-ref-equal test
+                    [2 1]
+                    (let-do [arr [1 2]]
+                      (Array.swap! &arr 0 1)
+                      arr)
+                    "swap! works as expected")
+  (assert-ref-equal test
+                    [1 3]
+                    (aupdate [1 2] 1 &inc-ref)
+                    "aupdate works as expected")
+  (assert-ref-equal test
+                    [1 3]
+                    (let-do [arr [1 2]]
+                      (aupdate! &arr 1 &inc-ref)
+                      arr)
+                    "aupdate! works as expected")
+  (assert-ref-equal test
+                    [1 2 3 4 5 6 7 8]
+                    (concat &[[1] [2 3] [4 5 6] [7 8]])
+                    "concat works as expected")
+  (assert-ref-equal test
+                    [11 22 33]
+                    (zip &add-ref &[1 2 3 4 5 6 7] &[10 20 30])
+                    "zip works as expected")
   (assert-equal test
                 "[(Pair 0 @\"a\") (Pair 1 @\"b\") (Pair 2 @\"c\")]"
                 &(str &(Array.enumerated &[@"a" @"b" @"c"]))
@@ -194,102 +190,94 @@
   (let-do [arr [1 2 3 4 5 6]
            exp [1 2 3 4 5 6 7]
            new (Array.push-back arr 7)]
-          (assert-equal test
-                        &exp
-                        &new
-                        "Array.push-back works as expected"))
+          (assert-ref-equal test
+                            exp
+                            new
+                            "Array.push-back works as expected"))
   (let-do [arr [1 2 3]
            exp [1 2 3 4 5 6 7 8 9 10 11 12 13 14]]
-          (Array.push-back! &arr 4)
-          (Array.push-back! &arr 5)
-          (Array.push-back! &arr 6)
-          (Array.push-back! &arr 7)
-          (Array.push-back! &arr 8)
-          (Array.push-back! &arr 9)
-          (Array.push-back! &arr 10)
-          (Array.push-back! &arr 11)
-          (Array.push-back! &arr 12)
-          (Array.push-back! &arr 13)
-          (Array.push-back! &arr 14)
-          (assert-equal test
-                        &exp
-                        &arr
-                        "Array.push-back! works as expected"))
+    (Array.push-back! &arr 4)
+    (Array.push-back! &arr 5)
+    (Array.push-back! &arr 6)
+    (Array.push-back! &arr 7)
+    (Array.push-back! &arr 8)
+    (Array.push-back! &arr 9)
+    (Array.push-back! &arr 10)
+    (Array.push-back! &arr 11)
+    (Array.push-back! &arr 12)
+    (Array.push-back! &arr 13)
+    (Array.push-back! &arr 14)
+    (assert-ref-equal test
+                      exp
+                      arr
+                      "Array.push-back! works as expected"))
   (let-do [a [1 2 3 4 5 6]
            b (Array.pop-back a)
            c (Array.pop-back b)
            d (Array.pop-back c)
            exp [1 2 3]]
-          (assert-equal test
-                        &exp
-                        &d
-                       "Array.pop-back works as expected"))
+    (assert-ref-equal test
+                      exp
+                      d
+                      "Array.pop-back works as expected"))
   (let-do [arr [1 2 3 4 5 6]
            exp [1 2 3]
            six  (Array.pop-back! &arr)
            five (Array.pop-back! &arr)
            four (Array.pop-back! &arr)]
-          (assert-true test
-                       (and* (= &exp &arr)
-                             (= six  6)
-                             (= five 5)
-                             (= four 4))
-                       "Array.pop-back! works as expected"))
-  (assert-equal test
-                &[1 2 3 4 5 6 7 8 9]
-                &(sort (range 9 1 -1))
-                "sort works as expected")
+    (assert-true test
+                 (and* (= &exp &arr)
+                       (= six  6)
+                       (= five 5)
+                       (= four 4))
+                 "Array.pop-back! works as expected"))
+  (assert-ref-equal test
+                    [1 2 3 4 5 6 7 8 9]
+                    (sort (range 9 1 -1))
+                    "sort works as expected")
   (let-do [arr [3 2 5]
            exp [2 3 5]]
-          (sort! &arr)
-          (assert-equal test
-                        &exp
-                        &arr
-                        "sort! works as expected"))
-  (assert-equal test
-                &[1 2 3 4 5 6 7 8 9]
-                &(sorted &[9 2 1 3 7 8 6 5 4])
-                "sorted works as expected")
-  (assert-equal test
-                true
-                (empty? &(the (Array ()) []))
-                "empty? works as expected I")
-  (assert-equal test
-                false
+    (sort! &arr)
+    (assert-ref-equal test
+                      exp
+                      arr
+                      "sort! works as expected"))
+  (assert-ref-equal test
+                    [1 2 3 4 5 6 7 8 9]
+                    (sorted &[9 2 1 3 7 8 6 5 4])
+                    "sorted works as expected")
+  (assert-true test
+               (empty? &(the (Array ()) []))
+               "empty? works as expected I")
+  (assert-false test
                 (empty? &[1])
                 "empty? works as expected II")
-  (assert-equal test
-                true
-                (any? &(fn [x] (= 0 @x)) &(range 0 10 1))
-                "any? works as expected I")
-  (assert-equal test
-                false
+  (assert-true test
+               (any? &(fn [x] (= 0 @x)) &(range 0 10 1))
+               "any? works as expected I")
+  (assert-false test
                 (any? &(fn [x] (= 0 @x)) &(range 1 10 1))
                 "any? works as expected II")
-  (assert-equal test
-                true
-                (all? &(fn [x] (< 0 @x)) &(range 1 10 1))
-                "all? works as expected I")
-  (assert-equal test
-                false
+  (assert-true test
+               (all? &(fn [x] (< 0 @x)) &(range 1 10 1))
+               "all? works as expected I")
+  (assert-false test
                 (all? &(fn [x] (= 0 @x)) &(range 10 1 -1))
                 "all? works as expected II")
-  (assert-equal test
-                &(Maybe.Just 3)
-                &(find &(fn [x] (= 3 @x)) &(range 1 10 1))
-                "find works as expected I")
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(find &(fn [x] (= 0 @x)) &(range 1 10 1))
-                "find works as expected II")
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(find-index &(fn [i] (Int.even? @i)) &[1 3 5])
-                "find-index works I")
-  (assert-equal test
-                &(Maybe.Just 1)
-                &(find-index &(fn [i] (Int.even? @i)) &[1 8 5])
-                "find-index works II")
+  (assert-ref-equal test
+                    (Maybe.Just 3)
+                    (find &(fn [x] (= 3 @x)) &(range 1 10 1))
+                    "find works as expected I")
+  (assert-nothing test
+                  &(find &(fn [x] (= 0 @x)) &(range 1 10 1))
+                  "find works as expected II")
+  (assert-nothing test
+                  &(find-index &(fn [i] (Int.even? @i)) &[1 3 5])
+                  "find-index works I")
+  (assert-ref-equal test
+                    (Maybe.Just 1)
+                    (find-index &(fn [i] (Int.even? @i)) &[1 8 5])
+                    "find-index works II")
   (assert-equal test
                 2
                 (element-count &[1 4 3 4] &4)
@@ -306,30 +294,30 @@
                 &2
                 (Pointer.to-ref (Pointer.inc (unsafe-raw &[1 2 3])))
                 "unsafe-raw works II")
-  (assert-equal test
-                &[1 3 5]
-                &(remove &2 [2 1 3 2 5])
-                "remove works")
-  (assert-equal test
-                &[1 3]
-                &(remove &2 [1 3])
-                "remove works when element is not found")
-  (assert-equal test
-                &[1 3]
-                &(remove-nth 1 [1 2 3])
-                "remove-nth works")
-  (assert-equal test
-                &[1.0 1.5 2.0 2.5]
-                &(unreduce 1.0 &(fn [x] (< x 3.0)) &(fn [x] (+ x 0.5)))
-                "unreduce works")
+  (assert-ref-equal test
+                    [1 3 5]
+                    (remove &2 [2 1 3 2 5])
+                    "remove works")
+  (assert-ref-equal test
+                    [1 3]
+                    (remove &2 [1 3])
+                    "remove works when element is not found")
+  (assert-ref-equal test
+                    [1 3]
+                    (remove-nth 1 [1 2 3])
+                    "remove-nth works")
+  (assert-ref-equal test
+                    [1.0 1.5 2.0 2.5]
+                    (unreduce 1.0 &(fn [x] (< x 3.0)) &(fn [x] (+ x 0.5)))
+                    "unreduce works")
   (assert-true test
                 (contains? &[0 1 2] &1)
                 "contains? works as expected I")
   (assert-false test
                 (contains? &[0 1 2] &100)
                 "contains? works as expected II")
-  (assert-equal test
-                &[1 2 3]
-                &(from-static $[1 2 3])
-                "from-static works"))
+  (assert-ref-equal test
+                    [1 2 3]
+                    (from-static $[1 2 3])
+                    "from-static works"))
 

--- a/test/binary.carp
+++ b/test/binary.carp
@@ -25,10 +25,9 @@
                 &(bytes->int16 (ByteOrder.BigEndian) &[3b 8b])
                 "Unsafe big endian bytes->int16 works as expected.")
 
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(bytes->int16 (ByteOrder.LittleEndian) &[3b])
-                "bytes->int16 returns Nothing on insufficient data.")
+  (assert-nothing test
+                  &(bytes->int16 (ByteOrder.LittleEndian) &[3b])
+                  "bytes->int16 returns Nothing on insufficient data.")
 
   (assert-equal test
                 &[(Uint16.from-long 2051l) (Uint16.from-long 776l)]
@@ -79,10 +78,9 @@
                 &(bytes->int32 (ByteOrder.BigEndian) &[1b 2b 3b 4b])
                 "Unsafe big endian bytes->int32 works as expected.")
 
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(bytes->int32 (ByteOrder.LittleEndian) &[3b])
-                "bytes->int32 returns Nothing on insufficient data.")
+  (assert-nothing test
+                  &(bytes->int32 (ByteOrder.LittleEndian) &[3b])
+                  "bytes->int32 returns Nothing on insufficient data.")
 
   (assert-equal test
                 &[(Uint32.from-long 67305985l) (Uint32.from-long 16909060l)]
@@ -131,10 +129,9 @@
                 &(bytes->int64 (ByteOrder.BigEndian) &[1b 2b 3b 4b 5b 6b 0b 0b])
                 "Unsafe big endian bytes->int64 works as expected.")
 
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(bytes->int64 (ByteOrder.LittleEndian) &[3b])
-                "bytes->int64 returns Nothing on insufficient data.")
+  (assert-nothing test
+                  &(bytes->int64 (ByteOrder.LittleEndian) &[3b])
+                  "bytes->int64 returns Nothing on insufficient data.")
 
   (assert-equal test
                 &[(Uint64.from-long 6618611909121l) (Uint64.from-long 72623859790381056l)]

--- a/test/io.carp
+++ b/test/io.carp
@@ -2,13 +2,12 @@
 (use-all IO Test)
 
 (deftest test
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(IO.getenv @"thisdoesnotexist")
-                "getenv works on non-existant variable"
+  (assert-nothing test
+                  &(IO.getenv @"thisdoesnotexist")
+                  "getenv works on non-existant variable"
   )
-  (assert-true test
-               (Maybe.just? &(IO.getenv @"PATH"))
+  (assert-just test
+               &(IO.getenv @"PATH")
                "getenv works on existant variable"
   )
 )

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -92,15 +92,13 @@
                 &(find &(fn [x] (= 3 @x)) $[0 1 2 3])
                 "find works as expected I")
 
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(find &(fn [x] (= 4 @x)) $[0 1 2 3])
-                "find works as expected II")
+  (assert-nothing test
+                  &(find &(fn [x] (= 4 @x)) $[0 1 2 3])
+                  "find works as expected II")
 
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(find-index &(fn [i] (Int.even? @i)) $[1 3 5])
-                "find-index works I")
+  (assert-nothing test
+                  &(find-index &(fn [i] (Int.even? @i)) $[1 3 5])
+                  "find-index works I")
 
   (assert-equal test
                 &(Maybe.Just 1)
@@ -117,10 +115,9 @@
                 &(first $[1 2 3])
                 "first works as expected")
 
-  (assert-equal test
-                &(the (Maybe Int) (Maybe.Nothing))
-                &(first $[])
-                "first works as expected on empty array")
+  (assert-nothing test
+                  &(first (the (Ref (StaticArray Int)) $[]))
+                  "first works as expected on empty array")
 
   (assert-equal test
                 \c
@@ -132,10 +129,9 @@
                 &(last $[\a \b \c])
                 "last works as expected")
 
-  (assert-equal test
-                &(the (Maybe Char) (Maybe.Nothing))
-                &(last $[])
-                "last works as expected on empty array")
+  (assert-nothing test
+                  &(last (the (Ref (StaticArray Char)) $[]))
+                  "last works as expected on empty array")
 
   (assert-equal test
                 &(Maybe.Just 10)
@@ -167,10 +163,9 @@
                 &(index-of $[1 2 3 4] &4)
                 "index-of works as expected when element is in the array")
 
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(index-of $[1 2 3 4] &7)
-                "index-of works as expected when element is not in the array")
+  (assert-nothing test
+                  &(index-of $[1 2 3 4] &7)
+                  "index-of works as expected when element is not in the array")
 
   (assert-equal test
                 2
@@ -198,10 +193,9 @@
                     arr)
                   "swap! works as expected"))
 
-  (assert-equal test
-                &(Maybe.Nothing)
-                &(nth $[0 1 2] 3)
-                "nth works as expected I")
+  (assert-nothing test
+                  &(nth $[0 1 2] 3)
+                  "nth works as expected I")
 
   (assert-equal test
                 &(Maybe.Just 0)

--- a/test/vectorn.carp
+++ b/test/vectorn.carp
@@ -22,17 +22,17 @@
                 &(Maybe.unsafe-from
                   (add &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 2.5])))
                 "add operator works")
-  (assert-true test
-               (Maybe.nothing? &(add &(init 1 [2.0]) &(init 2 [1.0 2.0])))
-               "add operator works on wrong magnitudes")
+  (assert-nothing test
+                  &(add &(init 1 [2.0]) &(init 2 [1.0 2.0]))
+                  "add operator works on wrong magnitudes")
   (assert-equal test
                 &(init 3 [1.0 -1.0 -1.5])
                 &(Maybe.unsafe-from
                   (sub &(init 3 [2.0 1.0 2.0]) &(init 3 [1.0 2.0 3.5])))
                 "sub operator works")
-  (assert-true test
-                (Maybe.nothing? &(sub &(init 1 [2.0]) &(init 2 [1.0 2.0])))
-                "sub operator works on wrong magnitudes")
+  (assert-nothing test
+                  &(sub &(init 1 [2.0]) &(init 2 [1.0 2.0]))
+                  "sub operator works on wrong magnitudes")
   (assert-equal test
                 &(init 3 [4.0 2.0 2.2])
                 &(mul &(init 3 [2.0 1.0 1.1]) 2.0)


### PR DESCRIPTION
As promised in #691, I pulled out the new `assert` primitives and used them all over the test suite.

Cheers