### PR TITLE
Add str on refs for numeric types

### DIFF
--- a/core/String.carp
+++ b/core/String.carp
@@ -274,25 +274,33 @@
 (defmodule Long (defn prn [x] (Long.str x)) (implements prn Long.prn))
 (defmodule LongRef
   (defn prn [x] (Long.str @x))
+  (implements prn LongRef.prn)
   (defn str [x] (Long.str @x))
+  (implements str LongRef.str)
 )
 
 (defmodule Float (defn prn [x] (Float.str x)) (implements prn Float.prn))
 (defmodule FloatRef
   (defn prn [x] (Float.str @x))
+  (implements prn FloatRef.prn)
   (defn str [x] (Float.str @x))
+  (implements str FloatRef.str)
 )
 
 (defmodule Double (defn prn [x] (Double.str x)) (implements prn Double.prn))
 (defmodule DoubleRef
   (defn prn [x] (Double.str @x))
+  (implements prn DoubleRef.prn)
   (defn str [x] (Double.str @x))
+  (implements str DoubleRef.str)
 )
 
 (defmodule Bool (defn prn [x] (Bool.str x)) (implements prn Bool.prn))
 (defmodule BoolRef
   (defn prn [x] (Bool.str @x))
+  (implements prn BoolRef.prn)
   (defn str [x] (Bool.str @x))
+  (implements str BoolRef.str)
 )
 
 (defmodule Array (defn prn [x] (Array.str x)) (implements prn Array.prn))

--- a/core/String.carp
+++ b/core/String.carp
@@ -249,30 +249,50 @@
 )
 
 (defmodule Int (defn prn [x] (Int.str x))  (implements prn Int.prn))
-(defmodule Byte (defn prn [x] (Byte.str x)) (implements prn Byte.prn))
 (defmodule IntRef
   (defn prn [x] (Int.str @x))
   (implements prn IntRef.prn)
   (defn str [x] (Int.str @x))
   (implements str IntRef.str)
-  )
+)
 
 (defmodule BoolRef
   (defn prn [x] (Bool.str @x))
   (implements prn BoolRef.prn)
   (defn str [x] (Bool.str @x))
   (implements str BoolRef.str)
-  )
+)
 
+(defmodule Byte (defn prn [x] (Byte.str x)) (implements prn Byte.prn))
 (defmodule ByteRef
   (defn prn [x] (Byte.str @x))
   (implements prn ByteRef.prn)
   (defn str [x] (Byte.str @x))
   (implements str ByteRef.str)
-  )
+)
 
 (defmodule Long (defn prn [x] (Long.str x)) (implements prn Long.prn))
+(defmodule LongRef
+  (defn prn [x] (Long.str @x))
+  (defn str [x] (Long.str @x))
+)
+
 (defmodule Float (defn prn [x] (Float.str x)) (implements prn Float.prn))
+(defmodule FloatRef
+  (defn prn [x] (Float.str @x))
+  (defn str [x] (Float.str @x))
+)
+
 (defmodule Double (defn prn [x] (Double.str x)) (implements prn Double.prn))
+(defmodule DoubleRef
+  (defn prn [x] (Double.str @x))
+  (defn str [x] (Double.str @x))
+)
+
 (defmodule Bool (defn prn [x] (Bool.str x)) (implements prn Bool.prn))
+(defmodule BoolRef
+  (defn prn [x] (Bool.str @x))
+  (defn str [x] (Bool.str @x))
+)
+
 (defmodule Array (defn prn [x] (Array.str x)) (implements prn Array.prn))

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -87,7 +87,9 @@ String Pattern_internal_classend(PatternMatchState *ms, String p) {
             } while (*p != ']');
             return p + 1;
         }
-        default: { return p; }
+        default: {
+            return p;
+        }
     }
 }
 

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -154,7 +154,7 @@
                 String
             </h1>
             <div class="module-description">
-
+                
             </div>
             <div class="binder">
                 <a class="anchor" href="#&lt;">
@@ -169,10 +169,10 @@
                     (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -188,10 +188,10 @@
                     (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -207,10 +207,10 @@
                     (Fn [(Ref String a), (Ref String b)] Bool)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -226,10 +226,10 @@
                     (Fn [Int, Char] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -285,10 +285,10 @@
                     (Fn [(Ref String a), (Ref String b)] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -304,10 +304,10 @@
                     (Fn [(Ref String a), Int] Char)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -323,10 +323,10 @@
                     (Fn [(Ref String a)] (Array Char))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -385,7 +385,7 @@
                     (concat strings)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -441,10 +441,10 @@
                     (Fn [(Ref String a)] (Ptr CChar))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -500,10 +500,10 @@
                     (Fn [(Ref String a), (Ref String b)] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -519,10 +519,10 @@
                     (Fn [(Ref (Array Char) a)] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -538,10 +538,10 @@
                     (Fn [(Ptr CChar)] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -560,7 +560,7 @@
                     (hash k)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -636,10 +636,10 @@
                     (Fn [(Ref String a), Char] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -655,10 +655,10 @@
                     (Fn [(Ref String a), Char, Int] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -714,10 +714,10 @@
                     (Fn [(Ref String a)] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -836,7 +836,7 @@
                     (prefix s a)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -852,10 +852,10 @@
                     (Fn [(Ref String a)] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -874,7 +874,7 @@
                     (random-sized n)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -933,7 +933,7 @@
                     (slice s a b)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -989,10 +989,10 @@
                     (Fn [(Ref String a)] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -1008,10 +1008,10 @@
                     (Fn [(Ref String a), Int, Char] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -1027,10 +1027,10 @@
                     (Fn [(Ref String a), Int, (Ref String b)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -1049,7 +1049,7 @@
                     (suffix s b)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -1085,10 +1085,10 @@
                     (Fn [(Ref String a)] String)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -857,7 +857,7 @@
                     external
                 </div>
                 <p class="sig">
-                    (Fn [(Ref String a)] ())
+                    (Fn [(Ref String a)] Int)
                 </p>
                 <span>
                     

--- a/docs/sdl/IMG.html
+++ b/docs/sdl/IMG.html
@@ -54,7 +54,7 @@
                 IMG
             </h1>
             <div class="module-description">
-
+                
             </div>
             <div class="binder">
                 <a class="anchor" href="#load">
@@ -69,10 +69,10 @@
                     (Fn [(Ptr CChar)] (Ptr SDL_Surface))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -88,10 +88,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr CChar)] (Ptr SDL_Texture))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
         </div>

--- a/docs/sdl/Mixer.html
+++ b/docs/sdl/Mixer.html
@@ -54,7 +54,7 @@
                 Mixer
             </h1>
             <div class="module-description">
-
+                
             </div>
             <div class="binder">
                 <a class="anchor" href="#any-free-channel">
@@ -69,10 +69,10 @@
                     Int
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -88,10 +88,10 @@
                     (Fn [Int] Bool)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -107,10 +107,10 @@
                     Int
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -126,10 +126,10 @@
                     Int
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -145,10 +145,10 @@
                     (Fn [] (Ptr CChar))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -164,10 +164,10 @@
                     (Fn [Int] (Ptr CChar))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -183,10 +183,10 @@
                     (Fn [Int] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -202,10 +202,10 @@
                     (Fn [(Ptr CChar)] (Ptr Mix_Music))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -221,10 +221,10 @@
                     (Fn [(Ptr CChar)] (Ptr Mix_Chunk))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -240,10 +240,10 @@
                     Int
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -259,10 +259,10 @@
                     Int
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -278,10 +278,10 @@
                     (Fn [] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -297,10 +297,10 @@
                     Int
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -319,7 +319,7 @@
                     (ok? error-code)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -335,10 +335,10 @@
                     (Fn [Int, Int, Int, Int] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -354,10 +354,10 @@
                     (Fn [Int, (Ptr Mix_Chunk), Int] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -373,10 +373,10 @@
                     (Fn [(Ptr Mix_Music), Int] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -392,10 +392,10 @@
                     (Fn [] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -414,7 +414,7 @@
                     (valid-channel? ch)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
         </div>

--- a/docs/sdl/SDL.html
+++ b/docs/sdl/SDL.html
@@ -54,7 +54,7 @@
                 SDL
             </h1>
             <div class="module-description">
-
+                
             </div>
             <div class="binder">
                 <a class="anchor" href="#Event">
@@ -69,10 +69,10 @@
                     Module
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -88,10 +88,10 @@
                     Module
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -107,10 +107,10 @@
                     Int
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -126,10 +126,10 @@
                     Module
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -145,10 +145,10 @@
                     Module
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -164,10 +164,10 @@
                     Module
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -186,7 +186,7 @@
                     (bg rend color)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -202,10 +202,10 @@
                     SDL_BlendMode
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -221,10 +221,10 @@
                     SDL_BlendMode
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -240,10 +240,10 @@
                     SDL_BlendMode
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -259,10 +259,10 @@
                     SDL_BlendMode
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -278,10 +278,10 @@
                     (Fn [(Ptr SDL_Surface), (Ptr SDL_Rect), (Ptr SDL_Surface), (Ptr SDL_Rect)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -297,10 +297,10 @@
                     (Fn [Int, Int, Int, Int, Int, Int, Int, Int] (Ptr SDL_Surface))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -316,10 +316,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr SDL_Surface)] (Ptr SDL_Texture))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -335,10 +335,10 @@
                     (Fn [Int, Int, Int, (Ptr (Ptr SDL_Window)), (Ptr (Ptr SDL_Renderer))] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -354,10 +354,10 @@
                     (Fn [Int] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -373,10 +373,10 @@
                     (Fn [(Ptr SDL_Texture)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -392,10 +392,10 @@
                     (Fn [(Ptr SDL_Window)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -414,7 +414,7 @@
                     (dimensions texture)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -433,7 +433,7 @@
                     (draw-texture rend texture point)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -452,7 +452,7 @@
                     (draw-texture-centered rend texture point)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -468,10 +468,10 @@
                     SDL_RendererFlip
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -487,10 +487,10 @@
                     SDL_RendererFlip
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -506,10 +506,10 @@
                     SDL_RendererFlip
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -525,10 +525,10 @@
                     (Fn [(Ptr SDL_Surface)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -544,10 +544,10 @@
                     (Fn [] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -563,10 +563,10 @@
                     (Fn [(Ptr SDL_Window)] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -582,10 +582,10 @@
                     (Fn [Int] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -601,10 +601,10 @@
                     (Fn [Int, Int] SDL_Point)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -620,10 +620,10 @@
                     (Fn [(Ptr SDL_Texture), (Ptr Int), (Ptr Int), (Ptr Int), (Ptr Int)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -639,10 +639,10 @@
                     (Fn [] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -658,10 +658,10 @@
                     (Fn [Int, Int, Int, Int] SDL_Rect)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -677,10 +677,10 @@
                     (Fn [(Ptr SDL_Renderer)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -696,10 +696,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr SDL_Texture), (Ptr SDL_Rect), (Ptr SDL_Rect)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -715,10 +715,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr SDL_Texture), (Ptr SDL_Rect), (Ptr SDL_Rect), Double, (Ptr SDL_Point), SDL_RendererFlip] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -734,10 +734,10 @@
                     (Fn [(Ptr SDL_Renderer), Int, Int, Int, Int] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -753,10 +753,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr SDL_Point), Int] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -772,10 +772,10 @@
                     (Fn [(Ptr SDL_Renderer), Int, Int] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -791,10 +791,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr SDL_Rect)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -810,10 +810,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr SDL_Rect), Int] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -829,10 +829,10 @@
                     (Fn [(Ptr SDL_Renderer)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -848,10 +848,10 @@
                     (Fn [(Ptr SDL_Renderer), (Ptr SDL_Rect), Int, (Ptr ()), Int] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -867,10 +867,10 @@
                     (Fn [Int, Int, Int] SDL_Color)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -886,10 +886,10 @@
                     (Fn [Int, Int, Int] SDL_Color)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -905,10 +905,10 @@
                     (Fn [(Ptr SDL_Surface), String] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -924,10 +924,10 @@
                     (Fn [(Ptr SDL_Renderer), SDL_BlendMode] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -943,10 +943,10 @@
                     (Fn [(Ptr SDL_Renderer), Int, Int, Int, Int] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -962,10 +962,10 @@
                     (Fn [(Ptr SDL_Window), (Ptr CChar)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -981,10 +981,10 @@
                     (Fn [(Ptr SDL_Surface)] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -1000,10 +1000,10 @@
                     (Fn [(Ptr SDL_Surface)] (Ptr ()))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
         </div>

--- a/docs/sdl/TTF.html
+++ b/docs/sdl/TTF.html
@@ -54,7 +54,7 @@
                 TTF
             </h1>
             <div class="module-description">
-
+                
             </div>
             <div class="binder">
                 <a class="anchor" href="#close-font">
@@ -69,10 +69,10 @@
                     (Fn [(Ptr TTF_Font)] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -85,13 +85,13 @@
                     external
                 </div>
                 <p class="sig">
-                    (Fn [] (Ptr cChar))
+                    (Fn [] (Ptr CChar))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -107,10 +107,10 @@
                     (Fn [] Int)
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -129,7 +129,7 @@
                     (ok? error-code)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -145,10 +145,10 @@
                     (Fn [(Ptr CChar), Int] (Ptr TTF_Font))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -164,10 +164,10 @@
                     (Fn [] ())
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -183,10 +183,10 @@
                     (Fn [(Ptr TTF_Font), (Ptr CChar), SDL_Color] (Ptr SDL_Surface))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -202,10 +202,10 @@
                     (Fn [(Ptr TTF_Font), (Ptr CChar), SDL_Color, Int] (Ptr SDL_Surface))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -221,10 +221,10 @@
                     (Fn [(Ptr TTF_Font), (Ptr CChar), SDL_Color, SDL_Color] (Ptr SDL_Surface))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -240,10 +240,10 @@
                     (Fn [(Ptr TTF_Font), (Ptr CChar), SDL_Color] (Ptr SDL_Surface))
                 </p>
                 <span>
-
+                    
                 </span>
                 <p class="doc">
-
+                    
                 </p>
             </div>
             <div class="binder">
@@ -262,7 +262,7 @@
                     (render-text-to-texture rend font str color)
                 </pre>
                 <p class="doc">
-
+                    
                 </p>
             </div>
         </div>

--- a/test/execute.sh
+++ b/test/execute.sh
@@ -2,7 +2,7 @@
 
 # Runs the executable and compares its output to the .expected file
 ./carp.sh $1 --log-memory -b && \
-  ./out/Untitled > test/output/$1.output.actual 2>&1
+  ~/.carp/out/Untitled > test/output/$1.output.actual 2>&1
 echo $1
 
 if ! diff --strip-trailing-cr test/output/$1.output.actual test/output/$1.output.expected; then

--- a/test/execute.sh
+++ b/test/execute.sh
@@ -2,7 +2,7 @@
 
 # Runs the executable and compares its output to the .expected file
 ./carp.sh $1 --log-memory -b && \
-  ~/.carp/out/Untitled > test/output/$1.output.actual 2>&1
+  ./out/Untitled > test/output/$1.output.actual 2>&1
 echo $1
 
 if ! diff --strip-trailing-cr test/output/$1.output.actual test/output/$1.output.expected; then


### PR DESCRIPTION
This PR adds `str` for references on numeric types to make things like `(Double.+ 2.0 3.0)` work on the REPL, which implicitly call `str` on the `ref` of the result.

Cheers