### PR TITLE
Make Num.from-string better

### DIFF
--- a/core/Float.carp
+++ b/core/Float.carp
@@ -111,10 +111,13 @@ The margin of error is 0.00001.")
 (defmodule FloatRef
   (defn = [a b]
     (Float.= @a @b))
+  (implements = FloatRef.=)
 
   (defn < [a b]
     (Float.< @a @b))
+  (implements < FloatRef.<)
 
   (defn > [a b]
     (Float.> @a @b))
+  (implements > FloatRef.>)
 )

--- a/core/String.carp
+++ b/core/String.carp
@@ -199,7 +199,15 @@
   (implements str Int.str)
   (register format (Fn [&String Int] String))
   (implements format Int.format)
-  (register from-string (λ [&String] Int))
+  (private from-string-internal)
+  (hidden from-string-internal)
+  (register from-string-internal (λ [&String &Int] Bool))
+
+  (defn from-string [s]
+    (let [res 0]
+      (if (from-string-internal s &res)
+        (Maybe.Just res)
+        (Maybe.Nothing))))
   (implements from-string Int.from-string)
 )
 
@@ -208,7 +216,15 @@
   (implements str Byte.str)
   (register format (Fn [&String Byte] String))
   (implements format Byte.format)
-  (register from-string (λ [&String] Byte))
+  (private from-string-internal)
+  (hidden from-string-internal)
+  (register from-string-internal (λ [&String &Byte] Bool))
+
+  (defn from-string [s]
+    (let [res 0b]
+      (if (from-string-internal s &res)
+        (Maybe.Just res)
+        (Maybe.Nothing))))
   (implements from-string Byte.from-string)
 )
 
@@ -217,7 +233,15 @@
   (implements str Float.str)
   (register format (Fn [&String Float] String))
   (implements format Float.format)
-  (register from-string (λ [&String] Float))
+  (private from-string-internal)
+  (hidden from-string-internal)
+  (register from-string-internal (λ [&String &Float] Bool))
+
+  (defn from-string [s]
+    (let [res 0.0f]
+      (if (from-string-internal s &res)
+        (Maybe.Just res)
+        (Maybe.Nothing))))
   (implements from-string Float.from-string)
 )
 
@@ -226,7 +250,15 @@
   (implements str Long.str)
   (register format (Fn [&String Long] String))
   (implements format Long.format)
-  (register from-string (λ [&String] Long))
+  (private from-string-internal)
+  (hidden from-string-internal)
+  (register from-string-internal (λ [&String &Long] Bool))
+
+  (defn from-string [s]
+    (let [res 0l]
+      (if (from-string-internal s &res)
+        (Maybe.Just res)
+        (Maybe.Nothing))))
   (implements from-string Long.from-string)
 )
 
@@ -235,7 +267,15 @@
   (implements str Double.str)
   (register format (Fn [&String Double] String))
   (implements format Double.format)
-  (register from-string (λ [&String] Double))
+  (private from-string-internal)
+  (hidden from-string-internal)
+  (register from-string-internal (λ [&String &Double] Bool))
+
+  (defn from-string [s]
+    (let [res 0.0]
+      (if (from-string-internal s &res)
+        (Maybe.Just res)
+        (Maybe.Nothing))))
   (implements from-string Double.from-string)
 )
 

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -87,7 +87,9 @@ String Pattern_internal_classend(PatternMatchState *ms, String p) {
             } while (*p != ']');
             return p + 1;
         }
-        default: { return p; }
+        default: {
+            return p;
+        }
     }
 }
 

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -228,8 +228,10 @@ String Double_format(const String *s, double x) {
     return buffer;
 }
 
-double Double_from_MINUS_string(const String *s) {
-    return strtod(*s, NULL);
+bool Double_from_MINUS_string_MINUS_internal(const String *s, double *target) {
+    char *err;
+    *target = strtod(*s, &err);
+    return *err == 0;
 }
 
 String Float_str(float x) {
@@ -246,8 +248,10 @@ String Float_format(const String *str, float x) {
     return buffer;
 }
 
-float Float_from_MINUS_string(const String *s) {
-    return strtof(*s, NULL);
+bool Float_from_MINUS_string_MINUS_internal(const String *s, float *target) {
+    char *err;
+    *target = strtof(*s, &err);
+    return *err == 0;
 }
 
 String Int_str(int x) {
@@ -264,8 +268,10 @@ String Int_format(const String *str, int x) {
     return buffer;
 }
 
-int Int_from_MINUS_string(const String *s) {
-    return atoi(*s);
+bool Int_from_MINUS_string_MINUS_internal(const String *s, int *target) {
+    char *err;
+    *target = (int)strtol(*s, &err, 10);
+    return *err == 0;
 }
 
 String Long_str(Long x) {
@@ -282,8 +288,10 @@ String Long_format(const String *str, Long x) {
     return buffer;
 }
 
-Long Long_from_MINUS_string(const String *s) {
-    return atol(*s);
+bool Long_from_MINUS_string_MINUS_internal(const String *s, Long *target) {
+    char *err;
+    *target = strtol(*s, &err, 10);
+    return *err == 0;
 }
 
 String Byte_str(uint8_t x) {
@@ -300,8 +308,10 @@ String Byte_format(const String *str, uint8_t x) {
     return buffer;
 }
 
-uint8_t Byte_from_MINUS_string(const String *s) {
-    return atoi(*s);
+uint8_t Byte_from_MINUS_string_MINUS_internal(const String *s, byte *target) {
+    char *err;
+    *target = (uint8_t)strtol(*s, &err, 10);
+    return *err == 0;
 }
 
 int String_index_MINUS_of_MINUS_from(const String *s, char c, int i) {

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -543,14 +543,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [(Ref String a)] Byte)
+                    (Fn [(Ref String a)] (Maybe Byte))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (from-string s)
+                </pre>
                 <p class="doc">
                     
                 </p>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -697,14 +697,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [(Ref String a)] Double)
+                    (Fn [(Ref String a)] (Maybe Double))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (from-string s)
+                </pre>
                 <p class="doc">
                     
                 </p>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -659,14 +659,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [(Ref String a)] Float)
+                    (Fn [(Ref String a)] (Maybe Float))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (from-string s)
+                </pre>
                 <p class="doc">
                     
                 </p>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -602,14 +602,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [(Ref String a)] Int)
+                    (Fn [(Ref String a)] (Maybe Int))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (from-string s)
+                </pre>
                 <p class="doc">
                     
                 </p>

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -562,14 +562,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [(Ref String a)] Long)
+                    (Fn [(Ref String a)] (Maybe Long))
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (from-string s)
+                </pre>
                 <p class="doc">
                     
                 </p>

--- a/examples/guessing.carp
+++ b/examples/guessing.carp
@@ -46,6 +46,9 @@
               guessed-num (from-string &user-input)]
           (if (= &user-input "q\n")
             (exit!)
-            (cond (< guessed-num answer) (guess-again "low")
-                  (> guessed-num answer) (guess-again "high")
-                  (correct!)))))))
+            (match guessed-num
+              (Maybe.Nothing) (print "Invalid input.\nPlease guess again: ")
+              (Maybe.Just n)
+                (cond (< n answer) (guess-again "low")
+                      (> n answer) (guess-again "high")
+                      (correct!))))))))

--- a/test/double_math.carp
+++ b/test/double_math.carp
@@ -103,8 +103,13 @@
                 "to-bytes works as expected II"
   )
   (assert-equal test
-                10.3
-                (from-string "10.3")
-                "from-string works as expected"
+                &(Maybe.Just 10.3)
+                &(from-string "10.3")
+                "from-string works as expected I"
+  )
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(Double.from-string "abcd")
+                "from-string works as expected II"
   )
 )

--- a/test/float_math.carp
+++ b/test/float_math.carp
@@ -109,8 +109,13 @@
                 "to-bytes works as expected II"
   )
   (assert-equal test
-                10.3f
-                (from-string "10.3")
-                "from-string works as expected"
+                &(Maybe.Just 10.3f)
+                &(from-string "10.3")
+                "from-string works as expected I"
+  )
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(Float.from-string "abcd")
+                "from-string works as expected II"
   )
 )


### PR DESCRIPTION
This PR changes `from-string` for all the number types to actually fail when the string is not a valid number. This means that all of them return a `Maybe` now. Under the hood this is achieved by checking whether the `endptr` argument to `strto*` is `\0`, which means that we reached the end of the string after parsing.

Of note: these functions will still consume any leading whitespace, which is the behavior of `strto*`.

Cheers