### PR TITLE
Flamegraph for the haskell side.

### DIFF
--- a/carp.sh
+++ b/carp.sh
@@ -7,4 +7,4 @@ then
 	CARP="cabal -v0 run carp"
     fi
 fi
-$CARP "--" $*
+$CARP $BUILD_OPTS $"--" $*

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+{ nixpkgs ? import <nixpkgs> {}
+, compiler ? "default"
+, doBenchmark ? false
+, profiling ? false
+}:
 
 let
 
@@ -11,6 +15,7 @@ let
       , cmark, cmdargs, containers, directory, edit-distance, filepath
       , haskeline, HUnit, mtl, parsec, process, split, stdenv, text
       , darwin, glfw3, SDL2, SDL2_image, SDL2_gfx, SDL2_mixer, SDL2_ttf
+      , ghc-prof-flamegraph
       , clang , makeWrapper
 
       , libXext, libXcursor, libXinerama, libXi, libXrandr, libXScrnSaver, libXxf86vm, libpthreadstubs, libXdmcp, libGL
@@ -23,13 +28,13 @@ let
         isExecutable = true;
         enableSharedLibraries = false;
         enableSharedExecutables = false;
-        enableLibraryProfiling = false;
-        enableExecutableProfiling = false;
+        enableLibraryProfiling = profiling;
+        enableExecutableProfiling = profiling;
         libraryHaskellDepends = [
           ansi-terminal base blaze-html blaze-markup cmark containers
           directory edit-distance filepath haskeline mtl parsec process split
           text
-        ];
+        ] ++ optionals profiling [ ghc-prof-flamegraph ];
         pkgconfigDepends =
           [ glfw3 SDL2 SDL2_image SDL2_gfx SDL2_mixer SDL2_ttf ]
           ++ linuxOnly [ libXext libXcursor libXinerama libXi libXrandr libXScrnSaver libXxf86vm libpthreadstubs libXdmcp libGL];

--- a/haskell-flamegraph.sh
+++ b/haskell-flamegraph.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+# Usage:
+#
+# ./haskell-flamegraph <carp options>
+BUILD_OPTS="--enable-profiling --enable-library-profiling" ./carp.sh $* +RTS -p -hc
+ghc-prof-flamegraph carp.prof
+xdg-open carp.svg


### PR DESCRIPTION
Generate flamegraphs for the compiler.
```
$ nix-shell --arg profiling true
$ ./haskell-flamegraph.sh -b test/carp.sh
```
Generates the attached carp.svg.
[carp.svg.zip](https://github.com/carp-lang/Carp/files/4618746/carp.svg.zip)

