### PR TITLE
Add FreeBSD as a supported platform

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -51,3 +51,5 @@
 (not-on-windows
   (system-include "sys/wait.h")
   (system-include "unistd.h"))
+(freebsd-only
+  (system-include "signal.h"))

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -548,6 +548,11 @@
 (defmacro update! [x f]
   (list 'set! x (list f x)))
 
+(defmacro freebsd-only [:rest forms]
+  (if (= "freebsd" (os))
+    (eval (cons (quote do) forms))
+    ()))
+
 (defmacro mac-only [:rest forms]
   (if (= "darwin" (os))
     (eval (cons (quote do) forms))

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -61,7 +61,7 @@ enumerate 5 = "sixth"
 enumerate 6 = "seventh"
 enumerate n = show n ++ ":th"
 
-data Platform = Linux | MacOS | Windows deriving (Show, Eq)
+data Platform = Linux | MacOS | Windows | FreeBSD deriving (Show, Eq)
 
 platform :: Platform
 platform =
@@ -69,6 +69,7 @@ platform =
       "linux" -> Linux
       "darwin" -> MacOS
       "mingw32" -> Windows
+      "freebsd" -> FreeBSD
 
 unionOfSetsInList (x:xs) =
   foldl' Set.union x xs

--- a/test/double_math.carp
+++ b/test/double_math.carp
@@ -48,10 +48,6 @@
                 (tanh 0.0)
                 "tanh works as expected")
   (assert-equal test
-                Double.e
-                (exp 1.0)
-                "exp works as expected")
-  (assert-equal test
                 8.0
                 (ldexp 2.0 2)
                 "ldexp works as expected")
@@ -87,6 +83,11 @@
                 1.0
                 (floor 1.9)
                 "floor works as expected")
+  (assert-op test
+             Double.e
+             (exp 1.0)
+             "exp works as expected"
+             Double.approx)
   (assert-op test
              0.3
              (mod 9.3 3.0)


### PR DESCRIPTION
This commit adds FreeBSD as a supported platform. I understand that this may not be as easy as just adding it to the list, but if can point me at things that I should test, I can do that.

Tests (on FreeBSD 12.1-RELEASE, amd64)
- [x] Compiler builds and runs on FreeBSD
- [x] Compiles and runs the example SDL program
- [x] Builds and runs reptile.carp from examples.
- [x] Test 'exp works as expected' test
