### PR TITLE
Fix typo in docs for Generics.approx

### DIFF
--- a/core/Generics.carp
+++ b/core/Generics.carp
@@ -31,7 +31,7 @@
       (< (- x y) margin)
       (< (- y x) margin)))
 
-  (doc approx "checks whether `x` and `y` are approximately equal with a margin.
+  (doc approx "checks whether `x` and `y` are approximately equal within a margin.
 
 The margin of error is 0.00001.")
   (defn approx [a b]


### PR DESCRIPTION
This PR fixes a typo in the docs for `Generics.approx`.

Cheers