### PR TITLE
Add an implements-all macro

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -447,6 +447,15 @@
     (map-internal f xs (list)))
 )
 
+(defndynamic implement-declaration [mod interface]
+  (list 'implements interface (Symbol.prefix mod interface)))
+
+(doc implements-all
+  "Declares functions in mod with names matching `interfaces` as implementations
+  of those interfaces.")
+(defmacro implements-all [mod :rest interfaces]
+  (cons 'do (map (curry implement-declaration mod) interfaces)))
+
 (defndynamic cond-internal [xs]
   (if (= (length xs) 0)
     (list)


### PR DESCRIPTION
This macro adds implements forms for functions with the same name as a
given list of interfaces in a given module.