### PR TITLE
Fix Debug.trace for new evaluator

### DIFF
--- a/core/Debug.carp
+++ b/core/Debug.carp
@@ -38,9 +38,19 @@ immediately, raising a `SIGABRT` if it fails.")
 
   (doc trace "prints the value of an expression to `stdout`, then returns its value.")
   (defmacro trace [x]
-    (list 'let-do (array 'tmp x)
-      (list 'IO.println (list 'ref (list 'fmt "%s:%d:%d: %s" (file x) (line x) (column x) '&(str tmp))))
-      'tmp)
+    (let [sym (gensym)]
+      (list 'let-do [sym x]
+        ; we use eval here to ensure we resolve the symbol before putting it
+        ; into file, line, and column
+        (list 'IO.println
+          (list 'ref
+            (list 'fmt "%s:%d:%d: %s"
+              (eval (list 'file x))
+              (eval (list 'line x))
+              (eval (list 'column x))
+              (list 'ref (list 'str sym)))))
+        sym)
+    )
   )
 
   (doc leak-array "leaks some memory. This function is useful for testing tools that detect leaks.")


### PR DESCRIPTION
This PR fixes `Debug.trace` for the new evaluator. In the old evaluator `file`, `line`, and `column` were commands that evaluated their argument before it was passed in. Now they are primitives, and passing in a macro symbol will result in the information on the macro symbol being returned. We often do not want that, and that’s why we have to wrap it in an `eval` to make sure the symbol gets resolved first before passing it in.

Cheers