### PR TITLE
Add \return, \backspace, \formfeed, and \u unicode literals

### DIFF
--- a/test/char.carp
+++ b/test/char.carp
@@ -5,17 +5,21 @@
 
 (deftest test
   (assert-equal test
-		"a"
-  		&(str \a)
-		"str works with ASCII")
+    "Π"
+    &(str \u03a0)
+    "unicode literals work")
   (assert-equal test
-		"ñ"
-  		&(str \ñ)
-		"str works with Latin1")
+                "a"
+                &(str \a)
+                "str works with ASCII")
   (assert-equal test
-		"😲"
-  		&(str \😲)
-		"str works with Emoji")
+                "ñ"
+                &(str \ñ)
+                "str works with Latin1")
+  (assert-equal test
+                "😲"
+                &(str \😲)
+                "str works with Emoji")
   (assert-true test
                 (= \a \a)
                 "char = works as expected I")

--- a/test/char.carp
+++ b/test/char.carp
@@ -5,6 +5,34 @@
 
 (deftest test
   (assert-equal test
+    (String.head " ")
+    \space
+    "space literal works")
+  (assert-equal test
+    (String.head "\t")
+    \tab
+    "tab literal works")
+  (assert-equal test
+    (String.head "\t")
+    \tab
+    "tab literal works")
+  (assert-equal test
+    (String.head "\n")
+    \newline
+    "newline literal works")
+  (assert-equal test
+    (String.head "\b")
+    \backspace
+    "backspace literal works")
+  (assert-equal test
+    (String.head "\r")
+    \return
+    "return literal work")
+  (assert-equal test
+    (String.head "\f")
+    \formfeed
+    "formfeed literal works")
+  (assert-equal test
     "Π"
     &(str \u03a0)
     "unicode literals work")


### PR DESCRIPTION
This PR fixes #812 by introducing more special characters: `\return`, `\backspace`, `\formfeed`, and `\uNNNN` unicode literals.

Cheers