### PR TITLE
Add missing longref implements annotations

### DIFF
--- a/core/Long.carp
+++ b/core/Long.carp
@@ -62,10 +62,13 @@ to non-refs.")
 (defmodule LongRef
   (defn = [a b]
     (Long.= @a @b))
+  (implements = LongRef.=)
 
   (defn < [a b]
     (Long.< @a @b))
+  (implements < LongRef.<)
 
   (defn > [a b]
     (Long.> @a @b))
+  (implements > LongRef.>)
 )


### PR DESCRIPTION
This PR adds missing `implements` annotations to `LongRef`.

Cheers