### PR TITLE
Make NULL Ptr a instead of a

### DIFF
--- a/core/Maybe.carp
+++ b/core/Maybe.carp
@@ -56,10 +56,9 @@ It is the inverse of [`just?`](#just?).")
   (doc unsafe-ptr "Creates a `(Ptr a)` from a `(Maybe a)`. If the `Maybe` was
 `Nothing`, this function will return a `NULL` value.")
   (defn unsafe-ptr [a]
-    (the (Ptr a) (Unsafe.coerce
-      (match-ref a
-        (Nothing) NULL
-        (Just _) (the (Ref (Maybe a)) a)))))
+    (match-ref a
+      (Nothing) NULL
+      (Just _) ((the (Fn [(Ref (Maybe a))] (Ptr a)) Unsafe.coerce) a)))
 
  (doc from-ptr "Creates a `(Maybe a)` from a `(Ptr a)`. If the `Ptr` was
 `NULL`, this function will return `Nothing`.")

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -309,7 +309,7 @@ startingGlobalEnv noArray =
       , envMode = ExternalEnv
       , envFunctionNestingLevel = 0
       }
-  where bindings = Map.fromList $ [ register "NULL" (VarTy "a")
+  where bindings = Map.fromList $ [ register "NULL" (PointerTy (VarTy "a"))
                                   ]
                    ++ (if noArray then [] else [("Array", Binder emptyMeta (XObj (Mod arrayModule) Nothing Nothing))])
                    ++ [("StaticArray", Binder emptyMeta (XObj (Mod staticArrayModule) Nothing Nothing))]


### PR DESCRIPTION
This PR fixes #802 by making `NULL : (Ptr a)`. This requires a tiny change in `Maybe.unsafe-ptr`, which makes the function more principled anyway.

Cheers