### PR TITLE
Interface Implementation improvements

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -49,6 +49,10 @@
 (defmacro annotate [name annotation]
   (eval (list 'meta-set! name "annotations" (annotate-helper name annotation))))
 
+(doc implements? "Does `function` implement `interface`?")
+(defmacro implements? [interface function]
+  (eval (list 'any? (list 'fn (array 'x) (list '= 'x interface)) (list 'meta function "implements"))))
+
 (defmodule Dynamic
   (defndynamic caar [pair] (car (car pair)))
   (defndynamic cadr [pair] (car (cdr pair)))

--- a/core/Tuples.carp
+++ b/core/Tuples.carp
@@ -14,7 +14,7 @@
 
   (defn > [p1 p2]
     (PairRef.< p2 p1)))
-  (implements > PairRef.=)
+  (implements > PairRef.>)
 
 (defmodule Pair
   (defn init-from-refs [r1 r2]

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -139,7 +139,7 @@ lookupImplementations interface env =
   in  filter isImpl binders
   where isImpl (Binder meta _) =
           case Map.lookup "implements" (getMeta meta) of
-            Just (XObj (Sym i@(SymPath _ _) _) _ _) -> i == interface
+            Just (XObj (Lst interfaces) _ _) -> interface `elem` (map getPath interfaces)
             _ -> False
 
 getEnvFromBinder :: (a, Binder) -> Env

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -149,7 +149,7 @@ primitiveImplements xobj ctx [x@(XObj (Sym interface@(SymPath _ _) _) _ _), i@(X
                     in  return (ctx' {contextGlobalEnv = envInsertAt global (getPath defobj) (Binder adjustedMeta defobj)},
                                dynamicNil)
                   _ ->
-                    let impls = XObj (Lst [x]) (Just dummyInfo) (Just UnitTy)
+                    let impls = XObj (Lst [x]) (Just dummyInfo) (Just DynamicTy)
                         adjustedMeta = meta {getMeta = Map.insert "implements" impls (getMeta meta)}
                     in  return (ctx' {contextGlobalEnv = envInsertAt global (getPath defobj) (Binder adjustedMeta defobj)},
                                  dynamicNil)

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -141,8 +141,10 @@ primitiveImplements xobj ctx [x@(XObj (Sym interface@(SymPath _ _) _) _ _), i@(X
              do currentImplementations <- primitiveMeta xobj ctx [i, XObj (Str "implements") (Just dummyInfo) (Just StringTy)]
                 case snd currentImplementations of
                   Left err  -> return $ (ctx, Left err)
-                  Right (XObj (Lst impls) inf ty) ->
-                    let newImpls = XObj (Lst (x : impls)) inf (Just DynamicTy)
+                  Right old@(XObj (Lst impls) inf ty) ->
+                    let newImpls = if x `elem` impls
+                                   then old
+                                   else XObj (Lst (x : impls)) inf (Just DynamicTy)
                         adjustedMeta = meta {getMeta = Map.insert "implements" newImpls (getMeta meta)}
                     in  return (ctx' {contextGlobalEnv = envInsertAt global (getPath defobj) (Binder adjustedMeta defobj)},
                                dynamicNil)


### PR DESCRIPTION
This PR bundles a few small improvements to our handling of interfaces and implementations:

- [x] Updates `primitiveMeta` to handle qualified cases
  
   Before `meta` use to fail to find its argument binding in cases
   like this one:

   ```
   (defmodule Foo (hidden bar) (meta Foo.bar "hidden"))
   ```

   This is because `meta` used to cons path strings to the path even if
   the path was already qualified with a module name as in the example
   above. We now treat these cases separately, and instances like the
   above work.

- [x] Updates `primitiveImplements` to set the "implements" meta to a list of implemented interfaces, instead of a single interface. Duplicates aren't added.
  
   This makes sense since functions could implement multiple generic
   interfaces. An example of the new behavior:

   ```
   (implements inc foo)
   (implements dec foo)
   (meta foo "implements")
   => (dec inc)
   ```
  
- [x] Adds an `implements?` macro that returns a bool indicating whether or not a given binding implements a given interface:

  ```
  鲤 (implements inc foo)
  鲤 (implements dec foo)
  鲤 (eval (implements? 'inc foo))
  => true
  鲤 (eval (implements? 'dec foo))
  => true
  鲤 (eval (implements? '+ foo))
  => false 
  ```

I also fixed an erroneous `implements` declaration for `PairRef.>` that I happened to spot.