### PR TITLE
Add `s-exp` primitive and Introspection module

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -18,6 +18,7 @@
 (load-once "Interfaces.carp")
 (load-once "Bool.carp")
 (load-once "Macros.carp")
+(load-once "Introspect.carp")
 (load-once "Pointer.carp")
 (load-once "Unsafe.carp")
 (load-once "Generics.carp")

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -1,0 +1,76 @@
+(doc Introspect
+  "Dynamic functions that return information about the s-expressions associated
+  to a binding.")
+(defmodule Introspect
+  (doc module?
+    "Is this binding a module?")
+  (defmacro module? [binding]
+    (not (list? (eval (list 's-exp binding)))))
+  (doc function? 
+    "Is this binding a function?")
+  (defmacro function? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+      (Dynamic.= (Symbol.from "defn") (car (eval (list 's-exp binding))))))
+  (doc variable?
+    "Is this binding a variable?")
+  (defmacro variable? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+      (Dynamic.= (Symbol.from "def") (car (eval (list 's-exp binding))))))
+  (doc type?
+    "Is this binding a type?")
+  (defmacro type? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+        (Dynamic.= (Symbol.from "deftype") (car (eval (list 's-exp binding))))))
+  (doc struct? 
+    "Is this binding a struct?")
+  (defmacro struct? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+        (array? (caddr (eval (list 's-exp binding))))))
+  (doc sumtype?
+    "Is this binding a sumtype?")
+  (defmacro sumtype? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+        (list? (caddr (eval (list 's-exp binding))))))
+  (doc arity 
+    "What's the arity of this binding?
+
+    - When `binding` is a function, returns the number of arguments.
+    - When `binding` is a struct, returns the number of fields.
+    - When `binding` is a sumtype, returns a list of the number of type
+      arguments of each constructor.")
+  (defmacro arity [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        0
+    (eval (list 'cond
+        (list 'Introspect.function? binding) (length (caddr (eval (list 's-exp binding))))
+        (list 'Introspect.struct? binding) (/ (length (caddr (eval (list 's-exp binding)))) 2)
+        (list 'Introspect.sumtype? binding) (quote (map (fn [arr] (/
+        (length arr) 2)) (cddr (eval (list 's-exp binding)))))
+        0))))
+  (doc macro?
+    "Is this binding a macro?")
+  (defmacro macro? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+        (Dynamic.= (Symbol.from "defmacro") (car (eval (list 's-exp binding))))))
+  (doc dynamic?
+    "Is this binding a dynamic binding?")
+  (defmacro dynamic? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+        (or (Dynamic.= (Symbol.from "defdynamic") (car (eval (list 's-exp
+        binding))))
+            (Dynamic.= (Symbol.from "dynamic") (car (eval (list 's-exp
+        binding)))))))
+  (doc interface? 
+    "Is this binding an interface?")
+  (defmacro interface? [binding]
+    (if (empty? (eval (list 's-exp binding)))
+        false
+        (Dynamic.= (Symbol.from "definterface") (car (eval (list 's-exp binding))))))
+)

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -5,37 +5,37 @@
   (doc module?
     "Is this binding a module?")
   (defmacro module? [binding]
-    (not (list? (eval (list 's-exp binding)))))
+    (not (list? (eval (list 's-expr binding)))))
   (doc function? 
     "Is this binding a function?")
   (defmacro function? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-      (Dynamic.= (Symbol.from "defn") (car (eval (list 's-exp binding))))))
+      (Dynamic.= (Symbol.from "defn") (car (eval (list 's-expr binding))))))
   (doc variable?
     "Is this binding a variable?")
   (defmacro variable? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-      (Dynamic.= (Symbol.from "def") (car (eval (list 's-exp binding))))))
+      (Dynamic.= (Symbol.from "def") (car (eval (list 's-expr binding))))))
   (doc type?
     "Is this binding a type?")
   (defmacro type? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-        (Dynamic.= (Symbol.from "deftype") (car (eval (list 's-exp binding))))))
+        (Dynamic.= (Symbol.from "deftype") (car (eval (list 's-expr binding))))))
   (doc struct? 
     "Is this binding a struct?")
   (defmacro struct? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-        (array? (caddr (eval (list 's-exp binding))))))
+        (array? (caddr (eval (list 's-expr binding))))))
   (doc sumtype?
     "Is this binding a sumtype?")
   (defmacro sumtype? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-        (list? (caddr (eval (list 's-exp binding))))))
+        (list? (caddr (eval (list 's-expr binding))))))
   (doc arity 
     "What's the arity of this binding?
 
@@ -44,33 +44,33 @@
     - When `binding` is a sumtype, returns a list of the number of type
       arguments of each constructor.")
   (defmacro arity [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         0
     (eval (list 'cond
-        (list 'Introspect.function? binding) (length (caddr (eval (list 's-exp binding))))
-        (list 'Introspect.struct? binding) (/ (length (caddr (eval (list 's-exp binding)))) 2)
+        (list 'Introspect.function? binding) (length (caddr (eval (list 's-expr binding))))
+        (list 'Introspect.struct? binding) (/ (length (caddr (eval (list 's-expr binding)))) 2)
         (list 'Introspect.sumtype? binding) (quote (map (fn [arr]
-        (length (cadr arr))) (cddr (eval (list 's-exp binding)))))
+        (length (cadr arr))) (cddr (eval (list 's-expr binding)))))
         0))))
   (doc macro?
     "Is this binding a macro?")
   (defmacro macro? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-        (Dynamic.= (Symbol.from "defmacro") (car (eval (list 's-exp binding))))))
+        (Dynamic.= (Symbol.from "defmacro") (car (eval (list 's-expr binding))))))
   (doc dynamic?
     "Is this binding a dynamic binding?")
   (defmacro dynamic? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-        (or (Dynamic.= (Symbol.from "defdynamic") (car (eval (list 's-exp
+        (or (Dynamic.= (Symbol.from "defdynamic") (car (eval (list 's-expr
         binding))))
-            (Dynamic.= (Symbol.from "dynamic") (car (eval (list 's-exp
+            (Dynamic.= (Symbol.from "dynamic") (car (eval (list 's-expr
         binding)))))))
   (doc interface? 
     "Is this binding an interface?")
   (defmacro interface? [binding]
-    (if (empty? (eval (list 's-exp binding)))
+    (if (empty? (eval (list 's-expr binding)))
         false
-        (Dynamic.= (Symbol.from "definterface") (car (eval (list 's-exp binding))))))
+        (Dynamic.= (Symbol.from "definterface") (car (eval (list 's-expr binding))))))
 )

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -49,8 +49,8 @@
     (eval (list 'cond
         (list 'Introspect.function? binding) (length (caddr (eval (list 's-exp binding))))
         (list 'Introspect.struct? binding) (/ (length (caddr (eval (list 's-exp binding)))) 2)
-        (list 'Introspect.sumtype? binding) (quote (map (fn [arr] (/
-        (length arr) 2)) (cddr (eval (list 's-exp binding)))))
+        (list 'Introspect.sumtype? binding) (quote (map (fn [arr]
+        (length (cadr arr))) (cddr (eval (list 's-exp binding)))))
         0))))
   (doc macro?
     "Is this binding a macro?")

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -725,7 +725,7 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
                return (ctx, Right (XObj (Lst (map toSymbols forms)) i t))
            Just (_, Binder _ xobj'') ->
              return (ctx, Right xobj'')
-           Nothing -> return (ctx, dynamicNil)
+           Nothing -> return (ctx, Right (XObj (Lst []) (Just dummyInfo) (Just DynamicTy)))
 primitiveSexpression (XObj _ i _) ctx xobj =
   return $ evalError ctx ("s-exp expected a symbol argument but got: " ++ unwords (map pretty xobj)) i
 

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -710,7 +710,7 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
              Just (_, Binder _ (XObj (Lst forms) i t)) ->
                return (ctx, Right (XObj (Lst (map toSymbols forms)) i t))
              Just (_, Binder _ xobj') ->
-               trace ("not a list") return (ctx, Right xobj')
+               return (ctx, Right xobj')
              -- Okay, this is just a `defmodule` not a type.
              Nothing ->
                return (ctx, Right mod)
@@ -725,7 +725,7 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
                return (ctx, Right (XObj (Lst (map toSymbols forms)) i t))
            Just (_, Binder _ xobj'') ->
              return (ctx, Right xobj'')
-           Nothing -> trace ("Nothing found: " ++ show env ++ show path) return (ctx, dynamicNil)
+           Nothing -> return (ctx, dynamicNil)
 primitiveSexpression (XObj _ i _) ctx xobj =
   return $ evalError ctx ("s-exp expected a symbol argument but got: " ++ show xobj) i
 

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -712,11 +712,20 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
              -- Okay, this is just a `defmodule` not a type.
              Nothing ->
                return (ctx, Right mod)
-         _ -> trace (show binder) return (ctx, Right xobj)
+         (XObj (Lst forms) i t) ->
+           return (ctx, Right (XObj (Lst (map toSymbols forms)) i t))
+         _ -> return (ctx, Right xobj)
        Nothing ->
-         -- Just to be sure, check the type env--this might be an interface or
+         -- Just to be sure, check the type env--this might be an interface
          case lookupInEnv path tyEnv of
            Just (_, Binder _ xobj'') ->
              return (ctx, Right xobj'')
            Nothing -> return (ctx, dynamicNil)
 
+toSymbols :: XObj -> XObj
+toSymbols (XObj (Defn _) i t) = (XObj (Sym (SymPath [] "defn") Symbol) i t)
+toSymbols (XObj Def i t) = (XObj (Sym (SymPath [] "def") Symbol) i t)
+toSymbols (XObj (Deftype _) i t) = (XObj (Sym (SymPath [] "deftype") Symbol) i t)
+toSymbols (XObj (DefSumtype _) i t) = (XObj (Sym (SymPath [] "deftype") Symbol) i t)
+toSymbols (XObj (Interface _ _) i t) = (XObj (Sym (SymPath [] "definterface") Symbol) i t)
+toSymbols x = x

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -707,6 +707,8 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
          -- form here.
          mod@(XObj (Mod env) _ _) ->
            case lookupInEnv path tyEnv of
+             Just (_, Binder _ (XObj (Lst forms) i t)) ->
+               return (ctx, Right (XObj (Lst (map toSymbols forms)) i t))
              Just (_, Binder _ xobj') ->
                return (ctx, Right xobj')
              -- Okay, this is just a `defmodule` not a type.

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -727,7 +727,7 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
              return (ctx, Right xobj'')
            Nothing -> return (ctx, dynamicNil)
 primitiveSexpression (XObj _ i _) ctx xobj =
-  return $ evalError ctx ("s-exp expected a symbol argument but got: " ++ show xobj) i
+  return $ evalError ctx ("s-exp expected a symbol argument but got: " ++ unwords (map pretty xobj)) i
 
 toSymbols :: XObj -> XObj
 toSymbols (XObj (Defn _) i t) = (XObj (Sym (SymPath [] "defn") Symbol) i t)

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -705,11 +705,13 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
          case xobj of
          -- Normally, modules print their names, we actually want the deftype
          -- form here.
-         (XObj (Mod env) _ _) ->
+         mod@(XObj (Mod env) _ _) ->
            case lookupInEnv path tyEnv of
              Just (_, Binder _ xobj') ->
                return (ctx, Right xobj')
-             Nothing -> return (ctx, dynamicNil)
+             -- Okay, this is just a `defmodule` not a type.
+             Nothing ->
+               return (ctx, Right mod)
          _ -> trace (show binder) return (ctx, Right xobj)
        Nothing ->
          -- Just to be sure, check the type env--this might be an interface or

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -248,7 +248,7 @@ dynamicModule = Env { envBindings = bindings
                     , makePrim "defined?" 1 "checks whether a symbol is defined." "(defined? mysymbol)" primitiveDefined
                     , makePrim "deftemplate" 4 "defines a new C template." "(deftemplate symbol Type declString defString)" primitiveDeftemplate
                     , makePrim "implements" 2 "designates a function as an implementation of an interface." "(implements zero Maybe.zero)" primitiveImplements
-                    , makePrim "s-exp" 1 "returns the s-expression associated with a binding. When the binding is a type, the deftype form is returned instead of the type's module." "(s-exp foo)" primitiveSexpression
+                    , makePrim "s-expr" 1 "returns the s-expression associated with a binding. When the binding is a type, the deftype form is returned instead of the type's module." "(s-expr foo)" primitiveSexpression
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -248,7 +248,7 @@ dynamicModule = Env { envBindings = bindings
                     , makePrim "defined?" 1 "checks whether a symbol is defined." "(defined? mysymbol)" primitiveDefined
                     , makePrim "deftemplate" 4 "defines a new C template." "(deftemplate symbol Type declString defString)" primitiveDeftemplate
                     , makePrim "implements" 2 "designates a function as an implementation of an interface." "(implements zero Maybe.zero)" primitiveImplements
-                    , makePrim "s-exp" 1 "returns the s-expression associated with a binding." "(s-exp foo)" primitiveSexpression
+                    , makePrim "s-exp" 1 "returns the s-expression associated with a binding. When the binding is a type, the deftype form is returned instead of the type's module." "(s-exp foo)" primitiveSexpression
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -248,6 +248,7 @@ dynamicModule = Env { envBindings = bindings
                     , makePrim "defined?" 1 "checks whether a symbol is defined." "(defined? mysymbol)" primitiveDefined
                     , makePrim "deftemplate" 4 "defines a new C template." "(deftemplate symbol Type declString defString)" primitiveDeftemplate
                     , makePrim "implements" 2 "designates a function as an implementation of an interface." "(implements zero Maybe.zero)" primitiveImplements
+                    , makePrim "s-exp" 1 "returns the s-expression associated with a binding." "(s-exp foo)" primitiveSexpression
                     ]
                     ++ [("String", Binder emptyMeta (XObj (Mod dynamicStringModule) Nothing Nothing))
                        ,("Symbol", Binder emptyMeta (XObj (Mod dynamicSymModule) Nothing Nothing))


### PR DESCRIPTION
This PR adds an `s-exp` primitive, which returns the s-expression or form associated with a binding. It's similar to the default behavior of dynamic xobjs, but it does some extra checking on receiving module xobjs to return the original deftype forms whenever the modules are generated from a type.

`s-exp` is the backbone of a new `Introspection` module, which contains predicates about bindings and their associated forms. One can use this module in a dynamic context to determine if a binding is a function, struct, sumtype, interface, it's arity, etc.

Here are a few examples of `s-exp`:

```clojure
鲤 (def foo 3)
鲤 (s-exp foo)
=> (def foo 3)
鲤 (defn bar [x] x)
鲤 (s-exp bar)
=> (defn bar [x] x)
鲤 (deftype Foo [x Int])
鲤 (s-exp Foo)
=> (deftype Foo [x Int])
鲤 (deftype (Bar a) (Baz [a])) 
鲤 (s-exp Bar)
=> (deftype Bar (Baz [a]))
鲤 (definterface carp (Fn [a] a))
鲤 (s-exp carp)
=> (definterface carp)
鲤 
```

and the `Introspect` module:

```clojure
鲤 (Introspect.function? bar)
=> true
鲤 (Introspect.arity bar)
=> 1
鲤 (Introspect.function? foo)
=> false
鲤 (Introspect.variable? foo)
=> true
鲤 (Introspect.type? Foo)
=> true
鲤 (Introspect.struct? Foo)
=> true
鲤 (Introspect.arity Foo)
=> 1
鲤 (Introspect.sumtype? Foo)
=> false
鲤 (Introspect.sumtype? Bar)
=> true
鲤 (Introspect.arity Bar)
=> (1)
鲤 (deftype (Qux a) (Goo [a]) (Loo [a Int]))
鲤 (Introspect.arity Qux)
=> (1 2)
```

Let's go ahead and say this fixes #560?