### PR TITLE
Command line switches to evaluate code

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -79,6 +79,7 @@ executable carp
                      , filepath
                      , haskeline
                      , process
+                     , optparse-applicative
   default-language:    Haskell2010
 
 executable carp-header-parse
@@ -89,8 +90,8 @@ executable carp-header-parse
                      , CarpHask
                      , containers
                      , directory
-                     , cmdargs
                      , parsec
+                     , optparse-applicative
   default-language:    Haskell2010
 
 test-suite CarpHask-test

--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -62,7 +62,7 @@ library
                      , blaze-html
                      , blaze-markup
                      , text
-                     , ansi-terminal >= 0.9
+                     , ansi-terminal >= 0.10.3
                      , cmark
                      , edit-distance
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -86,7 +86,7 @@ main = do setLocaleEncoding utf8
                                   , projectGenerateOnly = generateOnly
                                   , projectCarpDir = fromMaybe (projectCarpDir p) $ lookup "CARP_DIR" sysEnv
                                   , projectCompiler = fromMaybe (projectCompiler p) compiler
-                                  , projectPrompt = prompt
+                                  , projectPrompt = fromMaybe (projectPrompt p) prompt
                                   }
               project = applySettings defaultProject
               noArray = False
@@ -158,7 +158,7 @@ data OtherOptions = OtherOptions
   , otherLogMemory :: Bool
   , otherOptimize :: Bool
   , otherGenerateOnly :: Bool
-  , otherPrompt :: String
+  , otherPrompt :: Maybe String
   } deriving Show
 
 parseOther :: Parser OtherOptions
@@ -168,7 +168,7 @@ parseOther = OtherOptions
   <*> switch (long "log-memory" <> help "Log memory allocations")
   <*> switch (long "optimize" <> help "Optimized build")
   <*> switch (long "generate-only" <> help "Stop after generating the C code")
-  <*> strOption (long "prompt" <> help "Set REPL prompt")
+  <*> optional (strOption (long "prompt" <> help "Set REPL prompt"))
 
 parseExecMode :: Parser ExecutionMode
 parseExecMode =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -99,8 +99,8 @@ main = do setLocaleEncoding utf8
               execStr info str ctx = executeString True False ctx str info
               execStrs :: String -> [String] -> Context -> IO Context
               execStrs info strs ctx = foldM (\ctx str -> execStr info str ctx) ctx strs
-              preloads = fromMaybe [] (optPreload fullOpts)
-              postloads = fromMaybe [] (optPostload fullOpts)
+              preloads = optPreload fullOpts
+              postloads = optPostload fullOpts
               load = flip loadFiles
           carpProfile <- configPath "profile.carp"
           hasProfile <- doesFileExist carpProfile
@@ -124,8 +124,8 @@ main = do setLocaleEncoding utf8
 data FullOptions = FullOptions
   { optExecMode :: ExecutionMode
   , optOthers :: OtherOptions
-  , optPreload :: Maybe [String]
-  , optPostload :: Maybe [String]
+  , optPreload :: [String]
+  , optPostload :: [String]
   , optFiles :: [FilePath]
   } deriving Show
 
@@ -133,8 +133,8 @@ parseFull :: Parser FullOptions
 parseFull = FullOptions
   <$> parseExecMode
   <*> parseOther
-  <*> optional (some (strOption (long "eval-preload" <> metavar "CODE" <> help "Eval CODE after loading config and before FILES")))
-  <*> optional (some (strOption (long "eval-postload" <> metavar "CODE" <> help "Eval CODE after loading FILES")))
+  <*> many (strOption (long "eval-preload" <> metavar "CODE" <> help "Eval CODE after loading config and before FILES"))
+  <*> many (strOption (long "eval-postload" <> metavar "CODE" <> help "Eval CODE after loading FILES"))
   <*> parseFiles
 
 data OtherOptions = OtherOptions
@@ -164,4 +164,4 @@ parseExecMode =
   <|> pure Repl
 
 parseFiles :: Parser [FilePath]
-parseFiles = some (argument str (metavar "FILES...")) <|> pure []
+parseFiles = many (argument str (metavar "FILES..."))

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,8 +57,6 @@ defaultProject =
           , projectGenerateOnly = False
           , projectForceReload = False
           }
-  where win = platform == Windows
-
 
 -- | Starting point of the application.
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -70,8 +70,8 @@ main = do setLocaleEncoding utf8
               otherOptions = optOthers fullOpts
               argFilesToLoad = optFiles fullOpts
               logMemory = otherLogMemory otherOptions
-              core = otherCore otherOptions
-              profile = otherProfile otherOptions
+              core = not $ otherNoCore otherOptions
+              profile = not $ otherNoProfile otherOptions
               optimize = otherOptimize otherOptions
               generateOnly = otherGenerateOnly otherOptions
               compiler = compCompiler compOptions
@@ -153,8 +153,8 @@ parseComp = CompOptions
   <*> optional (some (strOption (long "ldflag" <> metavar "FLAG" <> help "Add flag to the linker invocation")))
 
 data OtherOptions = OtherOptions
-  { otherCore :: Bool
-  , otherProfile :: Bool
+  { otherNoCore :: Bool
+  , otherNoProfile :: Bool
   , otherLogMemory :: Bool
   , otherOptimize :: Bool
   , otherGenerateOnly :: Bool
@@ -163,8 +163,8 @@ data OtherOptions = OtherOptions
 
 parseOther :: Parser OtherOptions
 parseOther = OtherOptions
-  <$> flag True False (long "core")
-  <*> switch (long "profile" <> help "Profiling information")
+  <$> switch (long "no-core" <> help "Don't load Core.carp")
+  <*> switch (long "no-profile" <> help "Don't load profile.carp")
   <*> switch (long "log-memory" <> help "Log memory allocations")
   <*> switch (long "optimize" <> help "Optimized build")
   <*> switch (long "generate-only" <> help "Stop after generating the C code")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,8 +115,8 @@ main = do setLocaleEncoding utf8
                                      putStrLn "Evaluate (help) for more information."
                                      snd <$> runRepl ctx
                           Build -> execStr "Compiler (Build)" "(build)" ctx
-                          Install thing -> execStr ("(load \"" ++ thing ++ "\")") "Installation" ctx
-                          BuildAndRun -> execStr "(do (build) (run))" "Compiler (Build & Run)" ctx
+                          Install thing -> execStr "Installation" ("(load \"" ++ thing ++ "\")") ctx
+                          BuildAndRun -> execStr "Compiler (Build & Run)" "(do (build) (run))" ctx
                           Check -> execStr "Check" "" ctx
                           -- TODO: Handle the return value from executeString and return that one to the shell
           pure ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -168,7 +168,7 @@ parseOther = OtherOptions
   <*> switch (long "log-memory" <> help "Log memory allocations")
   <*> switch (long "optimize" <> help "Optimized build")
   <*> switch (long "generate-only" <> help "Stop after generating the C code")
-  <*> strOption (long "prompt" <> value "鲤 " <> help "Set REPL prompt")
+  <*> strOption (long "prompt" <> help "Set REPL prompt")
 
 parseExecMode :: Parser ExecutionMode
 parseExecMode =

--- a/carp.sh
+++ b/carp.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 if [ -z "$CARP" ]
 then
     if [ -z "$NIX_CC" ]
@@ -7,4 +8,4 @@ then
 	CARP="cabal -v0 run carp"
     fi
 fi
-$CARP $BUILD_OPTS $"--" $CARP_OPTS $*
+$CARP $BUILD_OPTS -- $CARP_OPTS "$@"

--- a/carp.sh
+++ b/carp.sh
@@ -7,4 +7,4 @@ then
 	CARP="cabal -v0 run carp"
     fi
 fi
-$CARP $BUILD_OPTS $"--" $*
+$CARP $BUILD_OPTS $"--" $CARP_OPTS $*

--- a/core/SafeInt.carp
+++ b/core/SafeInt.carp
@@ -1,12 +1,10 @@
 (system-include "carp_safe_int.h")
 
 (defmodule Int
-  (not-on-windows ; this seems to generate invalid code on some windows machines
-    (doc safe-add "Performs an addition and checks whether it overflowed.")
-    (register safe-add (λ [Int Int (Ref Int)] Bool))
-    (doc safe-sub "Performs an substraction and checks whether it overflowed.")
-    (register safe-sub (λ [Int Int (Ref Int)] Bool))
-    (doc safe-mul "Performs an multiplication and checks whether it overflowed.")
-    (register safe-mul (λ [Int Int (Ref Int)] Bool))
-  )
+  (doc safe-add "Performs an addition and checks whether it overflowed.")
+  (register safe-add (λ [Int Int (Ref Int)] Bool))
+  (doc safe-sub "Performs an substraction and checks whether it overflowed.")
+  (register safe-sub (λ [Int Int (Ref Int)] Bool))
+  (doc safe-mul "Performs an multiplication and checks whether it overflowed.")
+  (register safe-mul (λ [Int Int (Ref Int)] Bool))
 )

--- a/core/carp_long.h
+++ b/core/carp_long.h
@@ -24,7 +24,7 @@ bool Long_safe_MINUS_sub(Long x, Long y, Long* res) {
 bool Long_safe_MINUS_mul(Long x, Long y, Long* res) {
     Long r = x * y;
     *res = r;
-    return (r / y) != x;
+    return y == 0 || (r / y) != x;
 }
 #else
 bool Long_safe_MINUS_add(Long x, Long y, Long* res) {

--- a/core/carp_long.h
+++ b/core/carp_long.h
@@ -10,7 +10,17 @@ Long Long__MUL_(Long x, Long y) {
 Long Long__DIV_(Long x, Long y) {
     return x / y;
 }
-#if defined _WIN32 || defined __TINYC__
+#if defined __GNUC__
+bool Long_safe_MINUS_add(Long x, Long y, Long* res) {
+    return __builtin_add_overflow(x, y, res);
+}
+bool Long_safe_MINUS_sub(Long x, Long y, Long* res) {
+    return __builtin_sub_overflow(x, y, res);
+}
+bool Long_safe_MINUS_mul(Long x, Long y, Long* res) {
+    return __builtin_mul_overflow(x, y, res);
+}
+#else
 bool Long_safe_MINUS_add(Long x, Long y, Long* res) {
     Long r = x + y;
     *res = r;
@@ -25,16 +35,6 @@ bool Long_safe_MINUS_mul(Long x, Long y, Long* res) {
     Long r = x * y;
     *res = r;
     return y == 0 || (r / y) != x;
-}
-#else
-bool Long_safe_MINUS_add(Long x, Long y, Long* res) {
-    return __builtin_add_overflow(x, y, res);
-}
-bool Long_safe_MINUS_sub(Long x, Long y, Long* res) {
-    return __builtin_sub_overflow(x, y, res);
-}
-bool Long_safe_MINUS_mul(Long x, Long y, Long* res) {
-    return __builtin_mul_overflow(x, y, res);
 }
 #endif
 bool Long__EQ_(Long x, Long y) {

--- a/core/carp_long.h
+++ b/core/carp_long.h
@@ -10,7 +10,23 @@ Long Long__MUL_(Long x, Long y) {
 Long Long__DIV_(Long x, Long y) {
     return x / y;
 }
-#ifndef _WIN32
+#if defined _WIN32 || defined __TINYC__
+bool Long_safe_MINUS_add(Long x, Long y, Long* res) {
+    Long r = x + y;
+    *res = r;
+    return (y > 0) && (x > (INT64_MAX - y)) || (y < 0) && (x < (INT64_MIN - y));
+}
+bool Long_safe_MINUS_sub(Long x, Long y, Long* res) {
+    Long r = x - y;
+    *res = r;
+    return (y > 0 && x < (INT64_MIN + y)) || (y < 0 && x > (INT64_MAX + y));
+}
+bool Long_safe_MINUS_mul(Long x, Long y, Long* res) {
+    Long r = x * y;
+    *res = r;
+    return (r / y) != x;
+}
+#else
 bool Long_safe_MINUS_add(Long x, Long y, Long* res) {
     return __builtin_add_overflow(x, y, res);
 }

--- a/core/carp_safe_int.h
+++ b/core/carp_safe_int.h
@@ -1,4 +1,22 @@
-#ifndef _WIN32
+#if defined _WIN32 || defined __TINYC__
+
+bool Int_safe_MINUS_add(int x, int y, int* res) {
+    int r = x + y;
+    *res = r;
+    return (y > 0) && (x > (INT_MAX - y)) || (y < 0) && (x < (INT_MIN - y));
+}
+bool Int_safe_MINUS_sub(int x, int y, int* res) {
+    int r = x - y;
+    *res = r;
+    *res = x - y;
+    return (y > 0 && x < (INT_MIN + y)) || (y < 0 && x > (INT_MAX + y));
+}
+bool Int_safe_MINUS_mul(int x, int y, int* res) {
+    int r = x * y;
+    *res = r;
+    return (r / y) != x;
+}
+#else
 bool Int_safe_MINUS_add(int x, int y, int* res) {
     return __builtin_add_overflow(x, y, res);
 }

--- a/core/carp_safe_int.h
+++ b/core/carp_safe_int.h
@@ -1,5 +1,14 @@
-#if defined _WIN32 || defined __TINYC__
-
+#if defined __GNUC__
+bool Int_safe_MINUS_add(int x, int y, int* res) {
+    return __builtin_add_overflow(x, y, res);
+}
+bool Int_safe_MINUS_sub(int x, int y, int* res) {
+    return __builtin_sub_overflow(x, y, res);
+}
+bool Int_safe_MINUS_mul(int x, int y, int* res) {
+    return __builtin_mul_overflow(x, y, res);
+}
+#else
 bool Int_safe_MINUS_add(int x, int y, int* res) {
     int r = x + y;
     *res = r;
@@ -15,15 +24,5 @@ bool Int_safe_MINUS_mul(int x, int y, int* res) {
     int r = x * y;
     *res = r;
     return y == 0 || (r / y) != x;
-}
-#else
-bool Int_safe_MINUS_add(int x, int y, int* res) {
-    return __builtin_add_overflow(x, y, res);
-}
-bool Int_safe_MINUS_sub(int x, int y, int* res) {
-    return __builtin_sub_overflow(x, y, res);
-}
-bool Int_safe_MINUS_mul(int x, int y, int* res) {
-    return __builtin_mul_overflow(x, y, res);
 }
 #endif

--- a/core/carp_safe_int.h
+++ b/core/carp_safe_int.h
@@ -14,7 +14,7 @@ bool Int_safe_MINUS_sub(int x, int y, int* res) {
 bool Int_safe_MINUS_mul(int x, int y, int* res) {
     int r = x * y;
     *res = r;
-    return (r / y) != x;
+    return y == 0 || (r / y) != x;
 }
 #else
 bool Int_safe_MINUS_add(int x, int y, int* res) {

--- a/default.nix
+++ b/default.nix
@@ -73,6 +73,6 @@ in
   if pkgs.lib.inNixShell
   then drv.env.overrideAttrs (o: {
     buildInputs = with pkgs; o.buildInputs ++ [ haskellPackages.cabal-install clang gdb ]
-                  ++ linuxOnly [ flamegraph linuxPackages.perf ];
+                  ++ linuxOnly [ flamegraph linuxPackages.perf tinycc ];
   })
   else drv

--- a/default.nix
+++ b/default.nix
@@ -11,9 +11,10 @@ let
   optionals = nixpkgs.stdenv.lib.optionals;
   linuxOnly = optionals nixpkgs.stdenv.isLinux;
 
-  f = { mkDerivation, ansi-terminal, base, blaze-html, blaze-markup
-      , cmark, cmdargs, containers, directory, edit-distance, filepath
-      , haskeline, HUnit, mtl, parsec, process, split, stdenv, text
+  f = { mkDerivation, stdenv
+      , ansi-terminal, base, blaze-html, blaze-markup
+      , cmark, containers, directory, edit-distance, filepath
+      , haskeline, HUnit, mtl, optparse-applicative, parsec, process, split, text
       , darwin, glfw3, SDL2, SDL2_image, SDL2_gfx, SDL2_mixer, SDL2_ttf
       , ghc-prof-flamegraph
       , clang , makeWrapper
@@ -39,7 +40,7 @@ let
           [ glfw3 SDL2 SDL2_image SDL2_gfx SDL2_mixer SDL2_ttf ]
           ++ linuxOnly [ libXext libXcursor libXinerama libXi libXrandr libXScrnSaver libXxf86vm libpthreadstubs libXdmcp libGL];
         executableHaskellDepends = [
-          base cmdargs containers directory haskeline parsec process
+          base containers directory haskeline optparse-applicative parsec process
           clang
         ];
         executableFrameworkDepends = with darwin.apple_sdk.frameworks; optionals stdenv.isDarwin [

--- a/examples/basics.carp
+++ b/examples/basics.carp
@@ -234,4 +234,5 @@
       (two-lengths-in-same-func)
       (changing-target-of-ref)
       (resolve-correctly)
+      0
       ))

--- a/headerparse/Main.hs
+++ b/headerparse/Main.hs
@@ -3,7 +3,7 @@
 
 module Main where
 
-import System.Console.CmdArgs
+import Options.Applicative hiding ((<|>))
 import Text.Parsec ((<|>))
 import qualified Text.Parsec as Parsec
 import Data.Char (toLower, isUpper)
@@ -12,16 +12,18 @@ import Types
 import Obj
 import Path
 
-data Args = Args { sourcePath :: String
-                 , prefixToRemove :: String
+data Args = Args { prefixToRemove :: String
                  , kebabCase :: Bool
-                 } deriving (Show, Data, Typeable)
+                 , sourcePath :: String
+                 } deriving Show
 
-main = do parsedArgs <- cmdArgs (Args { sourcePath = def &= argPos 0
-                                      , prefixToRemove = def
-                                      , kebabCase = False
-                                      }
-                                 &= summary "Carp Header Parse 0.0.1")
+parseArgs :: Parser Args
+parseArgs = Args
+  <$> strOption (long "prefixtoremove" <> short 'p' <> metavar "ITEM" <> value "")
+  <*> switch (long "kebabcase" <> short 'f')
+  <*> argument str (metavar "FILE")
+
+main = do parsedArgs <- execParser $ Options.Applicative.info (parseArgs <**> helper) fullDesc
           let path = sourcePath parsedArgs
           if path /= ""
             then do source <- slurp path

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -701,10 +701,11 @@ memberToDecl indent (memberName, memberType) =
 
 defStructToDeclaration :: Ty -> SymPath -> [XObj] -> String
 defStructToDeclaration structTy@(StructTy typeName typeVariables) path rest =
-  let indent' = indentAmount
+  let indent = indentAmount
 
       typedefCaseToMemberDecl :: XObj -> State EmitterState [()]
-      typedefCaseToMemberDecl (XObj (Arr members) _ _) = mapM (memberToDecl indent') (pairwise members)
+      typedefCaseToMemberDecl (XObj (Arr []) _ _) = sequence $ pure $ appendToSrc (addIndent indent ++ "char __dummy;\n")
+      typedefCaseToMemberDecl (XObj (Arr members) _ _) = mapM (memberToDecl indent) (pairwise members)
       typedefCaseToMemberDecl _ = error "Invalid case in typedef."
 
       -- Note: the names of types are not namespaced

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -704,6 +704,7 @@ defStructToDeclaration structTy@(StructTy typeName typeVariables) path rest =
   let indent = indentAmount
 
       typedefCaseToMemberDecl :: XObj -> State EmitterState [()]
+      -- ANSI C doesn't allow empty structs, insert a dummy member to keep the compiler happy.
       typedefCaseToMemberDecl (XObj (Arr []) _ _) = sequence $ pure $ appendToSrc (addIndent indent ++ "char __dummy;\n")
       typedefCaseToMemberDecl (XObj (Arr members) _ _) = mapM (memberToDecl indent) (pairwise members)
       typedefCaseToMemberDecl _ = error "Invalid case in typedef."

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -813,18 +813,21 @@ printC xobj =
 
 buildMainFunction :: XObj -> XObj
 buildMainFunction xobj =
-  XObj (Lst [ XObj (Defn Nothing) (Just dummyInfo) Nothing
-            , XObj (Sym (SymPath [] "main") Symbol) (Just dummyInfo) Nothing
-            , XObj (Arr []) (Just dummyInfo) Nothing
-            , case ty xobj of
-                Just UnitTy -> xobj
-                Just (RefTy _ _) -> XObj (Lst [XObj (Sym (SymPath [] "println*") Symbol) (Just dummyInfo) Nothing, xobj])
-                                       (Just dummyInfo) (Just UnitTy)
-                Just _ -> XObj (Lst [XObj (Sym (SymPath [] "println*") Symbol) (Just dummyInfo) Nothing,
-                                     XObj (Lst [XObj Ref (Just dummyInfo) Nothing, xobj])
-                                           (Just dummyInfo) (Just UnitTy)])
-                               (Just dummyInfo) (Just UnitTy)
-            ]) (Just dummyInfo) (Just (FuncTy [] UnitTy StaticLifetimeTy))
+  XObj (Lst [ XObj (Defn Nothing) di Nothing
+            , XObj (Sym (SymPath [] "main") Symbol) di Nothing
+            , XObj (Arr []) di Nothing
+            , XObj (Lst [ XObj Do di Nothing
+                        , case ty xobj of
+                            Just UnitTy -> xobj
+                            Just (RefTy _ _) -> XObj (Lst [XObj (Sym (SymPath [] "println*") Symbol) di Nothing, xobj])
+                                                di (Just UnitTy)
+                            Just _ -> XObj (Lst [XObj (Sym (SymPath [] "println*") Symbol) di Nothing,
+                                                 XObj (Lst [XObj Ref di Nothing, xobj])
+                                                 di (Just UnitTy)])
+                                      di (Just UnitTy)
+                        , XObj (Num IntTy 0) di Nothing
+                        ]) di Nothing]) di (Just (FuncTy [] UnitTy StaticLifetimeTy))
+  where di = Just dummyInfo
 
 primitiveDefdynamic :: Primitive
 primitiveDefdynamic _ ctx [XObj (Sym (SymPath [] name) _) _ _, value] = do

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -151,6 +151,7 @@ resetAlreadyLoadedFiles context =
       proj' = proj { projectAlreadyLoaded = [] }
   in  context { contextProj = proj' }
 
+runRepl :: Context -> IO ((), Context)
 runRepl context = do
   historyFile <- configPath "history"
   createDirectoryIfMissing True (takeDirectory historyFile)

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-14.9
+resolver: lts-15.13
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,7 +39,7 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: [ansi-terminal-0.9]
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-15.13
+resolver: lts-15.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/init_global.carp
+++ b/test/init_global.carp
@@ -6,4 +6,6 @@
 
 ;; The one allocation left after 'carp_init_globals' should be 'g' itself:
 (defn main []
-  (assert (= 1l (Debug.memory-balance))))
+  (do
+    (assert (= 1l (Debug.memory-balance)))
+    0))


### PR DESCRIPTION
This is a more flexible alternative to #803. Implements `--eval-preload` and `--eval-postload` with the intention of changing compiler and flags, but could be useful for other purposes.
 