### PR TITLE
Info Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 main.obj
 examples/out
 /stack.yaml.lock
+tags

--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -15,7 +15,8 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Obj,
+  exposed-modules:     Info,
+                       Obj,
                        Parsing,
                        Infer,
                        Emit,

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,6 +12,7 @@ import StartingEnv
 import Eval
 import Util
 import Path
+import Info
 
 defaultProject :: Project
 defaultProject =

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -25,6 +25,7 @@ import Lookup
 import RenderDocs
 import TypeError
 import Path
+import Info
 
 data CarpException =
     ShellOutException { shellOutMessage :: String, returnCode :: Int }

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -21,6 +21,7 @@ import Lookup
 import ToTemplate
 import Validate
 import SumtypeCase
+import Info
 
 data Level = Toplevel | Inside
 

--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -19,6 +19,7 @@ import Lookup
 import StructUtils
 import TypeError
 import Validate
+import Info
 
 {-# ANN module "HLint: ignore Reduce duplication" #-}
 -- | This function creates a "Type Module" with the same name as the type being defined.

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -24,6 +24,7 @@ import Template
 import Scoring
 import Lookup
 import Concretize
+import Info
 
 addIndent :: Int -> String
 addIndent n = replicate n ' '

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -32,6 +32,7 @@ import TypeError
 import Concretize
 import Path
 import Primitives
+import Info
 
 import Debug.Trace
 

--- a/src/Expand.hs
+++ b/src/Expand.hs
@@ -9,6 +9,7 @@ import Obj
 import Util
 import Lookup
 import TypeError
+import Info
 
 -- | Used for calling back to the 'eval' function in Eval.hs
 type DynamicEvaluator = Context -> XObj -> IO (Context, Either EvalError XObj)

--- a/src/GenerateConstraints.hs
+++ b/src/GenerateConstraints.hs
@@ -15,6 +15,7 @@ import Constraints
 import Util
 import TypeError
 import Lookup
+import Info
 
 -- | Will create a list of type constraints for a form.
 genConstraints :: Env -> XObj -> Maybe (Ty, XObj) -> Either TypeError [Constraint]

--- a/src/Info.hs
+++ b/src/Info.hs
@@ -1,0 +1,91 @@
+-- | Module Info defines data types and functions for reporting details about
+-- the Carp forms in a source file.
+module Info (Info(..),
+             Deleter(..),
+             FilePathPrintLength(..),
+             dummyInfo,
+             getInfo,
+             prettyInfo,
+             freshVar,
+             machineReadableInfo,
+             makeTypeVariableNameFromInfo) where
+
+import qualified Data.Set as Set
+import Path (takeFileName)
+import Types
+import Util
+
+-- | Information about where the Obj originated from.
+data Info = Info { infoLine :: Int
+                 , infoColumn :: Int
+                 , infoFile :: String
+                 , infoDelete :: Set.Set Deleter
+                 , infoIdentifier :: Int
+                 } deriving (Show, Eq, Ord)
+
+-- TODO: The name 'deleter' for these things are really confusing!
+-- | Designates the deleter function for a Carp object.
+data Deleter = ProperDeleter { deleterPath :: SymPath
+                             , deleterVariable :: String
+                             }
+             -- used for external types with no delete function
+             | FakeDeleter { deleterVariable :: String 
+                           }
+             -- used by primitive types (i.e. Int) to signify that the variable is alive
+             | PrimDeleter { aliveVariable :: String 
+                           }
+             | RefDeleter { refVariable :: String
+                          }
+             deriving (Eq, Ord)
+
+instance Show Deleter where
+  show (ProperDeleter path var) = "(ProperDel " ++ show path ++ " " ++ show var ++ ")"
+  show (FakeDeleter var) = "(FakeDel " ++ show var ++ ")"
+  show (PrimDeleter var) = "(PrimDel " ++ show var ++ ")"
+  show (RefDeleter var) = "(RefDel " ++ show var ++ ")"
+
+-- | Whether or not the full path of a source file or a short path should be
+-- printed.
+data FilePathPrintLength = FullPath
+                         | ShortPath deriving Eq
+
+instance Show FilePathPrintLength where
+  show FullPath = "full"
+  show ShortPath = "short"
+
+-- | A "dummy" info object, used for bindings that do not have meaningful info,
+-- such as compiler generated bindings.
+dummyInfo :: Info
+dummyInfo = Info 0 0 "dummy-file" Set.empty (-1)
+
+-- | Returns the line number, column number, and filename associated with an
+-- Info.
+getInfo :: Info -> (Int, Int, String)
+getInfo i = (infoLine i, infoColumn i, infoFile i)
+
+-- | Pretty print Info. Used for REPL output
+prettyInfo :: Info -> String
+prettyInfo i =
+  let (line, column, file) = getInfo i
+  in  (if line > -1 then "line " ++ show line else "unknown line") ++ ", " ++
+      (if column > -1 then "column " ++ show column else "unknown column") ++
+      " in '" ++ file ++ "'"
+
+-- TODO: change name of this function
+freshVar :: Info -> String
+freshVar i = "_" ++ show (infoIdentifier i)
+
+-- | Print Info in a machine readable format.
+machineReadableInfo :: FilePathPrintLength -> Info -> String
+machineReadableInfo filePathPrintLength i =
+  let (line, column, file) = getInfo i
+      file' = case filePathPrintLength of
+                FullPath -> file
+                ShortPath -> takeFileName file
+  in  file' ++ ":" ++ show line ++ ":" ++ show column
+
+-- | Use an Info to generate a type variable name.
+makeTypeVariableNameFromInfo :: Maybe Info -> String
+makeTypeVariableNameFromInfo (Just i) =
+  "tyvar-from-info-" ++ show (infoIdentifier i) ++ "_" ++ show (infoLine i) ++ "_" ++ show (infoColumn i)
+makeTypeVariableNameFromInfo Nothing = error "unnamed-typevariable"

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -10,6 +10,7 @@ import Obj
 import Util
 import TypeError
 import Lookup
+import Info
 
 -- | Create a fresh type variable (eg. 'VarTy t0', 'VarTy t1', etc...)
 genVarTyWithPrefix :: String -> State Integer Ty

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -13,6 +13,7 @@ import Data.Char (ord)
 import Obj
 import Types
 import Util
+import Info
 import Control.Monad.Error.Class (throwError)
 
 import Debug.Trace

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -18,6 +18,7 @@ import Types
 import Util
 import Template
 import ToTemplate
+import Info
 
 import Debug.Trace
 

--- a/src/Qualify.hs
+++ b/src/Qualify.hs
@@ -9,6 +9,7 @@ import Types
 import Obj
 import Lookup
 import Util
+import Info
 
 -- | Changes the symbol part of a defn (the name) to a new symbol path
 -- | Example: (defn foo () 123) => (defn GreatModule.foo () 123)

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -15,6 +15,7 @@ import Parsing
 import Eval
 import Concretize
 import Primitives
+import Info
 import Debug.Trace (trace)
 
 -- | These modules will be loaded in order before any other code is evaluated.

--- a/src/Sumtypes.hs
+++ b/src/Sumtypes.hs
@@ -17,6 +17,7 @@ import StructUtils
 import TypeError
 import Validate
 import SumtypeCase
+import Info
 
 getCase :: [SumtypeCase] -> String -> Maybe SumtypeCase
 getCase cases caseNameToFind =

--- a/src/Template.hs
+++ b/src/Template.hs
@@ -11,6 +11,7 @@ import Parsing
 import Infer
 import Concretize
 import ToTemplate
+import Info
 
 -- | Create a binding pair used for adding a template instantiation to an environment.
 instanceBinder :: SymPath -> Ty -> Template -> String -> (String, Binder)

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -7,6 +7,7 @@ import Obj
 import Constraints
 import Util
 import Lookup
+import Info
 
 data TypeError = SymbolMissingType XObj Env
                | DefnMissingType XObj


### PR DESCRIPTION
This PR moves `Info` and related functions into its own module in `Info.hs`.

`Obj.hs` is quite large at this point and contains functions that have a wide variety of responsibilities. I think it's worthwhile to try and separate concerns a bit more and simplify the `Obj.hs` code. Unfortunately, there are mutually recursive dependencies between most of the key types in `Obj` which makes it difficult to move them into isolated modules. `Info` however is less problematic, and it's straightforward to port it into its own module.