### PR TITLE
Autogenerate Tuple types and document

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -137,40 +137,40 @@
   (doc flip
     "Flips the arguments of a function `f`.
 
-    For example,
+For example,
 
-    ```
-    ((flip Symbol.prefix) 'Bar 'Foo)
-    => ;; (Foo.Bar)
-    ```")
+```
+((flip Symbol.prefix) 'Bar 'Foo)
+=> ;; (Foo.Bar)
+```")
   (defndynamic flip [f]
     (fn [x y]
       (f y x)))
 
   (doc compose
     "Returns the composition of two functions `f` and `g` for functions of any
-     airity; concretely, returns a function accepting the correct number of
-     arguments for `g`, applies `g` to those arguments, then applies `f` to the
-     result.
+arity; concretely, returns a function accepting the correct number of
+arguments for `g`, applies `g` to those arguments, then applies `f` to the
+result.
 
-    If you only need to compose functions that take a single argument (unary arity)
-    see `comp`. Comp also generates the form that corresponds to the composition,
-    compose contrarily evaluates 'eagerly' and returns a computed symbol.
+If you only need to compose functions that take a single argument (unary arity)
+see `comp`. Comp also generates the form that corresponds to the composition,
+compose contrarily evaluates 'eagerly' and returns a computed symbol.
 
-    For exmaple:
+For exmaple:
 
-    ```
-    ;; a silly composition
-    ((compose empty take) 3 [1 2 3 4 5])
-    ;; => []
+```
+;; a silly composition
+((compose empty take) 3 [1 2 3 4 5])
+;; => []
 
-    (String.join (collect-into ((compose reverse map) Symbol.str '(p r a c)) array))
-    ;; => 'carp'
+(String.join (collect-into ((compose reverse map) Symbol.str '(p r a c)) array))
+;; => 'carp'
 
-    ;; comp for comparison
-    ((comp (curry + 1) (curry + 2)) 4)
-    ;; => (+ 1 (+ 2 4))
-    ```")
+;; comp for comparison
+((comp (curry + 1) (curry + 2)) 4)
+;; => (+ 1 (+ 2 4))
+```")
   (defndynamic compose [f g]
     ;; Recall that **unquoted** function names evaluate to their definitions in
     ;; dynamic contexts, e.g. f = (dyanmic f [arg] body)
@@ -195,14 +195,14 @@
 
   (doc curry
     "Returns a curried function accepting a single argument, that applies f to x
-    and then to the following argument.
+and then to the following argument.
 
-    For example,
+For example,
 
-    ```
-    (map (curry Symbol.prefix 'Foo) '(bar baz))
-    ;; => (Foo.bar Foo.baz)
-    ```")
+```
+(map (curry Symbol.prefix 'Foo) '(bar baz))
+;; => (Foo.bar Foo.baz)
+```")
   (defndynamic curry [f x]
     (fn [y]
      (f x y)))
@@ -210,19 +210,19 @@
   (doc curry*
     "Curry functions of any airity.
 
-     For example:
+For example:
 
-     ```
-     (map (curry* Dynamic.zip + '(1 2 3)) '((4 5) (6)))
-     ;; => (((+ 1 4) (+ 2 5)) ((+ 1 6)))
+```
+(map (curry* Dynamic.zip + '(1 2 3)) '((4 5) (6)))
+;; => (((+ 1 4) (+ 2 5)) ((+ 1 6)))
 
-     ((curry Dynamic.zip cons '(1 2 3)) '((4 5) (6)))
-     ;; => ((cons 1 (4 5)) (cons (2 (6))))
+((curry Dynamic.zip cons '(1 2 3)) '((4 5) (6)))
+;; => ((cons 1 (4 5)) (cons (2 (6))))
 
-     (defndynamic add-em-up [x y z] (+ (+ x y) z))
-     (map (curry* add-em-up 1 2) '(1 2 3))
-     ;; => (4 5 6)
-     ```")
+(defndynamic add-em-up [x y z] (+ (+ x y) z))
+(map (curry* add-em-up 1 2) '(1 2 3))
+;; => (4 5 6)
+```")
   (defndynamic curry* [f :rest args]
     (let [f-name (cadr f)
           all-args (caddr f)
@@ -245,7 +245,7 @@
 
   (doc reduce
     "Reduces or 'folds' a data literal, such as a list or array, into a single
-    value through successive applications of `f`.")
+value through successive applications of `f`.")
   (defndynamic reduce [f x xs]
     (if (empty? xs)
       x
@@ -265,27 +265,28 @@
 
   (doc unreduce
     "Applies `f` to a starting value `x`, then generates a sequence of values
-     by successively applying `f` to the result `lim-1` times.
-     Collects results in the structure given by `acc`.
+by successively applying `f` to the result `lim-1` times.
+Collects results in the structure given by `acc`.
 
-     For example:
+For example:
 
-     ```
-     (unreduce (curry + 1) 0 10 (list))
-     ;; => (1 2 3 4 5 6 7 8 9 10)
-     ```")
+```
+(unreduce (curry + 1) 0 10 (list))
+;; => (1 2 3 4 5 6 7 8 9 10)
+```")
   (defndynamic unreduce [f x lim acc]
     (unreduce-internal f x lim acc 0))
 
   (doc filter
-    "Returns a list containing only the elements of `xs` that satisify predicate `p`.
+    "Returns a list containing only the elements of `xs` that satisify
+predicate `p`.
 
-     For example:
+For example:
 
-     ```
-     (filter (fn [x] (= 'a x)) '(a b a b a b a b))
-     ;; => (a a a a)
-     ```")
+```
+(filter (fn [x] (= 'a x)) '(a b a b a b a b))
+;; => (a a a a)
+```")
   (defndynamic filter [p xs]
     (let [filter-fn (fn [x y] (if (p y) (append x (list y)) x))]
       (reduce filter-fn (list) xs)))
@@ -293,12 +294,12 @@
   (doc reverse
     "Reverses the order of elements in an array or list.
 
-     For example:
+For example:
 
-     ```
-     (reverse [1 2 3 4])
-     ;; => [4 3 2 1]
-     ```")
+```
+(reverse [1 2 3 4])
+;; => [4 3 2 1]
+```")
   (defndynamic reverse [xs]
     (if (array? xs)
       (reduce (flip append) (array) (map array xs))
@@ -307,14 +308,14 @@
   (doc empty
     "Returns the empty form of `xs`.
 
-     For example:
+For example:
 
-     ```
-     (empty '(1 2 3 4))
-     ;; => ()
-     (empty '[1 2 3 4])
-     ;; => []
-     ```")
+```
+(empty '(1 2 3 4))
+;; => ()
+(empty '[1 2 3 4])
+;; => []
+```")
   (defndynamic empty [xs]
     (if (array? xs)
         (array)
@@ -323,12 +324,12 @@
   (doc take
     "Returns a list containing the first `n` eleements of a list.
 
-     For example:
+For example:
 
-     ```
-     (take 3 '(1 2 3 4 5))
-     ;; => (1 2 3)
-     ```")
+```
+(take 3 '(1 2 3 4 5))
+;; => (1 2 3)
+```")
   (defndynamic take [n xs]
     ;; A more straightforward impl is likely more efficient?
     (let [indicies (unreduce (curry + 1) 0 n (list))
@@ -339,7 +340,7 @@
 
   (doc apply
     "Applies the function `f` to the provided argument list, passing each value
-    in the list as an argument to the function.")
+in the list as an argument to the function.")
   (defndynamic apply [f argument-list]
     ;; The let clause here is a tad mysterious at first glance. When passed a
     ;; standalone function name (i.e. not an application (f x), carp evaluates
@@ -372,27 +373,27 @@
 
   (doc any?
     "checks whether any of the elements in `xs` conforms to the predicate
-    function `f`.
+function `f`.
 
-    Example:
+Example:
 
-    ```
-    (any? (fn [x] (= 'a x)) '(a b c)) ; => true
-    (any? (fn [x] (= 'a x)) '(e f g)) ; => false
-    ```")
+```
+(any? (fn [x] (= 'a x)) '(a b c)) ; => true
+(any? (fn [x] (= 'a x)) '(e f g)) ; => false
+```")
   (defndynamic any? [f xs]
     (reduce (fn [acc x] (or acc (f x))) false xs))
 
   (doc any?
     "checks whether all of the elements in `xs` conform to the predicate
-    function `f`.
+function `f`.
 
-    Example:
+Example:
 
-    ```
-    (all? (fn [x] (< 1 x)) '(2 3 4)) ; => true
-    (all? (fn [x] (< 1 x)) '(-1 0 1)) ; => false
-    ```")
+```
+(all? (fn [x] (< 1 x)) '(2 3 4)) ; => true
+(all? (fn [x] (< 1 x)) '(-1 0 1)) ; => false
+```")
   (defndynamic all? [f xs]
     (reduce (fn [acc x] (and acc (f x))) true xs))
 
@@ -408,47 +409,62 @@
 
   (doc zip
     "Returns the *form* that results from applying  a function `f` to each of
-    the values supplied in `forms`.
+the values supplied in `forms`.
 
-    If the members of a single form are exhuasted, the result of the
-    applications thus far is returned, and any remaining members in the other
-    forms are ignored.
+If the members of a single form are exhuasted, the result of the
+applications thus far is returned, and any remaining members in the other
+forms are ignored.
 
-    For example,
+For example,
 
-    ```
-    (zip + '(1 2 3) '(4 5 6))
-    ;; => ((+ 1 4) (+ 2 5) (+ 3 6))
-    ```
+```
+(zip + '(1 2 3) '(4 5 6))
+;; => ((+ 1 4) (+ 2 5) (+ 3 6))
+```
 
-    It's important to note that zip operates on forms, and that the form
-    returned by zip may not be evaluable by itself. For instance, to actually
-    transform the result in the example above into something Carp can
-    evaluate, we need to wrap each member of the list in a `do`:
+It's important to note that zip operates on forms, and that the form
+returned by zip may not be evaluable by itself. For instance, to actually
+transform the result in the example above into something Carp can
+evaluate, we need to wrap each member of the list in a `do`:
 
-    ```
-    (append (list 'do) (zip + '(1 2 3) '(4 5 6)))
-    ;; => (do (+ 1 4) (+ 2 5) (+ 3 6))
-    (eval (append (list 'do) (zip + '(1 2 3) '(4 5 6))))
-    ;; => 9 ;; do returns the value of the last form in its body
-    ```")
+```
+(append (list 'do) (zip + '(1 2 3) '(4 5 6)))
+;; => (do (+ 1 4) (+ 2 5) (+ 3 6))
+(eval (append (list 'do) (zip + '(1 2 3) '(4 5 6))))
+;; => 9 ;; do returns the value of the last form in its body
+```")
   (defndynamic zip [f :rest forms]
     (zip-internal f forms (list)))
 
   (doc map
     "Applies a function `f` to each element in the list or array `xs` and
-     returns a list dynamic data literal containing the result of the function
-     applications.
+returns a list dynamic data literal containing the result of the function
+applications.
 
-     For example:
-      ```clojure
-      '(map symbol? '(a b c))
-      => (true true true)
-      '(map (curry + 1) '(1 2 3))
-      => (2 3 4)
-      ```")
+For example:
+```clojure
+'(map symbol? '(a b c))
+=> (true true true)
+'(map (curry + 1) '(1 2 3))
+=> (2 3 4)
+```")
   (defndynamic map [f xs]
     (map-internal f xs (list)))
+
+  (doc flatten "flattens a list recursively.
+
+For example:
+```
+(flatten '(1 2 (3 (4))))
+; => '(1 2 3 4)
+```")
+  (defndynamic flatten [l]
+    (reduce (fn [acc x]
+              (if (list? x)
+                (append acc (flatten x))
+                (cons-last x acc)))
+            '()
+            l))
 )
 
 (defndynamic implement-declaration [mod interface]
@@ -456,7 +472,7 @@
 
 (doc implements-all
   "Declares functions in mod with names matching `interfaces` as implementations
-  of those interfaces.")
+of those interfaces.")
 (defmacro implements-all [mod :rest interfaces]
   (cons 'do (map (curry implement-declaration mod) interfaces)))
 

--- a/core/Tuples.carp
+++ b/core/Tuples.carp
@@ -1,43 +1,95 @@
-(deftype (Pair a b) [a a b b])
+(defmodule Dynamic
+  (private deftuple-type-)
+  (hidden deftuple-type-)
+  (defndynamic deftuple-type- [name props]
+    (list 'deftype (cons name props)
+      (collect-into (flatten (map (fn [x] (list x x)) props)) array)))
 
-(defmodule PairRef
-  (defn = [p1 p2]
-    (and (= (Pair.a p1) (Pair.a p2))
-         (= (Pair.b p1) (Pair.b p2))))
-  (implements = PairRef.=)
+  (private deftuple-lt-)
+  (hidden deftuple-lt-)
+  (defndynamic deftuple-lt- [name props]
+    (if (empty? props)
+      'false
+      (let [fst (Symbol.prefix name (car props))]
+        (if (= (length props) 1)
+          (list '< (list fst 't1) (list fst 't2))
+          (list 'if (list '= (list fst 't1) (list fst 't2))
+            (deftuple-lt- name (cdr props))
+            (list '< (list fst 't1) (list fst 't2)))))))
 
-  (defn < [p1 p2]
-    (if (= (Pair.a p1) (Pair.a p2))
-      (< (Pair.b p1) (Pair.b p2))
-      (< (Pair.a p1) (Pair.a p2))))
-  (implements < PairRef.<)
+  ; this is basically just a giant template
+  (private deftuple-module-)
+  (hidden deftuple-module-)
+  (defndynamic deftuple-module- [name props]
+    (let [sname (Symbol.str name)
+          module-name (Symbol.concat [name 'Ref])]
+      (list 'do
+        (list 'defmodule module-name
+          (list 'defn '= ['t1 't2]
+            (cons 'and*
+              (map (fn [p]
+                    (list '=
+                      (list (Symbol.prefix name p) 't1)
+                      (list (Symbol.prefix name p) 't2)))
+                   props)))
+          (list 'implements '= (Symbol.prefix module-name '=))
 
-  (defn > [p1 p2]
-    (PairRef.< p2 p1)))
-  (implements > PairRef.>)
+          (list 'defn '< ['t1 't2] (deftuple-lt- name props))
+          (list 'implements '< (Symbol.prefix module-name '<))
 
-(defmodule Pair
-  (defn init-from-refs [r1 r2]
-    (Pair.init @r1 @r2))
+          (list 'defn '> ['t1 't2] (list (Symbol.prefix module-name '<) 't2 't1))
+          (list 'implements '> (Symbol.prefix module-name '>)))
 
-  (defn = [p1 p2]
-    (and (= (Pair.a &p1) (Pair.a &p2))
-         (= (Pair.b &p1) (Pair.b &p2))))
-  (implements = Pair.=)
+        (list 'defmodule name
+          (list 'doc 'init-from-refs
+            (String.concat ["initializes a `" sname "` from member references."]))
+          (let [prop-vars (map (fn [x] (Symbol.concat [x '-val])) props)]
+            (list 'defn 'init-from-refs (collect-into prop-vars array)
+              (cons 'init (map (fn [x] (list 'copy x)) prop-vars))))
 
-  (defn < [p1 p2]
-    (PairRef.< &p1 &p2))
-  (implements < Pair.<)
+          (list 'defn '= ['t1 't2]
+            (cons 'and*
+              (map (fn [p] (list '= (list p '(ref t1)) (list p '(ref t2)))) props)))
+          (list 'implements '= (Symbol.prefix name '=))
 
-  (defn > [p1 p2]
-    (PairRef.> &p1 &p2))
-  (implements > Pair.>)
+          (list 'defn '< ['t1 't2]
+            (list (Symbol.prefix module-name '<) '(ref t1) '(ref t2)))
+          (list 'implements '< (Symbol.prefix name '<))
 
-  (doc reverse "reverses a `Pair` `p` such that its first member is its second member and vice versa.")
-  (defn reverse [p]
-    (Pair.init @(Pair.b p) @(Pair.a p)))
+          (list 'defn '> ['t1 't2]
+            (list (Symbol.prefix module-name '>) '(ref t1) '(ref t2)))
+          (list 'implements '> (Symbol.prefix name '>))
 
-  (doc zero "return default values of the type inside `Pair`")
-  (defn zero []
-      (Pair.init (zero) (zero)))
+          (list 'doc 'reverse
+            (String.concat ["reverses a `" sname "` by reversing its member positions."]))
+          (list 'defn 'reverse ['t]
+            (cons 'init (map (fn [x] (list 'copy (list x 't))) (reverse props))))
+
+          (list 'defn 'zero [] (cons 'init (map (fn [_] '(zero)) props))))
+          (list 'implements 'zero (Symbol.prefix name 'zero))
+          ;(list 'doc 'zero
+          ;  (String.concat [
+          ;    "initializes a `" sname
+          ;    "` by calling `zero` for all its members. `zero` must be defined for all member types."]))
+    )))
+
+  (doc deftuple "defines a tuple type.
+
+For example:
+```
+; is the definition of Pair in the stdlib
+(deftuple Pair a b)
+```")
+  (defmacro deftuple [name :rest props]
+    (do
+      (eval (deftuple-type- name props))
+      (eval (deftuple-module- name props))
+    ))
 )
+
+(doc Pair "is a 2-tuple, i.e. a datatype with two members.")
+(deftuple Pair a b)
+(doc Triple "is a 3-tuple, i.e. a datatype with three members.")
+(deftuple Triple a b c)
+(doc Quadruple "is a 4-tuple, i.e. a datatype with three members.")
+(deftuple Quadruple a b c d)

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -435,12 +450,9 @@
                 <p class="doc">
                     <p>checks whether all of the elements in <code>xs</code> conform to the predicate
 function <code>f</code>.</p>
-<pre><code>Example:
-
-```
-(all? (fn [x] (&lt; 1 x)) '(2 3 4)) ; =&gt; true
+<p>Example:</p>
+<pre><code>(all? (fn [x] (&lt; 1 x)) '(2 3 4)) ; =&gt; true
 (all? (fn [x] (&lt; 1 x)) '(-1 0 1)) ; =&gt; false
-```
 </code></pre>
 
                 </p>
@@ -1284,17 +1296,14 @@ in the list as an argument to the function.</p>
                 </pre>
                 <p class="doc">
                     <p>Returns the composition of two functions <code>f</code> and <code>g</code> for functions of any
-airity; concretely, returns a function accepting the correct number of
+arity; concretely, returns a function accepting the correct number of
 arguments for <code>g</code>, applies <code>g</code> to those arguments, then applies <code>f</code> to the
 result.</p>
-<pre><code>If you only need to compose functions that take a single argument (unary arity)
-see `comp`. Comp also generates the form that corresponds to the composition,
-compose contrarily evaluates 'eagerly' and returns a computed symbol.
-
-For exmaple:
-
-```
-;; a silly composition
+<p>If you only need to compose functions that take a single argument (unary arity)
+see <code>comp</code>. Comp also generates the form that corresponds to the composition,
+compose contrarily evaluates 'eagerly' and returns a computed symbol.</p>
+<p>For exmaple:</p>
+<pre><code>;; a silly composition
 ((compose empty take) 3 [1 2 3 4 5])
 ;; =&gt; []
 
@@ -1304,7 +1313,6 @@ For exmaple:
 ;; comp for comparison
 ((comp (curry + 1) (curry + 2)) 4)
 ;; =&gt; (+ 1 (+ 2 4))
-```
 </code></pre>
 
                 </p>
@@ -1373,12 +1381,9 @@ For exmaple:
                 <p class="doc">
                     <p>Returns a curried function accepting a single argument, that applies f to x
 and then to the following argument.</p>
-<pre><code>For example,
-
-```
-(map (curry Symbol.prefix 'Foo) '(bar baz))
+<p>For example,</p>
+<pre><code>(map (curry Symbol.prefix 'Foo) '(bar baz))
 ;; =&gt; (Foo.bar Foo.baz)
-```
 </code></pre>
 
                 </p>
@@ -1400,19 +1405,16 @@ and then to the following argument.</p>
                 </pre>
                 <p class="doc">
                     <p>Curry functions of any airity.</p>
-<pre><code> For example:
+<p>For example:</p>
+<pre><code>(map (curry* Dynamic.zip + '(1 2 3)) '((4 5) (6)))
+;; =&gt; (((+ 1 4) (+ 2 5)) ((+ 1 6)))
 
- ```
- (map (curry* Dynamic.zip + '(1 2 3)) '((4 5) (6)))
- ;; =&gt; (((+ 1 4) (+ 2 5)) ((+ 1 6)))
+((curry Dynamic.zip cons '(1 2 3)) '((4 5) (6)))
+;; =&gt; ((cons 1 (4 5)) (cons (2 (6))))
 
- ((curry Dynamic.zip cons '(1 2 3)) '((4 5) (6)))
- ;; =&gt; ((cons 1 (4 5)) (cons (2 (6))))
-
- (defndynamic add-em-up [x y z] (+ (+ x y) z))
- (map (curry* add-em-up 1 2) '(1 2 3))
- ;; =&gt; (4 5 6)
- ```
+(defndynamic add-em-up [x y z] (+ (+ x y) z))
+(map (curry* add-em-up 1 2) '(1 2 3))
+;; =&gt; (4 5 6)
 </code></pre>
 
                 </p>
@@ -1617,6 +1619,30 @@ and then to the following argument.</p>
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#deftuple">
+                    <h3 id="deftuple">
+                        deftuple
+                    </h3>
+                </a>
+                <div class="description">
+                    macro
+                </div>
+                <p class="sig">
+                    Macro
+                </p>
+                <pre class="args">
+                    (deftuple name :rest props)
+                </pre>
+                <p class="doc">
+                    <p>defines a tuple type.</p>
+<p>For example:</p>
+<pre><code>; is the definition of Pair in the stdlib
+(deftuple Pair a b)
+</code></pre>
+
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#deftype">
                     <h3 id="deftype">
                         deftype
@@ -1675,14 +1701,11 @@ and then to the following argument.</p>
                 </pre>
                 <p class="doc">
                     <p>Returns the empty form of <code>xs</code>.</p>
-<pre><code> For example:
-
- ```
- (empty '(1 2 3 4))
- ;; =&gt; ()
- (empty '[1 2 3 4])
- ;; =&gt; []
- ```
+<p>For example:</p>
+<pre><code>(empty '(1 2 3 4))
+;; =&gt; ()
+(empty '[1 2 3 4])
+;; =&gt; []
 </code></pre>
 
                 </p>
@@ -1853,13 +1876,35 @@ and then to the following argument.</p>
                     (filter p xs)
                 </pre>
                 <p class="doc">
-                    <p>Returns a list containing only the elements of <code>xs</code> that satisify predicate <code>p</code>.</p>
-<pre><code> For example:
+                    <p>Returns a list containing only the elements of <code>xs</code> that satisify
+predicate <code>p</code>.</p>
+<p>For example:</p>
+<pre><code>(filter (fn [x] (= 'a x)) '(a b a b a b a b))
+;; =&gt; (a a a a)
+</code></pre>
 
- ```
- (filter (fn [x] (= 'a x)) '(a b a b a b a b))
- ;; =&gt; (a a a a)
- ```
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#flatten">
+                    <h3 id="flatten">
+                        flatten
+                    </h3>
+                </a>
+                <div class="description">
+                    dynamic
+                </div>
+                <p class="sig">
+                    Dynamic
+                </p>
+                <pre class="args">
+                    (flatten l)
+                </pre>
+                <p class="doc">
+                    <p>flattens a list recursively.</p>
+<p>For example:</p>
+<pre><code>(flatten '(1 2 (3 (4))))
+; =&gt; '(1 2 3 4)
 </code></pre>
 
                 </p>
@@ -1881,12 +1926,9 @@ and then to the following argument.</p>
                 </pre>
                 <p class="doc">
                     <p>Flips the arguments of a function <code>f</code>.</p>
-<pre><code>For example,
-
-```
-((flip Symbol.prefix) 'Bar 'Foo)
+<p>For example,</p>
+<pre><code>((flip Symbol.prefix) 'Bar 'Foo)
 =&gt; ;; (Foo.Bar)
-```
 </code></pre>
 
                 </p>
@@ -2224,13 +2266,11 @@ and then to the following argument.</p>
                     <p>Applies a function <code>f</code> to each element in the list or array <code>xs</code> and
 returns a list dynamic data literal containing the result of the function
 applications.</p>
-<pre><code> For example:
-  ```clojure
-  '(map symbol? '(a b c))
-  =&gt; (true true true)
-  '(map (curry + 1) '(1 2 3))
-  =&gt; (2 3 4)
-  ```
+<p>For example:</p>
+<pre><code class="language-clojure">'(map symbol? '(a b c))
+=&gt; (true true true)
+'(map (curry + 1) '(1 2 3))
+=&gt; (2 3 4)
 </code></pre>
 
                 </p>
@@ -2648,14 +2688,7 @@ value through successive applications of <code>f</code>.</p>
                     (reverse xs)
                 </pre>
                 <p class="doc">
-                    <p>Reverses the order of elements in an array or list.</p>
-<pre><code> For example:
-
- ```
- (reverse [1 2 3 4])
- ;; =&gt; [4 3 2 1]
- ```
-</code></pre>
+                    <p>reverses a <code>Quadruple</code> by reversing its member positions.</p>
 
                 </p>
             </div>
@@ -2791,12 +2824,9 @@ value through successive applications of <code>f</code>.</p>
                 </pre>
                 <p class="doc">
                     <p>Returns a list containing the first <code>n</code> eleements of a list.</p>
-<pre><code> For example:
-
- ```
- (take 3 '(1 2 3 4 5))
- ;; =&gt; (1 2 3)
- ```
+<p>For example:</p>
+<pre><code>(take 3 '(1 2 3 4 5))
+;; =&gt; (1 2 3)
 </code></pre>
 
                 </p>
@@ -2843,12 +2873,9 @@ value through successive applications of <code>f</code>.</p>
                     <p>Applies <code>f</code> to a starting value <code>x</code>, then generates a sequence of values
 by successively applying <code>f</code> to the result <code>lim-1</code> times.
 Collects results in the structure given by <code>acc</code>.</p>
-<pre><code> For example:
-
- ```
- (unreduce (curry + 1) 0 10 (list))
- ;; =&gt; (1 2 3 4 5 6 7 8 9 10)
- ```
+<p>For example:</p>
+<pre><code>(unreduce (curry + 1) 0 10 (list))
+;; =&gt; (1 2 3 4 5 6 7 8 9 10)
 </code></pre>
 
                 </p>
@@ -2917,28 +2944,21 @@ Collects results in the structure given by <code>acc</code>.</p>
                 <p class="doc">
                     <p>Returns the <em>form</em> that results from applying  a function <code>f</code> to each of
 the values supplied in <code>forms</code>.</p>
-<pre><code>If the members of a single form are exhuasted, the result of the
+<p>If the members of a single form are exhuasted, the result of the
 applications thus far is returned, and any remaining members in the other
-forms are ignored.
-
-For example,
-
-```
-(zip + '(1 2 3) '(4 5 6))
+forms are ignored.</p>
+<p>For example,</p>
+<pre><code>(zip + '(1 2 3) '(4 5 6))
 ;; =&gt; ((+ 1 4) (+ 2 5) (+ 3 6))
-```
-
-It's important to note that zip operates on forms, and that the form
+</code></pre>
+<p>It's important to note that zip operates on forms, and that the form
 returned by zip may not be evaluable by itself. For instance, to actually
 transform the result in the example above into something Carp can
-evaluate, we need to wrap each member of the list in a `do`:
-
-```
-(append (list 'do) (zip + '(1 2 3) '(4 5 6)))
+evaluate, we need to wrap each member of the list in a <code>do</code>:</p>
+<pre><code>(append (list 'do) (zip + '(1 2 3) '(4 5 6)))
 ;; =&gt; (do (+ 1 4) (+ 2 5) (+ 3 6))
 (eval (append (list 'do) (zip + '(1 2 3) '(4 5 6))))
 ;; =&gt; 9 ;; do returns the value of the last form in its body
-```
 </code></pre>
 
                 </p>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pair.html
+++ b/docs/core/Pair.html
@@ -166,86 +166,11 @@
                 </div>
             </div>
             <h1>
-                Long
+                Pair
             </h1>
             <div class="module-description">
-                
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#*">
-                    <h3 id="*">
-                        *
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#+">
-                    <h3 id="+">
-                        +
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#-">
-                    <h3 id="-">
-                        -
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#/">
-                    <h3 id="/">
-                        /
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
+                <p>is a 2-tuple, i.e. a datatype with two members.</p>
+
             </div>
             <div class="binder">
                 <a class="anchor" href="#&lt;">
@@ -254,14 +179,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Pair a b), (Pair a b)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (&lt; t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
@@ -273,14 +198,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Pair a b), (Pair a b)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (= t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
@@ -292,187 +217,56 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Pair a b), (Pair a b)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (&gt; t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#MAX">
-                    <h3 id="MAX">
-                        MAX
+                <a class="anchor" href="#a">
+                    <h3 id="a">
+                        a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    Long
+                    (Fn [(Ref (Pair a b) c)] (Ref a c))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the <code>a</code> property of a <code>Pair</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#MIN">
-                    <h3 id="MIN">
-                        MIN
+                <a class="anchor" href="#b">
+                    <h3 id="b">
+                        b
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    Long
+                    (Fn [(Ref (Pair a b) c)] (Ref b c))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#abs">
-                    <h3 id="abs">
-                        abs
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-and">
-                    <h3 id="bit-and">
-                        bit-and
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-not">
-                    <h3 id="bit-not">
-                        bit-not
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-or">
-                    <h3 id="bit-or">
-                        bit-or
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-shift-left">
-                    <h3 id="bit-shift-left">
-                        bit-shift-left
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-shift-right">
-                    <h3 id="bit-shift-right">
-                        bit-shift-right
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-xor">
-                    <h3 id="bit-xor">
-                        bit-xor
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
+                    <p>gets the <code>b</code> property of a <code>Pair</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -482,111 +276,37 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [(Ref Long a)] Long)
+                    (Fn [(Ref (Pair a b) c)] (Pair a b))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>copies the <code>Pair</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dec">
-                    <h3 id="dec">
-                        dec
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] Long)
+                    (Fn [(Pair a b)] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#even?">
-                    <h3 id="even?">
-                        even?
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [Long] Bool)
-                </p>
-                <pre class="args">
-                    (even? a)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#format">
-                    <h3 id="format">
-                        format
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [(Ref String a), Long] String)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#from-int">
-                    <h3 id="from-int">
-                        from-int
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Int] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#from-string">
-                    <h3 id="from-string">
-                        from-string
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [(Ref String a)] (Maybe Long))
-                </p>
-                <pre class="args">
-                    (from-string s)
-                </pre>
-                <p class="doc">
-                    
+                    <p>deletes a <code>Pair</code>. Should usually not be called manually.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -599,86 +319,49 @@
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [(Ref Long a)] Int)
+                    (Fn [(Ref (Pair a b) c)] Int)
                 </p>
                 <pre class="args">
-                    (hash k)
+                    (hash pair)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#inc">
-                    <h3 id="inc">
-                        inc
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] Long)
+                    (Fn [a, b] (Pair a b))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>creates a <code>Pair</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#mod">
-                    <h3 id="mod">
-                        mod
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#neg">
-                    <h3 id="neg">
-                        neg
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#odd?">
-                    <h3 id="odd?">
-                        odd?
+                <a class="anchor" href="#init-from-refs">
+                    <h3 id="init-from-refs">
+                        init-from-refs
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [Long] Bool)
+                    (Fn [(Ref a b), (Ref c d)] (Pair a c))
                 </p>
                 <pre class="args">
-                    (odd? a)
+                    (init-from-refs a-val b-val)
                 </pre>
                 <p class="doc">
                     
@@ -691,130 +374,116 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] String)
+                    (Fn [(Ref (Pair a b) c)] String)
                 </p>
-                <pre class="args">
-                    (prn x)
-                </pre>
-                <p class="doc">
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>converts a <code>Pair</code> to a string.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#random">
-                    <h3 id="random">
-                        random
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [] Long)
-                </p>
-                <pre class="args">
-                    (random)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#random-between">
-                    <h3 id="random-between">
-                        random-between
+                <a class="anchor" href="#reverse">
+                    <h3 id="reverse">
+                        reverse
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Long)
+                    (Fn [(Ref (Pair a b) c)] (Pair b a))
                 </p>
                 <pre class="args">
-                    (random-between lower upper)
+                    (reverse t)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-add">
-                    <h3 id="safe-add">
-                        safe-add
+                <a class="anchor" href="#set-a">
+                    <h3 id="set-a">
+                        set-a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Pair a b), a] (Pair a b))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>a</code> property of a <code>Pair</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-mul">
-                    <h3 id="safe-mul">
-                        safe-mul
+                <a class="anchor" href="#set-a!">
+                    <h3 id="set-a!">
+                        set-a!
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Ref (Pair a b) c), a] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>a</code> property of a <code>Pair</code> in place.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-sub">
-                    <h3 id="safe-sub">
-                        safe-sub
+                <a class="anchor" href="#set-b">
+                    <h3 id="set-b">
+                        set-b
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Pair a b), b] (Pair a b))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>b</code> property of a <code>Pair</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#seed">
-                    <h3 id="seed">
-                        seed
+                <a class="anchor" href="#set-b!">
+                    <h3 id="set-b!">
+                        set-b!
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] ())
+                    (Fn [(Ref (Pair a b) c), b] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>b</code> property of a <code>Pair</code> in place.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -824,35 +493,57 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] String)
+                    (Fn [(Ref (Pair a b) c)] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>converts a <code>Pair</code> to a string.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#to-int">
-                    <h3 id="to-int">
-                        to-int
+                <a class="anchor" href="#update-a">
+                    <h3 id="update-a">
+                        update-a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [Long] Int)
+                    (Fn [(Pair a b), (Ref (Fn [a] a c) d)] (Pair a b))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
+                    <p>updates the <code>a</code> property of a <code>Pair</code> using a function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-b">
+                    <h3 id="update-b">
+                        update-b
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (Fn [(Pair a b), (Ref (Fn [b] b c) d)] (Pair a b))
+                </p>
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>updates the <code>b</code> property of a <code>Pair</code> using a function <code>f</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -865,7 +556,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [] Long)
+                    (Fn [] (Pair a b))
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pointer.html
+++ b/docs/core/Pointer.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Quadruple.html
+++ b/docs/core/Quadruple.html
@@ -166,86 +166,11 @@
                 </div>
             </div>
             <h1>
-                Long
+                Quadruple
             </h1>
             <div class="module-description">
-                
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#*">
-                    <h3 id="*">
-                        *
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#+">
-                    <h3 id="+">
-                        +
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#-">
-                    <h3 id="-">
-                        -
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#/">
-                    <h3 id="/">
-                        /
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
+                <p>is a 4-tuple, i.e. a datatype with three members.</p>
+
             </div>
             <div class="binder">
                 <a class="anchor" href="#&lt;">
@@ -254,14 +179,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Quadruple a b c d), (Quadruple a b c d)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (&lt; t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
@@ -273,14 +198,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Quadruple a b c d), (Quadruple a b c d)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (= t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
@@ -292,187 +217,76 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Quadruple a b c d), (Quadruple a b c d)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (&gt; t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#MAX">
-                    <h3 id="MAX">
-                        MAX
+                <a class="anchor" href="#a">
+                    <h3 id="a">
+                        a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    Long
+                    (Fn [(Ref (Quadruple a b c d) e)] (Ref a e))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the <code>a</code> property of a <code>Quadruple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#MIN">
-                    <h3 id="MIN">
-                        MIN
+                <a class="anchor" href="#b">
+                    <h3 id="b">
+                        b
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    Long
+                    (Fn [(Ref (Quadruple a b c d) e)] (Ref b e))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the <code>b</code> property of a <code>Quadruple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#abs">
-                    <h3 id="abs">
-                        abs
+                <a class="anchor" href="#c">
+                    <h3 id="c">
+                        c
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [Long] Long)
+                    (Fn [(Ref (Quadruple a b c d) e)] (Ref c e))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-and">
-                    <h3 id="bit-and">
-                        bit-and
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-not">
-                    <h3 id="bit-not">
-                        bit-not
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-or">
-                    <h3 id="bit-or">
-                        bit-or
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-shift-left">
-                    <h3 id="bit-shift-left">
-                        bit-shift-left
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-shift-right">
-                    <h3 id="bit-shift-right">
-                        bit-shift-right
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-xor">
-                    <h3 id="bit-xor">
-                        bit-xor
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
+                    <p>gets the <code>c</code> property of a <code>Quadruple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -482,206 +296,97 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [(Ref Long a)] Long)
+                    (Fn [(Ref (Quadruple a b c d) e)] (Quadruple a b c d))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>copies the <code>Quadruple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dec">
-                    <h3 id="dec">
-                        dec
+                <a class="anchor" href="#d">
+                    <h3 id="d">
+                        d
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [Long] Long)
+                    (Fn [(Ref (Quadruple a b c d) e)] (Ref d e))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the <code>d</code> property of a <code>Quadruple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#even?">
-                    <h3 id="even?">
-                        even?
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Quadruple a b c d)] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>deletes a <code>Quadruple</code>. Should usually not be called manually.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [a, b, c, d] (Quadruple a b c d))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>creates a <code>Quadruple</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init-from-refs">
+                    <h3 id="init-from-refs">
+                        init-from-refs
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [Long] Bool)
+                    (Fn [(Ref a b), (Ref c d), (Ref e f), (Ref g h)] (Quadruple a c e g))
                 </p>
                 <pre class="args">
-                    (even? a)
+                    (init-from-refs a-val b-val c-val d-val)
                 </pre>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#format">
-                    <h3 id="format">
-                        format
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [(Ref String a), Long] String)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#from-int">
-                    <h3 id="from-int">
-                        from-int
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Int] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#from-string">
-                    <h3 id="from-string">
-                        from-string
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [(Ref String a)] (Maybe Long))
-                </p>
-                <pre class="args">
-                    (from-string s)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#hash">
-                    <h3 id="hash">
-                        hash
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [(Ref Long a)] Int)
-                </p>
-                <pre class="args">
-                    (hash k)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#inc">
-                    <h3 id="inc">
-                        inc
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#mod">
-                    <h3 id="mod">
-                        mod
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#neg">
-                    <h3 id="neg">
-                        neg
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#odd?">
-                    <h3 id="odd?">
-                        odd?
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [Long] Bool)
-                </p>
-                <pre class="args">
-                    (odd? a)
-                </pre>
-                <p class="doc">
-                    
+                    <p>initializes a <code>Triple</code> from member references.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -691,130 +396,196 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] String)
+                    (Fn [(Ref (Quadruple a b c d) e)] String)
                 </p>
-                <pre class="args">
-                    (prn x)
-                </pre>
-                <p class="doc">
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>converts a <code>Quadruple</code> to a string.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#random">
-                    <h3 id="random">
-                        random
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [] Long)
-                </p>
-                <pre class="args">
-                    (random)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#random-between">
-                    <h3 id="random-between">
-                        random-between
+                <a class="anchor" href="#reverse">
+                    <h3 id="reverse">
+                        reverse
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Long)
+                    (Fn [(Ref (Quadruple a b c d) e)] (Quadruple d c b a))
                 </p>
                 <pre class="args">
-                    (random-between lower upper)
+                    (reverse t)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-add">
-                    <h3 id="safe-add">
-                        safe-add
+                <a class="anchor" href="#set-a">
+                    <h3 id="set-a">
+                        set-a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Quadruple a b c d), a] (Quadruple a b c d))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>a</code> property of a <code>Quadruple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-mul">
-                    <h3 id="safe-mul">
-                        safe-mul
+                <a class="anchor" href="#set-a!">
+                    <h3 id="set-a!">
+                        set-a!
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Ref (Quadruple a b c d) e), a] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>a</code> property of a <code>Quadruple</code> in place.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-sub">
-                    <h3 id="safe-sub">
-                        safe-sub
+                <a class="anchor" href="#set-b">
+                    <h3 id="set-b">
+                        set-b
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Quadruple a b c d), b] (Quadruple a b c d))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>b</code> property of a <code>Quadruple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#seed">
-                    <h3 id="seed">
-                        seed
+                <a class="anchor" href="#set-b!">
+                    <h3 id="set-b!">
+                        set-b!
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] ())
+                    (Fn [(Ref (Quadruple a b c d) e), b] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
+                    <p>sets the <code>b</code> property of a <code>Quadruple</code> in place.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-c">
+                    <h3 id="set-c">
+                        set-c
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Quadruple a b c d), c] (Quadruple a b c d))
+                </p>
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>sets the <code>c</code> property of a <code>Quadruple</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-c!">
+                    <h3 id="set-c!">
+                        set-c!
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Ref (Quadruple a b c d) e), c] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>sets the <code>c</code> property of a <code>Quadruple</code> in place.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-d">
+                    <h3 id="set-d">
+                        set-d
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Quadruple a b c d), d] (Quadruple a b c d))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>sets the <code>d</code> property of a <code>Quadruple</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-d!">
+                    <h3 id="set-d!">
+                        set-d!
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Ref (Quadruple a b c d) e), d] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>sets the <code>d</code> property of a <code>Quadruple</code> in place.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -824,35 +595,97 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] String)
+                    (Fn [(Ref (Quadruple a b c d) e)] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>converts a <code>Quadruple</code> to a string.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#to-int">
-                    <h3 id="to-int">
-                        to-int
+                <a class="anchor" href="#update-a">
+                    <h3 id="update-a">
+                        update-a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [Long] Int)
+                    (Fn [(Quadruple a b c d), (Ref (Fn [a] a e) f)] (Quadruple a b c d))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
+                    <p>updates the <code>a</code> property of a <code>Quadruple</code> using a function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-b">
+                    <h3 id="update-b">
+                        update-b
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (Fn [(Quadruple a b c d), (Ref (Fn [b] b e) f)] (Quadruple a b c d))
+                </p>
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>updates the <code>b</code> property of a <code>Quadruple</code> using a function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-c">
+                    <h3 id="update-c">
+                        update-c
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (Fn [(Quadruple a b c d), (Ref (Fn [c] c e) f)] (Quadruple a b c d))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>updates the <code>c</code> property of a <code>Quadruple</code> using a function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-d">
+                    <h3 id="update-d">
+                        update-d
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (Fn [(Quadruple a b c d), (Ref (Fn [d] d e) f)] (Quadruple a b c d))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>updates the <code>d</code> property of a <code>Quadruple</code> using a function <code>f</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -865,7 +698,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [] Long)
+                    (Fn [] (Quadruple a b c d))
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Triple.html
+++ b/docs/core/Triple.html
@@ -166,86 +166,11 @@
                 </div>
             </div>
             <h1>
-                Long
+                Triple
             </h1>
             <div class="module-description">
-                
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#*">
-                    <h3 id="*">
-                        *
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#+">
-                    <h3 id="+">
-                        +
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#-">
-                    <h3 id="-">
-                        -
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#/">
-                    <h3 id="/">
-                        /
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
+                <p>is a 3-tuple, i.e. a datatype with three members.</p>
+
             </div>
             <div class="binder">
                 <a class="anchor" href="#&lt;">
@@ -254,14 +179,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Triple a b c), (Triple a b c)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (&lt; t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
@@ -273,14 +198,14 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Triple a b c), (Triple a b c)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (= t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
@@ -292,187 +217,76 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Bool)
+                    (Fn [(Triple a b c), (Triple a b c)] Bool)
                 </p>
-                <span>
-                    
-                </span>
+                <pre class="args">
+                    (&gt; t1 t2)
+                </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#MAX">
-                    <h3 id="MAX">
-                        MAX
+                <a class="anchor" href="#a">
+                    <h3 id="a">
+                        a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    Long
+                    (Fn [(Ref (Triple a b c) d)] (Ref a d))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the <code>a</code> property of a <code>Triple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#MIN">
-                    <h3 id="MIN">
-                        MIN
+                <a class="anchor" href="#b">
+                    <h3 id="b">
+                        b
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    Long
+                    (Fn [(Ref (Triple a b c) d)] (Ref b d))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>gets the <code>b</code> property of a <code>Triple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#abs">
-                    <h3 id="abs">
-                        abs
+                <a class="anchor" href="#c">
+                    <h3 id="c">
+                        c
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [Long] Long)
+                    (Fn [(Ref (Triple a b c) d)] (Ref c d))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-and">
-                    <h3 id="bit-and">
-                        bit-and
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-not">
-                    <h3 id="bit-not">
-                        bit-not
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-or">
-                    <h3 id="bit-or">
-                        bit-or
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-shift-left">
-                    <h3 id="bit-shift-left">
-                        bit-shift-left
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-shift-right">
-                    <h3 id="bit-shift-right">
-                        bit-shift-right
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#bit-xor">
-                    <h3 id="bit-xor">
-                        bit-xor
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
+                    <p>gets the <code>c</code> property of a <code>Triple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -482,206 +296,77 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [(Ref Long a)] Long)
+                    (Fn [(Ref (Triple a b c) d)] (Triple a b c))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>copies the <code>Triple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dec">
-                    <h3 id="dec">
-                        dec
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] Long)
+                    (Fn [(Triple a b c)] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>deletes a <code>Triple</code>. Should usually not be called manually.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#even?">
-                    <h3 id="even?">
-                        even?
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [a, b, c] (Triple a b c))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>creates a <code>Triple</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init-from-refs">
+                    <h3 id="init-from-refs">
+                        init-from-refs
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [Long] Bool)
+                    (Fn [(Ref a b), (Ref c d), (Ref e f)] (Triple a c e))
                 </p>
                 <pre class="args">
-                    (even? a)
+                    (init-from-refs a-val b-val c-val)
                 </pre>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#format">
-                    <h3 id="format">
-                        format
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [(Ref String a), Long] String)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#from-int">
-                    <h3 id="from-int">
-                        from-int
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Int] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#from-string">
-                    <h3 id="from-string">
-                        from-string
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [(Ref String a)] (Maybe Long))
-                </p>
-                <pre class="args">
-                    (from-string s)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#hash">
-                    <h3 id="hash">
-                        hash
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [(Ref Long a)] Int)
-                </p>
-                <pre class="args">
-                    (hash k)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#inc">
-                    <h3 id="inc">
-                        inc
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#mod">
-                    <h3 id="mod">
-                        mod
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long, Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#neg">
-                    <h3 id="neg">
-                        neg
-                    </h3>
-                </a>
-                <div class="description">
-                    external
-                </div>
-                <p class="sig">
-                    (Fn [Long] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#odd?">
-                    <h3 id="odd?">
-                        odd?
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [Long] Bool)
-                </p>
-                <pre class="args">
-                    (odd? a)
-                </pre>
-                <p class="doc">
-                    
+                    <p>initializes a <code>Pair</code> from member references.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -691,130 +376,156 @@
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] String)
+                    (Fn [(Ref (Triple a b c) d)] String)
                 </p>
-                <pre class="args">
-                    (prn x)
-                </pre>
-                <p class="doc">
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>converts a <code>Triple</code> to a string.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#random">
-                    <h3 id="random">
-                        random
-                    </h3>
-                </a>
-                <div class="description">
-                    defn
-                </div>
-                <p class="sig">
-                    (Fn [] Long)
-                </p>
-                <pre class="args">
-                    (random)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#random-between">
-                    <h3 id="random-between">
-                        random-between
+                <a class="anchor" href="#reverse">
+                    <h3 id="reverse">
+                        reverse
                     </h3>
                 </a>
                 <div class="description">
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long] Long)
+                    (Fn [(Ref (Triple a b c) d)] (Triple c b a))
                 </p>
                 <pre class="args">
-                    (random-between lower upper)
+                    (reverse t)
                 </pre>
                 <p class="doc">
                     
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-add">
-                    <h3 id="safe-add">
-                        safe-add
+                <a class="anchor" href="#set-a">
+                    <h3 id="set-a">
+                        set-a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Triple a b c), a] (Triple a b c))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>a</code> property of a <code>Triple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-mul">
-                    <h3 id="safe-mul">
-                        safe-mul
+                <a class="anchor" href="#set-a!">
+                    <h3 id="set-a!">
+                        set-a!
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Ref (Triple a b c) d), a] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>a</code> property of a <code>Triple</code> in place.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#safe-sub">
-                    <h3 id="safe-sub">
-                        safe-sub
+                <a class="anchor" href="#set-b">
+                    <h3 id="set-b">
+                        set-b
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long, Long, (Ref Long a)] Bool)
+                    (Fn [(Triple a b c), b] (Triple a b c))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>sets the <code>b</code> property of a <code>Triple</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#seed">
-                    <h3 id="seed">
-                        seed
+                <a class="anchor" href="#set-b!">
+                    <h3 id="set-b!">
+                        set-b!
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] ())
+                    (Fn [(Ref (Triple a b c) d), b] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
+                    <p>sets the <code>b</code> property of a <code>Triple</code> in place.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-c">
+                    <h3 id="set-c">
+                        set-c
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Triple a b c), c] (Triple a b c))
+                </p>
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>sets the <code>c</code> property of a <code>Triple</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#set-c!">
+                    <h3 id="set-c!">
+                        set-c!
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Ref (Triple a b c) d), c] ())
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>sets the <code>c</code> property of a <code>Triple</code> in place.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -824,35 +535,77 @@
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Long] String)
+                    (Fn [(Ref (Triple a b c) d)] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>converts a <code>Triple</code> to a string.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#to-int">
-                    <h3 id="to-int">
-                        to-int
+                <a class="anchor" href="#update-a">
+                    <h3 id="update-a">
+                        update-a
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [Long] Int)
+                    (Fn [(Triple a b c), (Ref (Fn [a] a d) e)] (Triple a b c))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
+                    <p>updates the <code>a</code> property of a <code>Triple</code> using a function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-b">
+                    <h3 id="update-b">
+                        update-b
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (Fn [(Triple a b c), (Ref (Fn [b] b d) e)] (Triple a b c))
+                </p>
+                <span>
                     
+                </span>
+                <p class="doc">
+                    <p>updates the <code>b</code> property of a <code>Triple</code> using a function <code>f</code>.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#update-c">
+                    <h3 id="update-c">
+                        update-c
+                    </h3>
+                </a>
+                <div class="description">
+                    instantiate
+                </div>
+                <p class="sig">
+                    (Fn [(Triple a b c), (Ref (Fn [c] c d) e)] (Triple a b c))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>updates the <code>c</code> property of a <code>Triple</code> using a function <code>f</code>.</p>
+
                 </p>
             </div>
             <div class="binder">
@@ -865,7 +618,7 @@
                     defn
                 </div>
                 <p class="sig">
-                    (Fn [] Long)
+                    (Fn [] (Triple a b c))
                 </p>
                 <pre class="args">
                     (zero)

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -147,6 +147,21 @@
                                 Pointer
                             </a>
                         </li>
+                        <li>
+                            <a href="Pair.html">
+                                Pair
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Triple.html">
+                                Triple
+                            </a>
+                        </li>
+                        <li>
+                            <a href="Quadruple.html">
+                                Quadruple
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -143,6 +143,21 @@
                                     Pointer
                                 </a>
                             </li>
+                            <li>
+                                <a href="Pair.html">
+                                    Pair
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Triple.html">
+                                    Triple
+                                </a>
+                            </li>
+                            <li>
+                                <a href="Quadruple.html">
+                                    Quadruple
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -37,6 +37,9 @@
            Maybe
            Result
            Pointer
+           Pair
+           Triple
+           Quadruple
            )
 
 (quit)

--- a/test/tuples.carp
+++ b/test/tuples.carp
@@ -22,8 +22,16 @@
   (assert-false test
                 (< &(Pair.init @"a" 2) &(Pair.init @"a" 1))
                 "comparison works with (Ref (Pair String Int)) II")
-  (assert-equal test
-                &(Pair.init 2 @"a")
-                &(Pair.reverse &(Pair.init @"a" 2))
-                "reverse works")
+  (assert-ref-equal test
+                    (Pair.init 2 @"a")
+                    (Pair.reverse &(Pair.init @"a" 2))
+                    "reverse works")
+  (assert-ref-equal test
+                    (Pair.init 0 @"")
+                    (Pair.zero)
+                    "zero works")
+  (assert-ref-equal test
+                    (Pair.init @"" [1])
+                    (Pair.init-from-refs "" &[1])
+                    "init-from-refs works")
 )


### PR DESCRIPTION
This PR fixes #830 by autogenerating tuple modules (`Pair`, `Triple`, and `Quadruple`, for now).

It also adds `Dynamic.flatten`, which flattens a list.

I also added the tuple modules to documentation generation.

Cheers