### PR TITLE
Improve introspection support for interfaces

### DIFF
--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -47,6 +47,8 @@
     (if (empty? (eval (list 's-expr binding)))
         0
     (eval (list 'cond
+        (list 'Introspect.interface? binding) (length (car (cdaddr (eval (list
+        's-expr binding)))))
         (list 'Introspect.function? binding) (length (caddr (eval (list 's-expr binding))))
         (list 'Introspect.struct? binding) (/ (length (caddr (eval (list 's-expr binding)))) 2)
         (list 'Introspect.sumtype? binding) (quote (map (fn [arr]

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -722,6 +722,8 @@ primitiveSexpression (XObj _ i _) ctx [XObj (Sym path _) _ _] =
          -- Just to be sure, check the type env--this might be an interface or
          -- type
          case lookupInEnv path tyEnv of
+           Just (_, Binder _ (XObj (Lst [inter@(XObj (Interface ty _) _ _), path]) i t)) ->
+             return (ctx, Right (XObj (Lst [(toSymbols inter), path, (tyToXObj ty)]) i t))
            Just (_, Binder _ (XObj (Lst forms) i t)) ->
                return (ctx, Right (XObj (Lst (map toSymbols forms)) i t))
            Just (_, Binder _ xobj'') ->


### PR DESCRIPTION
Previously, introspecting an interface only returned `definterface` and
its name. We now return the form corresponding to the interface's types
signature, which enables us to introspect more effectively; e.g.
returning the appropriate arity of an interface.

For example:

```
鲤 (s-expr inc)
=> (definterface inc (Fn [a] a))
(arity inc)
=> 1
```