### PR TITLE
Improve register-type documentation

### DIFF
--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -266,7 +266,9 @@ primitiveRegisterType _ ctx _ =
     "I don't understand this usage of `register-type`.\n\n" ++
     "Valid usages :\n" ++
     "  (register-type Name)\n" ++
-    "  (register-type Name [field0 Type, ...])") Nothing)
+    "  (register-type Name [field0 Type, ...])\n" ++
+    "  (register-type Name c-name)\n" ++
+    "  (register-type Name c-name [field0 Type, ...]") Nothing)
 
 
 primitiveRegisterTypeWithoutFields :: Context -> String -> (Maybe String) -> IO (Context, Either EvalError XObj)

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -232,7 +232,7 @@ dynamicModule = Env { envBindings = bindings
                     , makeVarPrim "line" "returns the line a symbol was defined on." "(line mysymbol)" primitiveLine
                     , makeVarPrim "column" "returns the column a symbol was defined on." "(column mysymbol)" primitiveColumn
                     , makePrim "info" 1 "prints all information associated with a symbol." "(info mysymbol)" primitiveInfo
-                    , makeVarPrim "register-type" "registers a new type from C." "(register-type Name <optional: members>)" primitiveRegisterType
+                    , makeVarPrim "register-type" "registers a new type from C." "(register-type Name <optional: c-name> <optional: members>)" primitiveRegisterType
                     , makePrim "defmacro" 3 "defines a new macro." "(defmacro name [args :rest restargs] body)" primitiveDefmacro
                     , makePrim "defndynamic" 3 "defines a new dynamic function, i.e. a function available at compile time." "(defndynamic name [args] body)" primitiveDefndynamic
                     , makePrim "defdynamic" 2 "defines a new dynamic value, i.e. a value available at compile time." "(defdynamic name value)" primitiveDefdynamic


### PR DESCRIPTION
Add info about specifying c names in the `register-type` doc string. 