### PR TITLE
Fixed the issue with nested capture and nested lambdas

### DIFF
--- a/examples/nested_lambdas.carp
+++ b/examples/nested_lambdas.carp
@@ -1,0 +1,2 @@
+(defn my-curry [f] (fn [x] (fn [y] (f x y))))
+(defn double-curry [f] (fn [x] (fn [y] (fn [z] (f x y z)))))

--- a/examples/nested_lambdas.carp
+++ b/examples/nested_lambdas.carp
@@ -1,2 +1,5 @@
 (defn my-curry [f] (fn [x] (fn [y] (f x y))))
 (defn double-curry [f] (fn [x] (fn [y] (fn [z] (f x y z)))))
+
+(defn main []
+  (do (((my-curry (fn [x y] (Int.+ x y))) 1) 2)))

--- a/run_carp_tests.sh
+++ b/run_carp_tests.sh
@@ -43,6 +43,7 @@ done
 ./carp.sh ./examples/guessing.carp -b
 ./carp.sh ./examples/no_core.carp --no-core --no-profile -b
 ./carp.sh ./examples/check_malloc.carp -b
+./carp.sh ./examples/nested_lambdas.carp -b
 
 # Run tests which rely on SDL unless the `--no_sdl` argument was passed in
 if [[ ${NO_SDL} -eq 0 ]]; then

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -25,7 +25,7 @@ data DefinitionMode = AVariable
 
 -- | For local lookups, does the variable live in the current function or is it captured from outside it's body?
 data CaptureMode = NoCapture
-                 | Capture
+                 | Capture Int
                  deriving (Eq, Show, Ord)
 
 -- | A symbol knows a bit about what it refers to - is it a local scope or a global one? (the latter include modules).

--- a/src/Qualify.hs
+++ b/src/Qualify.hs
@@ -131,7 +131,7 @@ setFullyQualifiedSymbols typeEnv globalEnv localEnv xobj@(XObj (Sym path _) i t)
       XObj (InterfaceSym name) i t
 
     captureOrNot foundEnv = if envFunctionNestingLevel foundEnv < envFunctionNestingLevel localEnv
-                            then Capture
+                            then Capture (envFunctionNestingLevel localEnv - envFunctionNestingLevel foundEnv)
                             else NoCapture
 
     doesNotBelongToAnInterface :: Bool -> Env -> XObj


### PR DESCRIPTION
This should be fixing #805 
The solution I went for is to modify the `CaptureMode` datatype. The `Capture` constructor now takes an int which indicates the "Capture Distance" that is the number of lambdas between the binding of the variable and its usage (this is easy to calculate during Qualification).
This allows to differentiate between a variable bound by the last encountered lambda, and one which is present in its environment, and can be used to fill the next environment.