### PR TITLE
Fixed the issue with nested capture and nested lambdas

### DIFF
--- a/examples/nested_lambdas.carp
+++ b/examples/nested_lambdas.carp
@@ -1,0 +1,2 @@
+(defn my-curry [f] (fn [x] (fn [y] (f x y))))
+(defn double-curry [f] (fn [x] (fn [y] (fn [z] (f x y z)))))

--- a/run_carp_tests.sh
+++ b/run_carp_tests.sh
@@ -43,6 +43,7 @@ done
 ./carp.sh ./examples/guessing.carp -b
 ./carp.sh ./examples/no_core.carp --no-core --no-profile -b
 ./carp.sh ./examples/check_malloc.carp -b
+./carp.sh ./examples/nested_lambdas.carp -b
 
 # Run tests which rely on SDL unless the `--no_sdl` argument was passed in
 if [[ ${NO_SDL} -eq 0 ]]; then

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -25,7 +25,7 @@ data DefinitionMode = AVariable
 
 -- | For local lookups, does the variable live in the current function or is it captured from outside it's body?
 data CaptureMode = NoCapture
-                 | Capture
+                 | Capture Int
                  deriving (Eq, Show, Ord)
 
 -- | A symbol knows a bit about what it refers to - is it a local scope or a global one? (the latter include modules).

--- a/src/Qualify.hs
+++ b/src/Qualify.hs
@@ -131,7 +131,7 @@ setFullyQualifiedSymbols typeEnv globalEnv localEnv xobj@(XObj (Sym path _) i t)
       XObj (InterfaceSym name) i t
 
     captureOrNot foundEnv = if envFunctionNestingLevel foundEnv < envFunctionNestingLevel localEnv
-                            then Capture
+                            then Capture (envFunctionNestingLevel localEnv - envFunctionNestingLevel foundEnv)
                             else NoCapture
 
     doesNotBelongToAnInterface :: Bool -> Env -> XObj


### PR DESCRIPTION
Once again trying to fix the evaluation issue outlined in #850.
After the mistake made in #858, I tried to generalize the current "static evaluation", rather than change it completely. The results fixes the example shown in #850, but there is still a few issues that I would like to discuss before implementing a definitive solutions.
The current push code does evaluate correctly the following example:
```
(defn ident [x] x)
((ident (fn [x] x)) 1)
```
which was not the case before this PR. However I have found 2 categories of bug this does not fix:

* consider `(+ (ident 2) (ident 2)` which should evaluate to `4`. With the current code, the evaluator returns an error, as it tries to apply the primitive `+` to `((defn ident [...]) 2)`. 

    * I think this could be solved by checking `isStaticCall` on the arguments of a call (primitive or otherwise before applying it, but I worry this would make the evaluator code too complex. 
    * Another, maybe more robust solution would be to replace the return type of `eval` with a three way sum type : one representing an error, another a fully evaluated value, and the last a value waiting for a static evaluation; this would make treatement more explicit and hopefully less prone to forget "special cases", but would also necessitate a hefty refactor.

* Second problem : consider either `(let [x 1] (ident x)` or ((fn [x] (ident x) 1). Both these cases exhibit a similar bug : after dynamic evaluation, we're left with the expression `(ident x)`. The issue is that, as we go back up from recursive call in the `eval` function, the environment linking `x` to it's value `1` is lost. 
   * the first solution I thought of was to `eval` the arguments of a static call during the dynamic evaluation. This unfortunately caused other problems (for instance, with `((ident (fn [x] x)) 1)` the `fn` became a closure which was refused by typing when using `callFromRepl`; in the case of `((ident ident) 1)`, there was an issue with the borrow checker.
   * another, maybe safer solution would be to "save" the environment around the static call, in order to pass it when using `callFromRepl`. I'm not 100% sure how that would work however, and maybe that would need to introduce some new weird syntactic constructs, which would pollute the AST.

Here, I'd very much like to hear about you on the subject of these issues (and of course of the code I've already written). Thanks in advance !
