### PR TITLE
Generalization of the evaluation of static defn

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -215,13 +215,13 @@ eval ctx xobj@(XObj o i t) =
 
        x@(XObj (Lst [XObj (Primitive prim) _ _, _]) _ _):args -> (getPrimitive prim) x ctx args
 
-       XObj (Lst (XObj (Defn _) _ _:_)) _ _:_ -> return (ctx, Left HasStaticCall)
-       XObj (Lst (XObj (Interface _ _) _ _:_)) _ _:_ -> return (ctx, Left HasStaticCall)
-       XObj (Lst (XObj (Instantiate _) _ _:_)) _ _:_ -> return (ctx, Left HasStaticCall)
-       XObj (Lst (XObj (Deftemplate _) _ _:_)) _ _:_ -> return (ctx, Left HasStaticCall)
-       XObj (Lst (XObj (External _) _ _:_)) _ _:_ -> return (ctx, Left HasStaticCall)
-       XObj (Match _) _ _:_ -> return (ctx, Left HasStaticCall)
-       [XObj Ref _ _, _] -> return (ctx, Left HasStaticCall)
+       XObj (Lst (XObj (Defn _) _ _:_)) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))
+       XObj (Lst (XObj (Interface _ _) _ _:_)) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))
+       XObj (Lst (XObj (Instantiate _) _ _:_)) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))
+       XObj (Lst (XObj (Deftemplate _) _ _:_)) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))
+       XObj (Lst (XObj (External _) _ _:_)) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))
+       XObj (Match _) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))
+       [XObj Ref _ _, _] -> return (ctx, Left (HasStaticCall xobj i))
 
        l@(XObj (Lst _) i t):args -> do
          (newCtx, f) <- eval ctx l
@@ -393,7 +393,7 @@ executeCommand ctx@(Context env _ _ _ _ _ _ _) xobj =
        -- special case: calling something static at the repl
        Right (XObj (Lst (XObj (Lst (XObj (Defn _) _ _:(XObj (Sym (SymPath [] "main") _) _ _):_)) _ _:_)) _ _) ->
         executeCommand newCtx (withBuildAndRun (XObj (Lst []) (Just dummyInfo) Nothing))
-       Left HasStaticCall ->
+       Left (HasStaticCall _ _) ->
         callFromRepl newCtx xobj
 
        Right result -> return (result, newCtx)

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -343,9 +343,12 @@ prettyCaptures :: Set.Set XObj -> String
 prettyCaptures captures =
   joinWithComma (map (\x -> getName x ++ " : " ++ fromMaybe "" (fmap show (ty x))) (Set.toList captures))
 
-data EvalError = EvalError String [XObj] FilePathPrintLength (Maybe Info) deriving (Eq)
+data EvalError = EvalError String [XObj] FilePathPrintLength (Maybe Info)
+               | HasStaticCall
+               deriving (Eq)
 
 instance Show EvalError where
+  show HasStaticCall = "HasStaticCall"
   show (EvalError msg t fppl i) = msg ++ getInfo i ++ getTrace
     where getInfo (Just i) = " at " ++ machineReadableInfo fppl i ++ "."
           getInfo Nothing = ""

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -344,11 +344,13 @@ prettyCaptures captures =
   joinWithComma (map (\x -> getName x ++ " : " ++ fromMaybe "" (fmap show (ty x))) (Set.toList captures))
 
 data EvalError = EvalError String [XObj] FilePathPrintLength (Maybe Info)
-               | HasStaticCall
+               | HasStaticCall XObj (Maybe Info)
                deriving (Eq)
 
 instance Show EvalError where
-  show HasStaticCall = "HasStaticCall"
+  show (HasStaticCall xobj info) = "Expression " ++ (pretty xobj) ++ " has unexpected static call"++ getInfo info
+    where getInfo (Just i) = " at " ++ prettyInfo i ++ "."
+          getInfo Nothing = ""
   show (EvalError msg t fppl i) = msg ++ getInfo i ++ getTrace
     where getInfo (Just i) = " at " ++ machineReadableInfo fppl i ++ "."
           getInfo Nothing = ""


### PR DESCRIPTION
Once again trying to fix the evaluation issue outlined in #850.
After the mistake made in #858, I tried to generalize the current "static evaluation", rather than change it completely. The results fixes the example shown in #850, but there is still a few issues that I would like to discuss before implementing a definitive solutions.
The current push code does evaluate correctly the following example:
```
(defn ident [x] x)
((ident (fn [x] x)) 1)
```
which was not the case before this PR. However I have found 2 categories of bug this does not fix:

* consider `(+ (ident 2) (ident 2)` which should evaluate to `4`. With the current code, the evaluator returns an error, as it tries to apply the primitive `+` to `((defn ident [...]) 2)`. 

    * I think this could be solved by checking `isStaticCall` on the arguments of a call (primitive or otherwise before applying it, but I worry this would make the evaluator code too complex. 
    * Another, maybe more robust solution would be to replace the return type of `eval` with a three way sum type : one representing an error, another a fully evaluated value, and the last a value waiting for a static evaluation; this would make treatement more explicit and hopefully less prone to forget "special cases", but would also necessitate a hefty refactor.

* Second problem : consider either `(let [x 1] (ident x)` or ((fn [x] (ident x) 1). Both these cases exhibit a similar bug : after dynamic evaluation, we're left with the expression `(ident x)`. The issue is that, as we go back up from recursive call in the `eval` function, the environment linking `x` to it's value `1` is lost. 
   * the first solution I thought of was to `eval` the arguments of a static call during the dynamic evaluation. This unfortunately caused other problems (for instance, with `((ident (fn [x] x)) 1)` the `fn` became a closure which was refused by typing when using `callFromRepl`; in the case of `((ident ident) 1)`, there was an issue with the borrow checker.
   * another, maybe safer solution would be to "save" the environment around the static call, in order to pass it when using `callFromRepl`. I'm not 100% sure how that would work however, and maybe that would need to introduce some new weird syntactic constructs, which would pollute the AST.

Here, I'd very much like to hear about you on the subject of these issues (and of course of the code I've already written). Thanks in advance !
