### PR TITLE
Refactor Primitives.hs

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Info,
                        Obj,
+                       Meta,
                        Project,
                        Parsing,
                        Infer,

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -27,6 +27,7 @@ import RenderDocs
 import TypeError
 import Path
 import Info
+import qualified Meta
 
 data CarpException =
     ShellOutException { shellOutMessage :: String, returnCode :: Int }
@@ -59,7 +60,7 @@ addCommandConfigurable path maybeArity callback doc example =
                       ])
             (Just dummyInfo) (Just DynamicTy)
       SymPath _ name = path
-      meta = MetaData (Map.insert "doc" (XObj (Str docString) Nothing Nothing) Map.empty)
+      meta = Meta.set "doc" (XObj (Str docString) Nothing Nothing) emptyMeta
   in (name, Binder meta cmd)
   where f = case maybeArity of
               Just arity -> withArity arity

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -27,6 +27,7 @@ import Scoring
 import Lookup
 import Concretize
 import Info
+import qualified Meta
 
 addIndent :: Int -> String
 addIndent n = replicate n ' '
@@ -669,7 +670,7 @@ delete indent i = mapM_ deleterToC (infoDelete i)
 
 defnToDeclaration :: MetaData -> SymPath -> [XObj] -> Ty -> String
 defnToDeclaration meta path@(SymPath _ name) argList retTy =
-  let (XObj (Lst annotations) _ _) = fromMaybe emptyList (Map.lookup "annotations" (getMeta meta))
+  let (XObj (Lst annotations) _ _) = fromMaybe emptyList (Meta.get "annotations" meta)
       annotationsStr = joinWith " " (map strToC annotations)
       sep = if not (null annotationsStr) then " " else ""
   in annotationsStr ++ sep ++

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -34,6 +34,7 @@ import Concretize
 import Path
 import Primitives
 import Info
+import qualified Meta
 
 import Debug.Trace
 
@@ -506,7 +507,7 @@ getSigFromDefnOrDef ctx globalEnv fppl xobj@(XObj _ i t) =
                    (SymPath [] n) -> consPath pathStrings path
                    (SymPath quals n) -> path
       metaData = existingMeta globalEnv (XObj (Sym fullPath Symbol) i t)
-  in  case Map.lookup "sig" (getMeta metaData) of
+  in  case Meta.get "sig" metaData of
         Just foundSignature ->
           case xobjToTy foundSignature of
             Just t -> let sigToken = XObj (Sym (SymPath [] "sig") Symbol) Nothing Nothing

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -8,6 +8,8 @@ import Text.EditDistance (defaultEditCosts, levenshteinDistance)
 import Types
 import Obj
 import Util
+import qualified Meta
+
 import Debug.Trace
 
 -- | The type of generic lookup functions.
@@ -130,7 +132,7 @@ lookupByMeta :: String -> Env -> [Binder]
 lookupByMeta key env =
   let filtered = Map.filter hasMeta (envBindings env)
   in  map snd $ Map.toList filtered
-  where hasMeta (Binder meta _)= Map.member key (getMeta meta)
+  where hasMeta b = Meta.binderMember key b
 
 -- | Given an interface, lookup all binders that implement the interface.
 lookupImplementations :: SymPath -> Env -> [Binder]
@@ -138,7 +140,7 @@ lookupImplementations interface env =
   let binders = lookupByMeta "implements" env
   in  filter isImpl binders
   where isImpl (Binder meta _) =
-          case Map.lookup "implements" (getMeta meta) of
+          case Meta.get "implements" meta of
             Just (XObj (Lst interfaces) _ _) -> interface `elem` (map getPath interfaces)
             _ -> False
 

--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -3,6 +3,8 @@ module Meta (get,
              fromBinder,
              getBinderMetaValue,
              updateBinderMeta,
+             Meta.member,
+             binderMember
             ) where
 
 import Data.Map as Map
@@ -25,4 +27,8 @@ updateBinderMeta :: Binder -> String -> XObj -> Binder
 updateBinderMeta binder key value = 
   binder { binderMeta = set key value $ fromBinder binder }
 
+member :: String -> MetaData -> Bool
+member key meta = Map.member key $ getMeta meta
 
+binderMember :: String -> Binder -> Bool
+binderMember key binder = Meta.member key $ fromBinder binder

--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -1,0 +1,28 @@
+module Meta (get,
+             set,
+             fromBinder,
+             getBinderMetaValue,
+             updateBinderMeta,
+            ) where
+
+import Data.Map as Map
+import Obj
+
+get :: String -> MetaData -> Maybe XObj
+get key meta = Map.lookup key $ getMeta meta
+
+set :: String -> XObj -> MetaData -> MetaData
+set key value meta = MetaData $ Map.insert key value $ getMeta meta
+
+fromBinder :: Binder -> MetaData
+fromBinder binder = binderMeta binder
+
+getBinderMetaValue :: String -> Binder -> Maybe XObj
+getBinderMetaValue key binder = 
+  get key $ fromBinder binder
+
+updateBinderMeta :: Binder -> String -> XObj -> Binder
+updateBinderMeta binder key value = 
+  binder { binderMeta = set key value $ fromBinder binder }
+
+

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -68,55 +68,37 @@ makePrim' name maybeArity docString example callback =
         exampleUsage = "Example Usage:\n```\n" ++ example ++ "\n```\n"
 
 primitiveFile :: Primitive
-primitiveFile x@(XObj _ i t) ctx [] =
-  case i of
-    Just info -> return (ctx, Right (XObj (Str (infoFile info)) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
-primitiveFile x@(XObj _ i t) ctx [XObj _ mi _] =
-  case mi of
-    Just info -> return (ctx, Right (XObj (Str (infoFile info)) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
 primitiveFile x@(XObj _ i t) ctx args =
-  return (
-    evalError ctx
-      ("`file` expected 0 or 1 arguments, but got " ++ show (length args))
-      (info x))
+  return $ case args of
+             [] -> go i
+             [XObj _ mi _] -> go mi
+             _ -> evalError ctx
+                            ("`file` expected 0 or 1 arguments, but got " ++ show (length args))
+                            (info x)
+  where err = evalError ctx ("No information about object " ++ pretty x) (info x)
+        go  = maybe err (\info -> (ctx, Right (XObj (Str (infoFile info)) i t)))
 
 primitiveLine :: Primitive
-primitiveLine x@(XObj _ i t) ctx [] =
-  case i of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
-primitiveLine x@(XObj _ i t) ctx [XObj _ mi _] =
-  case mi of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
 primitiveLine x@(XObj _ i t) ctx args =
-  return (
-    evalError ctx
-      ("`line` expected 0 or 1 arguments, but got " ++ show (length args))
-      (info x))
+  return $ case args of
+             [] ->  go i
+             [XObj _ mi _] -> go mi
+             _ -> evalError ctx
+                            ("`line` expected 0 or 1 arguments, but got " ++ show (length args))
+                            (info x)
+  where err = evalError ctx ("No information about object " ++ pretty x) (info x)
+        go  = maybe err (\info -> (ctx, Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t)))
 
 primitiveColumn :: Primitive
-primitiveColumn x@(XObj _ i t) ctx [] =
-  case i of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
-primitiveColumn x@(XObj _ i t) ctx [XObj _ mi _] =
-  case mi of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
 primitiveColumn x@(XObj _ i t) ctx args =
-  return (
-    evalError ctx
-      ("`column` expected 0 or 1 arguments, but got " ++ show (length args))
-      (info x))
+  return $ case args of
+             [] -> go i
+             [XObj _ mi _] -> go mi
+             _ -> evalError ctx
+                 ("`column` expected 0 or 1 arguments, but got " ++ show (length args))
+                 (info x)
+  where err = evalError ctx ("No information about object " ++ pretty x) (info x)
+        go  = maybe err (\info -> (ctx, Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t)))
 
 primitiveImplements :: Primitive
 primitiveImplements xobj ctx [x@(XObj (Sym interface@(SymPath _ _) _) _ _), i@(XObj (Sym impl@(SymPath _ _) _) _ _)] =

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -21,6 +21,7 @@ import Types
 import Util
 import Path
 import AssignTypes (typeVariablesInOrderOfAppearance)
+import qualified Meta
 
 -- TODO: Move the beautification to a much earlier place, preferably when the function is defined/concretized-
 -- This might be a duplicate with the work in a PR by @jacereda
@@ -93,7 +94,7 @@ envBinderToHtml envBinder ctx moduleName moduleNames =
   let (env, meta) = getEnvAndMetaFromBinder envBinder
       title = projectTitle ctx
       css = projectDocsStyling ctx
-      moduleDescription = case Map.lookup "doc" (getMeta meta) of
+      moduleDescription = case Meta.get "doc" meta of
                             Just (XObj (Str s) _ _) -> s
                             Nothing -> ""
       moduleDescriptionHtml = commonmarkToHtml [optSafe] $ Text.pack moduleDescription
@@ -133,8 +134,7 @@ binderToHtml (Binder meta xobj) =
       typeSignature = case ty xobj of
                  Just t -> show (beautifyType t) -- NOTE: This destroys user-defined names of type variables!
                  Nothing -> ""
-      metaMap = getMeta meta
-      docString = case Map.lookup "doc" metaMap of
+      docString = case Meta.get "doc" meta of
                     Just (XObj (Str s) _ _) -> s
                     Just found -> pretty found
                     Nothing -> ""


### PR DESCRIPTION
**N.B. this also contains changes from PR #866 **

This PR mostly just factors out case statements from a variety of
functions using two useful utilities `maybe` and `either`.

Essentially, these functions enable you to express a case against a
Maybe or Either in terms of a function and default value, and generally
help readability. In our case they:

- Allow us to remove tons of repetitive return statements.
- Allow us to remove do's.
- Eliminate some cases and simplify the code structure.

In total, it eliminates about 66 loc

This PR contains no behavioral changes