### PR TITLE
Move interfaces code into its own module

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Info,
                        Obj,
+                       Meta,
                        Project,
                        Parsing,
                        Infer,

--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -52,6 +52,7 @@ library
                        RenderDocs,
                        StructUtils,
                        Path,
+                       Interfaces,
                        Primitives,
                        Validate
 

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -27,6 +27,7 @@ import RenderDocs
 import TypeError
 import Path
 import Info
+import qualified Meta
 
 data CarpException =
     ShellOutException { shellOutMessage :: String, returnCode :: Int }
@@ -59,7 +60,7 @@ addCommandConfigurable path maybeArity callback doc example =
                       ])
             (Just dummyInfo) (Just DynamicTy)
       SymPath _ name = path
-      meta = MetaData (Map.insert "doc" (XObj (Str docString) Nothing Nothing) Map.empty)
+      meta = Meta.set "doc" (XObj (Str docString) Nothing Nothing) emptyMeta
   in (name, Binder meta cmd)
   where f = case maybeArity of
               Just arity -> withArity arity

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -27,6 +27,7 @@ import Scoring
 import Lookup
 import Concretize
 import Info
+import qualified Meta
 
 addIndent :: Int -> String
 addIndent n = replicate n ' '
@@ -669,7 +670,7 @@ delete indent i = mapM_ deleterToC (infoDelete i)
 
 defnToDeclaration :: MetaData -> SymPath -> [XObj] -> Ty -> String
 defnToDeclaration meta path@(SymPath _ name) argList retTy =
-  let (XObj (Lst annotations) _ _) = fromMaybe emptyList (Map.lookup "annotations" (getMeta meta))
+  let (XObj (Lst annotations) _ _) = fromMaybe emptyList (Meta.get "annotations" meta)
       annotationsStr = joinWith " " (map strToC annotations)
       sep = if not (null annotationsStr) then " " else ""
   in annotationsStr ++ sep ++

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -34,6 +34,7 @@ import Concretize
 import Path
 import Primitives
 import Info
+import qualified Meta
 
 import Debug.Trace
 
@@ -506,7 +507,7 @@ getSigFromDefnOrDef ctx globalEnv fppl xobj@(XObj _ i t) =
                    (SymPath [] n) -> consPath pathStrings path
                    (SymPath quals n) -> path
       metaData = existingMeta globalEnv (XObj (Sym fullPath Symbol) i t)
-  in  case Map.lookup "sig" (getMeta metaData) of
+  in  case Meta.get "sig" metaData of
         Just foundSignature ->
           case xobjToTy foundSignature of
             Just t -> let sigToken = XObj (Sym (SymPath [] "sig") Symbol) Nothing Nothing

--- a/src/Interfaces.hs
+++ b/src/Interfaces.hs
@@ -1,0 +1,83 @@
+-- | This module contains interface registration functions.
+-- Interface registration involves associating some concrete form, e.g. a defn with an interface.
+-- Registered forms may be used wherever the interface is called.
+-- Registrations are stored w/ the interface in the context type environment.
+module Interfaces (registerInInterfaceIfNeeded,
+                   registerInInterface,
+                   retroactivelyRegisterInInterface) where
+
+import Data.Either (isRight)
+
+import Obj
+import Lookup
+import Types
+import Util
+import Constraints
+import Data.List (foldl')
+
+import Debug.Trace
+
+data InterfaceError = KindMismatch SymPath Ty Ty
+                    | TypeMismatch SymPath Ty Ty
+                    | NonInterface SymPath
+
+instance Show InterfaceError where
+  show (KindMismatch path definitionSignature interfaceSignature) = "[INTERFACE ERROR] " ++ show path ++ ":" ++ " One or more types in the interface implementation " ++
+                                                                    show definitionSignature ++ " have kinds that do not match the kinds of the types in the interface signature " ++
+                                                                    show interfaceSignature ++ "\n" ++ "Types of the form (f a) must be matched by constructor types such as (Maybe a)"
+  show (TypeMismatch path definitionSignature interfaceSignature) = "[INTERFACE ERROR] " ++ show path ++ " : " ++ show definitionSignature ++
+                                                                  " doesn't match the interface signature " ++ show interfaceSignature
+  show (NonInterface path) = "[INTERFACE ERROR] " ++ show path ++ "Cant' implement the non-interface `" ++ show path ++ "`"
+
+-- TODO: This is currently called once outside of this module--try to remove that call and make this internal.
+-- Checks whether a given form's type matches an interface, and if so, registers the form with the interface.
+registerInInterfaceIfNeeded :: Context -> SymPath -> SymPath -> Ty -> Either String Context
+registerInInterfaceIfNeeded ctx path@(SymPath _ _) interface@(SymPath [] name) definitionSignature =
+  maybe (return ctx) (typeCheck . snd) (lookupInEnv interface typeEnv)
+  where typeEnv = getTypeEnv (contextTypeEnv ctx)
+        typeCheck binder = case binder of
+                             Binder _ (XObj (Lst [inter@(XObj (Interface interfaceSignature paths) ii it), isym]) i t) ->
+                               if checkKinds interfaceSignature definitionSignature
+                                 -- N.B. the xobjs aren't important here--we only care about types,
+                                 -- thus we pass inter to all three xobj positions.
+                                 then if isRight $ solve [Constraint interfaceSignature definitionSignature inter inter inter OrdInterfaceImpl]
+                                      then let updatedInterface = XObj (Lst [XObj (Interface interfaceSignature (addIfNotPresent path paths)) ii it, isym]) i t
+                                           in  Right $  ctx { contextTypeEnv = TypeEnv (extendEnv typeEnv name updatedInterface) }
+                                      else Left (show $ TypeMismatch path definitionSignature interfaceSignature)
+                                 else Left (show $ KindMismatch path definitionSignature interfaceSignature)
+                             _ ->
+                               Left (show $ NonInterface interface)
+
+-- | Given an XObj and an interface path, ensure that the form is
+-- registered with the interface.
+registerInInterface :: Context -> XObj -> SymPath -> Either String Context
+registerInInterface ctx xobj interface =
+  case xobj of
+    XObj (Lst [XObj (Defn _) _ _, XObj (Sym path _) _ _, _, _]) _ (Just t) ->
+      -- This is a function, does it belong to an interface?
+      registerInInterfaceIfNeeded ctx path interface t
+    XObj (Lst [XObj (Deftemplate _) _ _, XObj (Sym path _) _ _]) _ (Just t) ->
+      -- Templates should also be registered.
+      registerInInterfaceIfNeeded ctx path interface t
+    XObj (Lst [XObj Def _ _, XObj (Sym path _) _ _, _]) _ (Just t) ->
+      -- Global variables can also be part of an interface
+      registerInInterfaceIfNeeded ctx path interface t
+      -- So can externals!
+    XObj (Lst [XObj (External _) _ _, XObj (Sym path _) _ _]) _ (Just t) ->
+      registerInInterfaceIfNeeded ctx path interface t
+      -- And instantiated/auto-derived type functions! (e.g. Pair.a)
+    XObj (Lst [XObj (Instantiate _) _ _, XObj (Sym path _) _ _]) _ (Just t) ->
+      registerInInterfaceIfNeeded ctx path interface t
+    _ -> return ctx
+
+-- | For forms that were declared as implementations of interfaces that didn't exist,
+-- retroactively register those forms with the interface once its defined.
+retroactivelyRegisterInInterface :: Context -> SymPath -> Context
+retroactivelyRegisterInInterface ctx interface@(SymPath _ inter) =
+  -- TODO: Don't use error here?
+  either (\e -> error e) id resultCtx
+  where env = contextGlobalEnv ctx
+        impls = recursiveLookupAll interface lookupImplementations env
+        resultCtx = foldl' folder (Right ctx) impls
+        folder ctx' binder = either Left register ctx'
+          where register ok = registerInInterface ok (binderXObj binder) interface

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -8,6 +8,8 @@ import Text.EditDistance (defaultEditCosts, levenshteinDistance)
 import Types
 import Obj
 import Util
+import qualified Meta
+
 import Debug.Trace
 
 -- | The type of generic lookup functions.
@@ -130,7 +132,7 @@ lookupByMeta :: String -> Env -> [Binder]
 lookupByMeta key env =
   let filtered = Map.filter hasMeta (envBindings env)
   in  map snd $ Map.toList filtered
-  where hasMeta (Binder meta _)= Map.member key (getMeta meta)
+  where hasMeta b = Meta.binderMember key b
 
 -- | Given an interface, lookup all binders that implement the interface.
 lookupImplementations :: SymPath -> Env -> [Binder]
@@ -138,7 +140,7 @@ lookupImplementations interface env =
   let binders = lookupByMeta "implements" env
   in  filter isImpl binders
   where isImpl (Binder meta _) =
-          case Map.lookup "implements" (getMeta meta) of
+          case Meta.get "implements" meta of
             Just (XObj (Lst interfaces) _ _) -> interface `elem` (map getPath interfaces)
             _ -> False
 

--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -3,6 +3,8 @@ module Meta (get,
              fromBinder,
              getBinderMetaValue,
              updateBinderMeta,
+             Meta.member,
+             binderMember
             ) where
 
 import Data.Map as Map
@@ -25,4 +27,8 @@ updateBinderMeta :: Binder -> String -> XObj -> Binder
 updateBinderMeta binder key value = 
   binder { binderMeta = set key value $ fromBinder binder }
 
+member :: String -> MetaData -> Bool
+member key meta = Map.member key $ getMeta meta
 
+binderMember :: String -> Binder -> Bool
+binderMember key binder = Meta.member key $ fromBinder binder

--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -1,0 +1,28 @@
+module Meta (get,
+             set,
+             fromBinder,
+             getBinderMetaValue,
+             updateBinderMeta,
+            ) where
+
+import Data.Map as Map
+import Obj
+
+get :: String -> MetaData -> Maybe XObj
+get key meta = Map.lookup key $ getMeta meta
+
+set :: String -> XObj -> MetaData -> MetaData
+set key value meta = MetaData $ Map.insert key value $ getMeta meta
+
+fromBinder :: Binder -> MetaData
+fromBinder binder = binderMeta binder
+
+getBinderMetaValue :: String -> Binder -> Maybe XObj
+getBinderMetaValue key binder = 
+  get key $ fromBinder binder
+
+updateBinderMeta :: Binder -> String -> XObj -> Binder
+updateBinderMeta binder key value = 
+  binder { binderMeta = set key value $ fromBinder binder }
+
+

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -68,55 +68,37 @@ makePrim' name maybeArity docString example callback =
         exampleUsage = "Example Usage:\n```\n" ++ example ++ "\n```\n"
 
 primitiveFile :: Primitive
-primitiveFile x@(XObj _ i t) ctx [] =
-  case i of
-    Just info -> return (ctx, Right (XObj (Str (infoFile info)) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
-primitiveFile x@(XObj _ i t) ctx [XObj _ mi _] =
-  case mi of
-    Just info -> return (ctx, Right (XObj (Str (infoFile info)) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
 primitiveFile x@(XObj _ i t) ctx args =
-  return (
-    evalError ctx
-      ("`file` expected 0 or 1 arguments, but got " ++ show (length args))
-      (info x))
+  return $ case args of
+             [] -> go i
+             [XObj _ mi _] -> go mi
+             _ -> evalError ctx
+                            ("`file` expected 0 or 1 arguments, but got " ++ show (length args))
+                            (info x)
+  where err = evalError ctx ("No information about object " ++ pretty x) (info x)
+        go  = maybe err (\info -> (ctx, Right (XObj (Str (infoFile info)) i t)))
 
 primitiveLine :: Primitive
-primitiveLine x@(XObj _ i t) ctx [] =
-  case i of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
-primitiveLine x@(XObj _ i t) ctx [XObj _ mi _] =
-  case mi of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
 primitiveLine x@(XObj _ i t) ctx args =
-  return (
-    evalError ctx
-      ("`line` expected 0 or 1 arguments, but got " ++ show (length args))
-      (info x))
+  return $ case args of
+             [] ->  go i
+             [XObj _ mi _] -> go mi
+             _ -> evalError ctx
+                            ("`line` expected 0 or 1 arguments, but got " ++ show (length args))
+                            (info x)
+  where err = evalError ctx ("No information about object " ++ pretty x) (info x)
+        go  = maybe err (\info -> (ctx, Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t)))
 
 primitiveColumn :: Primitive
-primitiveColumn x@(XObj _ i t) ctx [] =
-  case i of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
-primitiveColumn x@(XObj _ i t) ctx [XObj _ mi _] =
-  case mi of
-    Just info -> return (ctx, Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t))
-    Nothing ->
-      return (evalError ctx ("No information about object " ++ pretty x) (info x))
 primitiveColumn x@(XObj _ i t) ctx args =
-  return (
-    evalError ctx
-      ("`column` expected 0 or 1 arguments, but got " ++ show (length args))
-      (info x))
+  return $ case args of
+             [] -> go i
+             [XObj _ mi _] -> go mi
+             _ -> evalError ctx
+                 ("`column` expected 0 or 1 arguments, but got " ++ show (length args))
+                 (info x)
+  where err = evalError ctx ("No information about object " ++ pretty x) (info x)
+        go  = maybe err (\info -> (ctx, Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t)))
 
 primitiveImplements :: Primitive
 primitiveImplements xobj ctx [x@(XObj (Sym interface@(SymPath _ _) _) _ _), i@(XObj (Sym impl@(SymPath _ _) _) _ _)] =

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -21,6 +21,7 @@ import Types
 import Util
 import Path
 import AssignTypes (typeVariablesInOrderOfAppearance)
+import qualified Meta
 
 -- TODO: Move the beautification to a much earlier place, preferably when the function is defined/concretized-
 -- This might be a duplicate with the work in a PR by @jacereda
@@ -93,7 +94,7 @@ envBinderToHtml envBinder ctx moduleName moduleNames =
   let (env, meta) = getEnvAndMetaFromBinder envBinder
       title = projectTitle ctx
       css = projectDocsStyling ctx
-      moduleDescription = case Map.lookup "doc" (getMeta meta) of
+      moduleDescription = case Meta.get "doc" meta of
                             Just (XObj (Str s) _ _) -> s
                             Nothing -> ""
       moduleDescriptionHtml = commonmarkToHtml [optSafe] $ Text.pack moduleDescription
@@ -133,8 +134,7 @@ binderToHtml (Binder meta xobj) =
       typeSignature = case ty xobj of
                  Just t -> show (beautifyType t) -- NOTE: This destroys user-defined names of type variables!
                  Nothing -> ""
-      metaMap = getMeta meta
-      docString = case Map.lookup "doc" metaMap of
+      docString = case Meta.get "doc" meta of
                     Just (XObj (Str s) _ _) -> s
                     Just found -> pretty found
                     Nothing -> ""


### PR DESCRIPTION
**N.B. this PR includes changes from #866 and #867 ** 

This PR moves interface handling code out of Primitives.hs and into its
own module. The actual primitives user's rely on to define and implement
interfaces still live in Primitives.hs, but now all the
registration/internal context mgmt code related to interfaces lives in
its own module.

Hopefully this will make it easier to modify and extend!