### PR TITLE
Only allow Int as return type for main

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 if [ -z "$CARP" ]
 then
     if [ -z "$NIX_CC" ]
@@ -7,7 +8,4 @@ then
 	cabal build
     fi
 fi
-if which clang-format > /dev/null
-then
-  clang-format -i core/*.h
-fi
+command -v clang-format >/dev/null && clang-format -i core/*.h

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,4 @@ then
 	cabal build
     fi
 fi
-command -v clang-format >/dev/null && clang-format -i core/*.h
+command -v clang-format >/dev/null && clang-format -i core/*.h || true

--- a/examples/check_malloc.carp
+++ b/examples/check_malloc.carp
@@ -1,4 +1,5 @@
 (Debug.check-allocations)
 
-(defn main []
-  (println* &(Array.repeat 10000000 &Int.zero)))
+(defn-do main []
+  (println* &(Array.repeat 10000000 &Int.zero))
+  0)

--- a/examples/external_struct.carp
+++ b/examples/external_struct.carp
@@ -5,5 +5,6 @@
 (register-type Banana [price Double, size Int])
 
 (defn main []
-  (let [b (Banana.init 2.3 1000)]
-    (IO.println &(Banana.str &b))))
+  (let-do [b (Banana.init 2.3 1000)]
+    (IO.println &(Banana.str &b))
+    0))

--- a/examples/fonts.carp
+++ b/examples/fonts.carp
@@ -40,11 +40,11 @@
       state)))
 
 (defn main []
-  (let [app (SDLApp.create "Font Rendering with SDL_ttf" 400 300)
-        rend @(SDLApp.renderer &app)]
-    (do
-      (if (TTF.ok? (TTF.init))
-        (do (set! font (TTF.open-font (cstr "resources/Hasklig.otf") 20))
-            (set! text1 (TTF.render-text-to-texture rend font "Carp!" (SDL.rgb 0 0 0)))
-            (SDLApp.run-with-callbacks &app event-handler id draw 0))
-        (println* "Failed to initialize SDL_ttf: " &(from-cstr (TTF.get-error)))))))
+  (let-do [app (SDLApp.create "Font Rendering with SDL_ttf" 400 300)
+           rend @(SDLApp.renderer &app)]
+    (if (TTF.ok? (TTF.init))
+      (do (set! font (TTF.open-font (cstr "resources/Hasklig.otf") 20))
+          (set! text1 (TTF.render-text-to-texture rend font "Carp!" (SDL.rgb 0 0 0)))
+          (SDLApp.run-with-callbacks &app event-handler id draw 0))
+      (println* "Failed to initialize SDL_ttf: " &(from-cstr (TTF.get-error))))
+    0))

--- a/examples/function_members.carp
+++ b/examples/function_members.carp
@@ -28,4 +28,4 @@
     (println* &(attack &enemy hero))
     (println* &(change-self selfer))
     (println* &gen)
-    ))
+    0))

--- a/examples/functor.carp
+++ b/examples/functor.carp
@@ -37,4 +37,4 @@
     (println &(Array.str &(ArrayExtension.fmap &Int.inc [10 20 30 40 50])))
     ;(println &(str &(higherOrder (Box.init 999))))
     ;(println &(str &(higherOrder [9 99 999 9999])))
-    ))
+    0))

--- a/examples/game.carp
+++ b/examples/game.carp
@@ -83,10 +83,10 @@
 (defn tick [state] state)
 
 (defn main []
-  (let [app (SDLApp.create "~ CARP ~" 512 512)
+  (let-do [app (SDLApp.create "~ CARP ~" 512 512)
         rend @(SDLApp.renderer &app)
         initial-state 0]
-    (do
-      (set! images (Images.init (IMG.load-texture rend (cstr "./img/square.png"))
-                                (IMG.load-texture rend (cstr "./img/carp_logo_969_no_texture.png"))))
-      (SDLApp.run-with-callbacks &app event-handler tick draw initial-state))))
+    (set! images (Images.init (IMG.load-texture rend (cstr "./img/square.png"))
+                              (IMG.load-texture rend (cstr "./img/carp_logo_969_no_texture.png"))))
+    (SDLApp.run-with-callbacks &app event-handler tick draw initial-state)
+    0))

--- a/examples/generic_structs.carp
+++ b/examples/generic_structs.carp
@@ -42,4 +42,4 @@
     (IO.println &(str &(Pair.set-b (Pair.init 100 100) 200)))
     (IO.println &(str @(Pair.a &(Pair.init 100 100))))
     (try-dictionary)
-    ))
+    0))

--- a/examples/globals.carp
+++ b/examples/globals.carp
@@ -20,7 +20,7 @@
      ;;(IO.println &(A.str &a))
      (IO.println &(str &q))
      (IO.println &(str &stuff))
-     )
+     0)
      ;;)
      )
 

--- a/examples/guessing.carp
+++ b/examples/guessing.carp
@@ -37,18 +37,19 @@
   (do (println &(str* @"Too " @low-or-high @"."))
       (print "\nPlease guess again: ")))
 
-(defn main []
-  (do (println "Seeding random number generator...\n")
-      (Random.seed-from (Double.from-int (System.time)))
-      (start-new-game!)
-      (while guessing
-        (let [user-input (get-line)
-              guessed-num (from-string &user-input)]
-          (if (= &user-input "q\n")
-            (exit!)
-            (match guessed-num
-              (Maybe.Nothing) (print "Invalid input.\nPlease guess again: ")
-              (Maybe.Just n)
-                (cond (< n answer) (guess-again "low")
-                      (> n answer) (guess-again "high")
-                      (correct!))))))))
+(defn-do main []
+  (println "Seeding random number generator...\n")
+  (Random.seed-from (Double.from-int (System.time)))
+  (start-new-game!)
+  (while guessing
+    (let [user-input (get-line)
+          guessed-num (from-string &user-input)]
+      (if (= &user-input "q\n")
+        (exit!)
+        (match guessed-num
+               (Maybe.Nothing) (print "Invalid input.\nPlease guess again: ")
+               (Maybe.Just n)
+               (cond (< n answer) (guess-again "low")
+                     (> n answer) (guess-again "high")
+                     (correct!))))))
+  0)

--- a/examples/lambdas.carp
+++ b/examples/lambdas.carp
@@ -95,4 +95,5 @@
   (example-7)
   (example-8)
   (example-9)
-  (example-10))
+  (example-10)
+  0)

--- a/examples/life.carp
+++ b/examples/life.carp
@@ -105,7 +105,7 @@
 (defn main []
   (do
     (Random.seed)
-    (let [app (create "~ Game of Life ~" 800 600)
+    (let-do [app (create "~ Game of Life ~" 800 600)
           rend @(renderer &app)
           world (repeat (* height width) &flip)
           play false]
@@ -122,4 +122,5 @@
                     (delay 50)))
                 ())))
           (draw rend (ref world) play)
-          (delay 30))))))
+          (delay 30)))
+      0)))

--- a/examples/maps.carp
+++ b/examples/maps.carp
@@ -24,7 +24,8 @@
       (println* (Map.contains? &char-map &\b))
       (println* (Map.contains? &char-map &\c)))))
 
-(defn main []
-  (do (simple)
-      (start-with-empty)
-      (checking)))
+(defn-do main []
+  (simple)
+  (start-with-empty)
+  (checking)
+  0)

--- a/examples/minimal_sdl.carp
+++ b/examples/minimal_sdl.carp
@@ -9,6 +9,7 @@
   (bg rend &(rgb (/ @state 2) (/ @state 3) (/ @state 4))))
 
 (defn main []
-  (let [app (SDLApp.create "The Minimalistic Color Generator" 400 300)
-        state 0]
-    (SDLApp.run-with-callbacks &app SDLApp.quit-on-esc tick draw state)))
+  (let-do [app (SDLApp.create "The Minimalistic Color Generator" 400 300)
+           state 0]
+    (SDLApp.run-with-callbacks &app SDLApp.quit-on-esc tick draw state)
+    0))

--- a/examples/reptile.carp
+++ b/examples/reptile.carp
@@ -167,20 +167,20 @@
   ))
 
 (defn main []
-  (let [app (SDLApp.create "R E P T I L E" 832 640)
+  (let-do [app (SDLApp.create "R E P T I L E" 832 640)
         rend @(SDLApp.renderer &app)
         world (create-world)]
-    (do
-      (while (not @(World.dead &world))
-        (if reset
-          (do
-            (set! input-dir SDL.Keycode.right)
-            (set! world (create-world))
-            (set! reset false))
-          (do
-            (let [new-world (tick &world)]
-              (set! world new-world))
-            (handle-events &app rend &world)
-            (draw rend &world)
-            (SDL.delay 50))))
-       (render-dead rend))))
+    (while (not @(World.dead &world))
+      (if reset
+        (do
+          (set! input-dir SDL.Keycode.right)
+          (set! world (create-world))
+          (set! reset false))
+        (do
+          (let [new-world (tick &world)]
+            (set! world new-world))
+          (handle-events &app rend &world)
+          (draw rend &world)
+          (SDL.delay 50))))
+    (render-dead rend)
+    0))

--- a/examples/setting_variables.carp
+++ b/examples/setting_variables.carp
@@ -27,4 +27,4 @@
   (changing-target-of-ref)
   ;;(set-derefed)
   ;;(set-in-parameter)
-  )
+  0)

--- a/examples/sorting.carp
+++ b/examples/sorting.carp
@@ -20,4 +20,5 @@
   (let-do [ints (Array.sort [10 3 75 40])
            ages (Array.sort [(Age.init 10) (Age.init 3) (Age.init 75) (Age.init 40)])]
     (IO.println &(Array.str &ints))
-    (IO.println &(Array.str &ages))))
+    (IO.println &(Array.str &ages))
+    0))

--- a/examples/sounds.carp
+++ b/examples/sounds.carp
@@ -28,23 +28,23 @@
       state)))
 
 (defn main []
-  (let [app (SDLApp.create "Sound Effects with SDL_mixer" 400 300)
-        rend @(SDLApp.renderer &app)]
-    (do
-      (let [flags Mixer.mp3-support]
-        (when (/= flags (Mixer.init flags))
-          (println* "Mixer.init error: " &(from-cstr (Mixer.get-error)))))
-      (if (Mixer.ok? (Mixer.open-audio 22050 Mixer.default-format 2 4096))
-        ()
-        (println* "Mixer.open-audio error: " &(from-cstr (Mixer.get-error))))
-      (set! fx1 (Mixer.load-wav (cstr "resources/fx1.wav")))
-      (assert (not-null? fx1))
-      (let-do [n (Mixer.nr-of-music-decoders)]
-        (println* "Nr of music decoders: " n)
-        (for [i 0 n]
-          (println* " - " &(from-cstr (Mixer.get-music-decoder i)))))
-      (let-do [music (Mixer.load-music (cstr "resources/song.mp3"))]
-        (println* "Music is " (if (null? music) "null." "not null."))
-        (println* "Play result: " (Mixer.play-music music -1))
-        )
-      (SDLApp.run-with-callbacks &app event-handler id SDLApp.default-draw 0))))
+  (let-do [app (SDLApp.create "Sound Effects with SDL_mixer" 400 300)
+           rend @(SDLApp.renderer &app)]
+    (let [flags Mixer.mp3-support]
+      (when (/= flags (Mixer.init flags))
+        (println* "Mixer.init error: " &(from-cstr (Mixer.get-error)))))
+    (if (Mixer.ok? (Mixer.open-audio 22050 Mixer.default-format 2 4096))
+      ()
+      (println* "Mixer.open-audio error: " &(from-cstr (Mixer.get-error))))
+    (set! fx1 (Mixer.load-wav (cstr "resources/fx1.wav")))
+    (assert (not-null? fx1))
+    (let-do [n (Mixer.nr-of-music-decoders)]
+      (println* "Nr of music decoders: " n)
+      (for [i 0 n]
+        (println* " - " &(from-cstr (Mixer.get-music-decoder i)))))
+    (let-do [music (Mixer.load-music (cstr "resources/song.mp3"))]
+      (println* "Music is " (if (null? music) "null." "not null."))
+      (println* "Play result: " (Mixer.play-music music -1))
+      )
+    (SDLApp.run-with-callbacks &app event-handler id SDLApp.default-draw 0)
+    0))

--- a/examples/sumtypes.carp
+++ b/examples/sumtypes.carp
@@ -71,12 +71,12 @@
 ;;   (Arr [(Array JSON)])
 ;;   (Obj [(Map String JSON)]))
 
-(defn main []
-  (do
-    (println* (generic-sumtypes (Maybe.Just 123)))
-    (println* (generic-sumtypes (the (Maybe Int) (Maybe.Nothing))))
-    (println* &(figure-out-sumtype (Elements.Fire)))
-    (println* "Grade.B has value " (grade-value (Grade.B)))
-    (println* (confusion (Just @"Yo")))
-    (println* (wildcard (Just @"Woop")))
-    (println* (wildcards-inside (Simple @"Erik" @"Svedäng")))))
+(defn-do main []
+  (println* (generic-sumtypes (Maybe.Just 123)))
+  (println* (generic-sumtypes (the (Maybe Int) (Maybe.Nothing))))
+  (println* &(figure-out-sumtype (Elements.Fire)))
+  (println* "Grade.B has value " (grade-value (Grade.B)))
+  (println* (confusion (Just @"Yo")))
+  (println* (wildcard (Just @"Woop")))
+  (println* (wildcards-inside (Simple @"Erik" @"Svedäng")))
+  0)

--- a/examples/updating.carp
+++ b/examples/updating.carp
@@ -39,5 +39,6 @@
     (let [monsters (Array.copy-map &Monster.init-random &[@"Pegasus" @"Dragon" @"Devil"])]
       (do
         (println (ref (Array.str &monsters)))
-        (let [new-monsters (Array.endo-map &Monster.move monsters)]
-          (println (ref (Array.str &new-monsters))))))))
+        (let-do [new-monsters (Array.endo-map &Monster.move monsters)]
+          (println (ref (Array.str &new-monsters))))
+        0))))

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -69,8 +69,8 @@ concretizeXObj allowAmbiguityRoot typeEnv rootEnv visitedDefinitions root =
               visitedBody <- visit False Inside env body
               return $ do okBody <- visitedBody
                           let t = fromMaybe UnitTy (ty okBody)
-                          if not (isTypeGeneric t) && t /= UnitTy && t /= IntTy
-                            then Left (MainCanOnlyReturnUnitOrInt nameSymbol t)
+                          if not (isTypeGeneric t) && t /= IntTy
+                            then Left (MainCanOnlyReturnInt nameSymbol t)
                             else return [defn, nameSymbol, args, okBody]
 
     visitList _ Toplevel env (XObj (Lst [defn@(XObj (Defn _) _ _), nameSymbol, args@(XObj (Arr argsArr) _ _), body]) _ t) =

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -38,7 +38,7 @@ data TypeError = SymbolMissingType XObj Env
                | UsingUnownedValue XObj
                | UsingCapturedValue XObj
                | ArraysCannotContainRefs XObj
-               | MainCanOnlyReturnUnitOrInt XObj Ty
+               | MainCanOnlyReturnInt XObj Ty
                | MainCannotHaveArguments XObj Int
                | CannotConcretize XObj
                | TooManyAnnotateCalls XObj
@@ -185,8 +185,8 @@ instance Show TypeError where
   show (ArraysCannotContainRefs xobj) =
     "Arrays can’t contain references: `" ++ pretty xobj ++ "` at " ++
     prettyInfoFromXObj xobj ++ ".\n\nYou’ll have to make a copy using `@`."
-  show (MainCanOnlyReturnUnitOrInt xobj t) =
-    "The main function can only return an `Int` or a unit type (`()`), but it got `" ++
+  show (MainCanOnlyReturnInt xobj t) =
+    "The main function can only return an `Int`, but it got `" ++
     show t ++ "`."
   show (MainCannotHaveArguments xobj c) =
     "The main function may not receive arguments, but it got " ++ show c ++ "."
@@ -323,8 +323,8 @@ machineReadableErrorStrings fppl err =
     (ArraysCannotContainRefs xobj) ->
       [machineReadableInfoFromXObj fppl xobj ++ " Arrays can't contain references: '" ++ pretty xobj ++ "'."]
 
-    (MainCanOnlyReturnUnitOrInt xobj t) ->
-      [machineReadableInfoFromXObj fppl xobj ++ " Main function can only return Int or (), got " ++ show t ++ "."]
+    (MainCanOnlyReturnInt xobj t) ->
+      [machineReadableInfoFromXObj fppl xobj ++ " Main function can only return Int, got " ++ show t ++ "."]
     (MainCannotHaveArguments xobj c) ->
       [machineReadableInfoFromXObj fppl xobj ++ " Main function can not have arguments, got " ++ show c ++ "."]
 


### PR DESCRIPTION
With this change the test suite passes using `tcc` as the compiler.

Sits on top of #869. 
