### PR TITLE
Attempt at fixing #843

### DIFF
--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -371,7 +371,6 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
                        when isNotVoid $
                          appendToSrc (addIndent indent' ++ retVar ++ " = " ++ caseExprRetVal ++ ";\n")
                        let Just caseLhsInfo' = caseLhsInfo
-                       delete indent' caseLhsInfo'
                        appendToSrc (addIndent indent ++ "}\n")
 
               in  do exprVar <- visit indent expr

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -371,6 +371,8 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
                        when isNotVoid $
                          appendToSrc (addIndent indent' ++ retVar ++ " = " ++ caseExprRetVal ++ ";\n")
                        let Just caseLhsInfo' = caseLhsInfo
+                       when (matchMode == MatchValue)
+                         (delete indent' caseLhsInfo')
                        appendToSrc (addIndent indent ++ "}\n")
 
               in  do exprVar <- visit indent expr

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -23,6 +23,18 @@
     (let [] (set! x 2))
     (= x 2)))
 
+; make sure that match-ref doesn't delete references (issue #843)
+(deftype StrangeThings
+  (Piff [String])
+  (Puff [String]))
+
+(defn match-ref-1 []
+  (let-do [xs [(StrangeThings.Piff @"ABCD")]]
+    (match-ref (Array.unsafe-nth &xs 0)
+      (StrangeThings.Piff x) (println* x)
+      _ ())
+    1))
+
 (use-all Test Vector2 Foo)
 
 (deftest test
@@ -53,4 +65,8 @@
   (assert-true test
                (let-and-set)
                "test that nested let bindings and set! interplay nicely")
+  (assert-equal test
+                1
+                (match-ref-1)
+                "test that match-ref doesn't delete references")
 )

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -29,11 +29,10 @@
   (Puff [String]))
 
 (defn match-ref-1 []
-  (let-do [xs [(StrangeThings.Piff @"ABCD")]]
+  (let [xs [(StrangeThings.Puff @"ABCD")]]
     (match-ref (Array.unsafe-nth &xs 0)
-      (StrangeThings.Piff x) (println* x)
-      _ ())
-    1))
+      (StrangeThings.Piff x) false
+      _ true)))
 
 (use-all Test Vector2 Foo)
 
@@ -65,8 +64,7 @@
   (assert-true test
                (let-and-set)
                "test that nested let bindings and set! interplay nicely")
-  (assert-equal test
-                1
-                (match-ref-1)
-                "test that match-ref doesn't delete references")
+  (assert-true test
+               (match-ref-1)
+               "test that match-ref doesn't delete references")
 )


### PR DESCRIPTION
I am new to Haskell. Just met @hellerve at ZuriHac today and they pointed me to this issue: https://github.com/carp-lang/Carp/issues/843. My solution appears to fix 843 from the perspective that the example code provided in the issue now runs without exception (the generated C code no longer contains a call to `Example_delete` in the catch all block of code generated for `Match`), however I don't really understand why a deletion was taking place to begin with. I am trying to understand why a deletion may have made sense at this point... not sure if my fix breaks another test case. Thanks!

Related commit (which added the delete call): https://github.com/carp-lang/Carp/commit/c80d6429202f8437445afded85b4fafa0997b461