### PR TITLE
core: add Phantom

### DIFF
--- a/core/Phantom.carp
+++ b/core/Phantom.carp
@@ -1,0 +1,6 @@
+(deftype (Phantom a) [])
+
+(defmodule Phantom
+  (sig ensure (Fn [a (Phantom a)] a))
+  (defn ensure [a p] a)
+)

--- a/core/Phantom.carp
+++ b/core/Phantom.carp
@@ -1,6 +1,22 @@
+(doc Phantom "is a type without inhabitants and a free type variable, which is
+a fancy way of saying that it has no runtime representation.
+
+When trying to mark types programmatically using something like `the` but
+without the need for a special form, `Phantom` comes in handy.
+
+Example:
+
+```
+(defn test [a]
+  (Phantom.ensure a (the (Phantom Int) (Phantom.init))))
+
+(println* (test 123l)) ; this will not compile
+```")
 (deftype (Phantom a) [])
 
 (defmodule Phantom
+  (doc ensure "is a function that takes anything and a `Phantom`, ensuring that
+the type contained by the `Phantom` and the type of the first parameter match.")
   (sig ensure (Fn [a (Phantom a)] a))
   (defn ensure [a p] a)
 )

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pair.html
+++ b/docs/core/Pair.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Phantom.html
+++ b/docs/core/Phantom.html
@@ -171,187 +171,139 @@
                 </div>
             </div>
             <h1>
-                Debug
+                Phantom
             </h1>
             <div class="module-description">
-                
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#assert-balanced">
-                    <h3 id="assert-balanced">
-                        assert-balanced
-                    </h3>
-                </a>
-                <div class="description">
-                    macro
-                </div>
-                <p class="sig">
-                    Macro
-                </p>
-                <pre class="args">
-                    (assert-balanced form)
-                </pre>
-                <p class="doc">
-                    <p>raises an error if the memory balance (number of <code>alloc</code>s - number of <code>free</code>s) isn't <code>0</code>. Requires the flag <code>--log-memory</code> to be passed durng compilation.</p>
+                <p>is a type without inhabitants and a free type variable, which is
+a fancy way of saying that it has no runtime representation.</p>
+<p>When trying to mark types programmatically using something like <code>the</code> but
+without the need for a special form, <code>Phantom</code> comes in handy.</p>
+<p>Example:</p>
+<pre><code>(defn test [a]
+  (Phantom.ensure a (the (Phantom Int) (Phantom.init))))
 
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#check-allocations">
-                    <h3 id="check-allocations">
-                        check-allocations
-                    </h3>
-                </a>
-                <div class="description">
-                    dynamic
-                </div>
-                <p class="sig">
-                    Dynamic
-                </p>
-                <pre class="args">
-                    (check-allocations)
-                </pre>
-                <p class="doc">
-                    <p>will check the allocations made by the program
-immediately, raising a <code>SIGABRT</code> if it fails.</p>
+(println* (test 123l)) ; this will not compile
+</code></pre>
 
-                </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#leak-array">
-                    <h3 id="leak-array">
-                        leak-array
+                <a class="anchor" href="#copy">
+                    <h3 id="copy">
+                        copy
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [a] ())
+                    (Fn [(Ref (Phantom a) b)] (Phantom a))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>leaks some memory. This function is useful for testing tools that detect leaks.</p>
+                    <p>copies the <code>Phantom</code>.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#log-memory-balance!">
-                    <h3 id="log-memory-balance!">
-                        log-memory-balance!
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [Bool] ())
+                    (Fn [(Phantom a)] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
+                    <p>deletes a <code>Phantom</code>. Should usually not be called manually.</p>
+
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#memory-balance">
-                    <h3 id="memory-balance">
-                        memory-balance
+                <a class="anchor" href="#ensure">
+                    <h3 id="ensure">
+                        ensure
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    defn
                 </div>
                 <p class="sig">
-                    (Fn [] Long)
+                    (Fn [a, (Phantom a)] a)
+                </p>
+                <pre class="args">
+                    (ensure a p)
+                </pre>
+                <p class="doc">
+                    <p>is a function that takes anything and a <code>Phantom</code>, ensuring that
+the type contained by the <code>Phantom</code> and the type of the first parameter match.</p>
+
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#init">
+                    <h3 id="init">
+                        init
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [] (Phantom a))
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#memory-logged">
-                    <h3 id="memory-logged">
-                        memory-logged
-                    </h3>
-                </a>
-                <div class="description">
-                    macro
-                </div>
-                <p class="sig">
-                    Macro
-                </p>
-                <pre class="args">
-                    (memory-logged form)
-                </pre>
-                <p class="doc">
-                    <p>logs all calls to memory allocation within the form. Requires the flag <code>--log-memory</code> to be passed during compilation.</p>
+                    <p>creates a <code>Phantom</code>.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#reset-memory-balance!">
-                    <h3 id="reset-memory-balance!">
-                        reset-memory-balance!
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
                     </h3>
                 </a>
                 <div class="description">
-                    external
+                    template
                 </div>
                 <p class="sig">
-                    (Fn [] ())
+                    (Fn [(Ref (Phantom a) b)] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#sanitize-addresses">
-                    <h3 id="sanitize-addresses">
-                        sanitize-addresses
-                    </h3>
-                </a>
-                <div class="description">
-                    dynamic
-                </div>
-                <p class="sig">
-                    Dynamic
-                </p>
-                <pre class="args">
-                    (sanitize-addresses)
-                </pre>
-                <p class="doc">
-                    <p>instructs the compiler to sanitize addresses.</p>
-<p>This might not work on all compilers, but reasonably new versions of GCC and Clang are supported.</p>
+                    <p>converts a <code>Phantom</code> to a string.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#trace">
-                    <h3 id="trace">
-                        trace
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
                     </h3>
                 </a>
                 <div class="description">
-                    macro
+                    template
                 </div>
                 <p class="sig">
-                    Macro
+                    (Fn [(Ref (Phantom a) b)] String)
                 </p>
-                <pre class="args">
-                    (trace x)
-                </pre>
+                <span>
+                    
+                </span>
                 <p class="doc">
-                    <p>prints the value of an expression to <code>stdout</code>, then returns its value.</p>
+                    <p>converts a <code>Phantom</code> to a string.</p>
 
                 </p>
             </div>

--- a/docs/core/Pointer.html
+++ b/docs/core/Pointer.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Quadruple.html
+++ b/docs/core/Quadruple.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Triple.html
+++ b/docs/core/Triple.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -158,6 +158,11 @@
                                     Quadruple
                                 </a>
                             </li>
+                            <li>
+                                <a href="Phantom.html">
+                                    Phantom
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -10,6 +10,7 @@
 (load "Statistics.carp")
 (load "Test.carp")
 (load "Bench.carp")
+(load "Phantom.carp")
 
 (save-docs Dynamic
            Int
@@ -40,6 +41,7 @@
            Pair
            Triple
            Quadruple
+           Phantom
            )
 
 (quit)

--- a/test-for-errors/wrong-phantom.carp
+++ b/test-for-errors/wrong-phantom.carp
@@ -1,0 +1,7 @@
+(Project.config "file-path-print-length" "short")
+
+(load "Phantom.carp")
+
+(defn m [a] (Phantom.ensure a (the (Phantom Int) (Phantom.init))))
+
+(defn main [] (println* (m 123l)))

--- a/test/output/test-for-errors/wrong-phantom.carp.output.expected
+++ b/test/output/test-for-errors/wrong-phantom.carp.output.expected
@@ -1,0 +1,2 @@
+wrong-phantom.carp:7:28 Inferred Long, can't unify with Int.
+wrong-phantom.carp:7:26 Inferred Int, can't unify with Long.


### PR DESCRIPTION
This PR adds `Phantom` to core, which is a type that has no inhabitants but a type variable. They enable us to express type level constraints in code. Consider the example I added to the tests.

```clojure
(defn m [a] (Phantom.ensure a (the (Phantom Int) (Phantom.init))))

(println* (m 123l))
```

This will not unify, since `m` is passed a `Long`, not an `Int`, as required by the phantom. Wait, but don’t we already have `sig` and `the` to express such constraints? Yes, but Phantom types can be passed around like data, making those `ensure`s more expressive.

They also exist [in Rust](https://doc.rust-lang.org/std/marker/struct.PhantomData.html), for borrow-checking purposes, and we could add that sort of functionality if we ever add lifetime annotations, but for now they are useful as is.

Cheers