### PR TITLE
Add the Opaque type

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -49,6 +49,7 @@
 (load-once "Sort.carp")
 (load-once "Binary.carp")
 (load-once "Control.carp")
+(load-once "Opaque.carp")
 
 (not-on-windows
   (system-include "sys/wait.h")

--- a/core/Opaque.carp
+++ b/core/Opaque.carp
@@ -1,8 +1,8 @@
 (doc Opaque "The opaque type is an uninhabited type with no constructors.
 Opaque can be used to force some abstract type to range over a type constructor
-without concerning oneself with the inhabitant of the constructor--in other
-words, it may be used to enable a type to work for all inhabitants and can
-express relationships between types. It can facillitate generic programming.
+without concerning oneself with the inhabitant of the constructor. It may be
+used to enable a type to work for all inhabitants and can facillitate generic
+programming.
 
 Consider an example:
 
@@ -26,16 +26,20 @@ Consider an example:
 ```
 
 In the above example, the Opaque type allows us to define tabulate generically
-defined over Tuples without having to ensure their inhabitants match, allowing
-us to fully determine the resulting values type via tabulate's function
-argument. Without Opaque, Index would contain a generic type which would be
-unreseolved upon the call to `tabulate`. It allows us to ensure the `positions`
-we call are the positions of the correct constructor type `f` wihtout worrying
-having to restrict ourselves to only calling `Indexes` over an `f` of a
-specific type  (e.g. `(f a)`)--in other words, it allows us to constrain
-functions by constructor types only.
+over Tuples without having to ensure their inhabitants match. The result of
+tabulate is fully determined by the Index passed to it, which determines the
+constructor that will be used, and the return type of its function argument.
+Without Opaque, Index would contain a generic type which would be unreseolved
+upon the call to `tabulate` and Carp would have no means of determining which
+implementation of `positions` to use (unless we used a `the` declaration or a
+similar mechanism). Opaque allows us to ensure the `positions` we call are the
+positions of the correct constructor type `f` wihtout having to restrict
+ourselves to only calling `Indexes` over an `f` with a  specific inhabitant
+type (e.g. `(f a)`)--in other words, it allows us to constrain functions by
+constructor types only.
 
 Thanks to Opaque, tabulate can generate an `(Array Int)`, `(Array Bool)`,
-`(Array String)` all solely dependent on the return type of `h`.
+`(Array String)`, `(Maybe Bool)`, etc. all solely dependent on the return type
+of `h` and the `f` in the given `Index`.
 ")
 (deftype Opaque)

--- a/core/Opaque.carp
+++ b/core/Opaque.carp
@@ -1,0 +1,41 @@
+(doc Opaque "The opaque type is an uninhabited type with no constructors.
+Opaque can be used to force some abstract type to range over a type constructor
+without concerning oneself with the inhabitant of the constructor--in other
+words, it may be used to enable a type to work for all inhabitants and can
+express relationships between types. It can facillitate generic programming.
+
+Consider an example:
+
+```
+;; The type of indicies over containers of a single type argument
+(deftype (Index (f Opaque) b) [at b])
+
+(definterface tabulate (Fn [(Ref (Fn [(Index (f Opaque) b)] c))] (f c)))
+(definterface positions (f (Index (f Opaque) b)))
+
+(implements tabulate tabulate)
+(defn tabulate [h]
+  (fmap h @&positions))
+
+(deftype (Tuple a) [x a y a])
+
+(defmodule Tuple
+  (sig positions (Tuple (Index (Tuple Opaque) Bool)))
+  (def positions (Tuple.init (Index.init true) (Index.init false)))
+)
+```
+
+In the above example, the Opaque type allows us to define tabulate generically
+defined over Tuples without having to ensure their inhabitants match, allowing
+us to fully determine the resulting values type via tabulate's function
+argument. Without Opaque, Index would contain a generic type which would be
+unreseolved upon the call to `tabulate`. It allows us to ensure the `positions`
+we call are the positions of the correct constructor type `f` wihtout worrying
+having to restrict ourselves to only calling `Indexes` over an `f` of a
+specific type  (e.g. `(f a)`)--in other words, it allows us to constrain
+functions by constructor types only.
+
+Thanks to Opaque, tabulate can generate an `(Array Int)`, `(Array Bool)`,
+`(Array String)` all solely dependent on the return type of `h`.
+")
+(deftype Opaque)

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Array.html
+++ b/docs/core/Array.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bench.html
+++ b/docs/core/Bench.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Bool.html
+++ b/docs/core/Bool.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Byte.html
+++ b/docs/core/Byte.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Char.html
+++ b/docs/core/Char.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Debug.html
+++ b/docs/core/Debug.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Double.html
+++ b/docs/core/Double.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Dynamic.html
+++ b/docs/core/Dynamic.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Float.html
+++ b/docs/core/Float.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Geometry.html
+++ b/docs/core/Geometry.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/IO.html
+++ b/docs/core/IO.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Int.html
+++ b/docs/core/Int.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Long.html
+++ b/docs/core/Long.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Map.html
+++ b/docs/core/Map.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Maybe.html
+++ b/docs/core/Maybe.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Opaque.html
+++ b/docs/core/Opaque.html
@@ -171,30 +171,44 @@
                 </div>
             </div>
             <h1>
-                Pointer
+                Opaque
             </h1>
             <div class="module-description">
-                
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#add">
-                    <h3 id="add">
-                        add
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (Fn [(Ptr a), Long] (Ptr a))
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>adds a long integer value to a pointer.</p>
+                <p>The opaque type is an uninhabited type with no constructors.
+Opaque can be used to force some abstract type to range over a type constructor
+without concerning oneself with the inhabitant of the constructor--in other
+words, it may be used to enable a type to work for all inhabitants and can
+express relationships between types. It can facillitate generic programming.</p>
+<p>Consider an example:</p>
+<pre><code>;; The type of indicies over containers of a single type argument
+(deftype (Index (f Opaque) b) [at b])
 
-                </p>
+(definterface tabulate (Fn [(Ref (Fn [(Index (f Opaque) b)] c))] (f c)))
+(definterface positions (f (Index (f Opaque) b)))
+
+(implements tabulate tabulate)
+(defn tabulate [h]
+  (fmap h @&amp;positions))
+
+(deftype (Tuple a) [x a y a])
+
+(defmodule Tuple
+  (sig positions (Tuple (Index (Tuple Opaque) Bool)))
+  (def positions (Tuple.init (Index.init true) (Index.init false)))
+)
+</code></pre>
+<p>In the above example, the Opaque type allows us to define tabulate generically
+defined over Tuples without having to ensure their inhabitants match, allowing
+us to fully determine the resulting values type via tabulate's function
+argument. Without Opaque, Index would contain a generic type which would be
+unreseolved upon the call to <code>tabulate</code>. It allows us to ensure the <code>positions</code>
+we call are the positions of the correct constructor type <code>f</code> wihtout worrying
+having to restrict ourselves to only calling <code>Indexes</code> over an <code>f</code> of a
+specific type  (e.g. <code>(f a)</code>)--in other words, it allows us to constrain
+functions by constructor types only.</p>
+<p>Thanks to Opaque, tabulate can generate an <code>(Array Int)</code>, <code>(Array Bool)</code>,
+<code>(Array String)</code> all solely dependent on the return type of <code>h</code>.</p>
+
             </div>
             <div class="binder">
                 <a class="anchor" href="#copy">
@@ -203,196 +217,96 @@
                     </h3>
                 </a>
                 <div class="description">
-                    template
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [(Ref (Ptr a) b)] (Ptr a))
+                    (Fn [(Ref Opaque a)] Opaque)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>copies a pointer <code>p</code>.</p>
+                    <p>copies a <code>Opaque</code>.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#dec">
-                    <h3 id="dec">
-                        dec
+                <a class="anchor" href="#delete">
+                    <h3 id="delete">
+                        delete
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [(Ptr a)] (Ptr a))
-                </p>
-                <pre class="args">
-                    (dec a)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#eq">
-                    <h3 id="eq">
-                        eq
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (Fn [(Ptr a), (Ptr a)] Bool)
+                    (Fn [Opaque] ())
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>checks two pointers for equality.</p>
+                    <p>deletes a <code>Opaque</code>. This should usually not be called manually.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#from-long">
-                    <h3 id="from-long">
-                        from-long
+                <a class="anchor" href="#get-tag">
+                    <h3 id="get-tag">
+                        get-tag
                     </h3>
                 </a>
                 <div class="description">
-                    template
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [Long] (Ptr a))
+                    (Fn [(Ref Opaque a)] Int)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>converts a long integer to a pointer.</p>
+                    <p>Gets the tag from a <code>Opaque</code>.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#inc">
-                    <h3 id="inc">
-                        inc
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
                     </h3>
                 </a>
                 <div class="description">
-                    defn
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [(Ptr a)] (Ptr a))
-                </p>
-                <pre class="args">
-                    (inc a)
-                </pre>
-                <p class="doc">
-                    
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#sub">
-                    <h3 id="sub">
-                        sub
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (Fn [(Ptr a), Long] (Ptr a))
+                    (Fn [(Ref Opaque a)] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>subtracts a long integer value from a pointer.</p>
+                    <p>converts a <code>Opaque</code> to a string.</p>
 
                 </p>
             </div>
             <div class="binder">
-                <a class="anchor" href="#to-long">
-                    <h3 id="to-long">
-                        to-long
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
                     </h3>
                 </a>
                 <div class="description">
-                    template
+                    instantiate
                 </div>
                 <p class="sig">
-                    (Fn [(Ptr a)] Long)
+                    (Fn [(Ref Opaque a)] String)
                 </p>
                 <span>
                     
                 </span>
                 <p class="doc">
-                    <p>converts a pointer to a long integer.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#to-ref">
-                    <h3 id="to-ref">
-                        to-ref
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (Fn [(Ptr a)] (Ref a b))
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>converts a pointer to a reference type.</p>
-<p>The user will have to ensure themselves that this is a safe operation.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#to-value">
-                    <h3 id="to-value">
-                        to-value
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (Fn [(Ptr a)] a)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>converts a pointer to a value.</p>
-<p>The user will have to ensure themselves that this is a safe operation.</p>
-
-                </p>
-            </div>
-            <div class="binder">
-                <a class="anchor" href="#width">
-                    <h3 id="width">
-                        width
-                    </h3>
-                </a>
-                <div class="description">
-                    template
-                </div>
-                <p class="sig">
-                    (Fn [(Ptr a)] Long)
-                </p>
-                <span>
-                    
-                </span>
-                <p class="doc">
-                    <p>gets the byte size of a pointer.</p>
+                    <p>converts a <code>Opaque</code> to a string.</p>
 
                 </p>
             </div>

--- a/docs/core/Opaque.html
+++ b/docs/core/Opaque.html
@@ -163,6 +163,11 @@
                             </a>
                         </li>
                         <li>
+                            <a href="Phantom.html">
+                                Phantom
+                            </a>
+                        </li>
+                        <li>
                             <a href="Opaque.html">
                                 Opaque
                             </a>
@@ -176,9 +181,9 @@
             <div class="module-description">
                 <p>The opaque type is an uninhabited type with no constructors.
 Opaque can be used to force some abstract type to range over a type constructor
-without concerning oneself with the inhabitant of the constructor--in other
-words, it may be used to enable a type to work for all inhabitants and can
-express relationships between types. It can facillitate generic programming.</p>
+without concerning oneself with the inhabitant of the constructor. It may be
+used to enable a type to work for all inhabitants and can facillitate generic
+programming.</p>
 <p>Consider an example:</p>
 <pre><code>;; The type of indicies over containers of a single type argument
 (deftype (Index (f Opaque) b) [at b])
@@ -198,16 +203,20 @@ express relationships between types. It can facillitate generic programming.</p>
 )
 </code></pre>
 <p>In the above example, the Opaque type allows us to define tabulate generically
-defined over Tuples without having to ensure their inhabitants match, allowing
-us to fully determine the resulting values type via tabulate's function
-argument. Without Opaque, Index would contain a generic type which would be
-unreseolved upon the call to <code>tabulate</code>. It allows us to ensure the <code>positions</code>
-we call are the positions of the correct constructor type <code>f</code> wihtout worrying
-having to restrict ourselves to only calling <code>Indexes</code> over an <code>f</code> of a
-specific type  (e.g. <code>(f a)</code>)--in other words, it allows us to constrain
-functions by constructor types only.</p>
+over Tuples without having to ensure their inhabitants match. The result of
+tabulate is fully determined by the Index passed to it, which determines the
+constructor that will be used, and the return type of its function argument.
+Without Opaque, Index would contain a generic type which would be unreseolved
+upon the call to <code>tabulate</code> and Carp would have no means of determining which
+implementation of <code>positions</code> to use (unless we used a <code>the</code> declaration or a
+similar mechanism). Opaque allows us to ensure the <code>positions</code> we call are the
+positions of the correct constructor type <code>f</code> wihtout having to restrict
+ourselves to only calling <code>Indexes</code> over an <code>f</code> with a  specific inhabitant
+type (e.g. <code>(f a)</code>)--in other words, it allows us to constrain functions by
+constructor types only.</p>
 <p>Thanks to Opaque, tabulate can generate an <code>(Array Int)</code>, <code>(Array Bool)</code>,
-<code>(Array String)</code> all solely dependent on the return type of <code>h</code>.</p>
+<code>(Array String)</code>, <code>(Maybe Bool)</code>, etc. all solely dependent on the return type
+of <code>h</code> and the <code>f</code> in the given <code>Index</code>.</p>
 
             </div>
             <div class="binder">

--- a/docs/core/Pair.html
+++ b/docs/core/Pair.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pair.html
+++ b/docs/core/Pair.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pattern.html
+++ b/docs/core/Pattern.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Phantom.html
+++ b/docs/core/Phantom.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Pointer.html
+++ b/docs/core/Pointer.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Quadruple.html
+++ b/docs/core/Quadruple.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Quadruple.html
+++ b/docs/core/Quadruple.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Result.html
+++ b/docs/core/Result.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Statistics.html
+++ b/docs/core/Statistics.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/String.html
+++ b/docs/core/String.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/System.html
+++ b/docs/core/System.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Test.html
+++ b/docs/core/Test.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Triple.html
+++ b/docs/core/Triple.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Triple.html
+++ b/docs/core/Triple.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Vector2.html
+++ b/docs/core/Vector2.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/Vector3.html
+++ b/docs/core/Vector3.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -162,6 +162,11 @@
                                 Quadruple
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/VectorN.html
+++ b/docs/core/VectorN.html
@@ -167,6 +167,11 @@
                                 Phantom
                             </a>
                         </li>
+                        <li>
+                            <a href="Opaque.html">
+                                Opaque
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -158,6 +158,11 @@
                                     Quadruple
                                 </a>
                             </li>
+                            <li>
+                                <a href="Opaque.html">
+                                    Opaque
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/docs/core/core_index.html
+++ b/docs/core/core_index.html
@@ -163,6 +163,11 @@
                                     Phantom
                                 </a>
                             </li>
+                            <li>
+                                <a href="Opaque.html">
+                                    Opaque
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -42,6 +42,7 @@
            Triple
            Quadruple
            Phantom
+           Opaque
            )
 
 (quit)

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -40,6 +40,7 @@
            Pair
            Triple
            Quadruple
+           Opaque
            )
 
 (quit)


### PR DESCRIPTION
The opaque type is an uninhabited type with no constructors.  Opaque can
be used to force some abstract type to range over a type constructor
without concerning oneself with the inhabitant of the constructor--in
other words, it may be used to enable a type to work for all inhabitants
and can express relationships between types. It can facillitate generic
programming.

Consider an example:

```
;; The type of indicies over containers of a single type argument
(deftype (Index (f Opaque) b) [at b])

(definterface tabulate (Fn [(Ref (Fn [(Index (f Opaque) b)] c))] (f c)))
(definterface positions (f (Index (f Opaque) b)))

(implements tabulate tabulate)
(defn tabulate [h]
  (fmap h @&positions))

(deftype (Tuple a) [x a y a])

(defmodule Tuple
  (sig positions (Tuple (Index (Tuple Opaque) Bool)))
  (def positions (Tuple.init (Index.init true) (Index.init false)))
)
```

In the above example, the Opaque type allows us to define tabulate
generically defined over Tuples without having to ensure their
inhabitants match, allowing us to fully determine the resulting values
type via tabulate's function argument. Without Opaque, Index would
contain a generic type which would be unreseolved upon the call to
`tabulate`. It allows us to ensure the `positions` we call are the
positions of the correct constructor type `f` wihtout worrying having to
restrict ourselves to only calling `Indexes` over an `f` of a specific
type  (e.g. `(f a)`)--in other words, it allows us to constrain
functions by constructor types only.

Thanks to Opaque, tabulate can generate an `(Array Int)`, `(Array
Bool)`, `(Array String)` all solely dependent on the return type of `h`.