### PR TITLE
Implement Privacy Checking 

### DIFF
--- a/core/Format.carp
+++ b/core/Format.carp
@@ -1,4 +1,3 @@
-(private fmt-internal)
 (hidden fmt-internal)
 (defndynamic fmt-internal [s args]
   (let [idx (String.index-of s \%)

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -62,7 +62,10 @@ eval ctx xobj@(XObj o i t) =
                     Nothing -> Nothing
             tryLookup path =
                 case lookupInEnv path (contextGlobalEnv ctx) of
-                  Just (_, Binder _ found) -> return (ctx, Right (resolveDef found))
+                  Just (_, Binder meta found) ->
+                    if metaIsTrue meta "private"
+                    then return (evalError ctx ("The binding: " ++ show (getPath found) ++ " is private; it may only be used within the module that defines it.") i)
+                    else return (ctx, Right (resolveDef found))
                   Nothing ->
                     case lookupInEnv path (getTypeEnv (contextTypeEnv ctx)) of
                       Just (_, Binder _ found) -> return (ctx, Right (resolveDef found))

--- a/test-for-errors/private-bindings.carp
+++ b/test-for-errors/private-bindings.carp
@@ -3,6 +3,11 @@
 (deftype Foo [bar Int])
 (private Foo.bar)
 
+(defmodule Foo
+  (defn get [foo]
+    (Foo.bar foo))
+)
+
 (defn boo [] @(Foo.bar &(Foo.init 1)))
 
 (defn main [] (println* (Foo.bar &(Foo.init 1))))

--- a/test-for-errors/private-bindings.carp
+++ b/test-for-errors/private-bindings.carp
@@ -1,0 +1,8 @@
+(Project.config "file-path-print-length" "short")
+
+(deftype Foo [bar Int])
+(private Foo.bar)
+
+(defn boo [] @(Foo.bar &(Foo.init 1)))
+
+(defn main [] (println* (Foo.bar &(Foo.init 1))))

--- a/test/output/test-for-errors/private-bindings.carp.output.expected
+++ b/test/output/test-for-errors/private-bindings.carp.output.expected
@@ -1,2 +1,2 @@
-private-bindings.carp:6:16 The binding: Foo.bar is private; it may only be used within the module that defines it.
-private-bindings.carp:8:26 The binding: Foo.bar is private; it may only be used within the module that defines it.
+private-bindings.carp:11:16 The binding: Foo.bar is private; it may only be used within the module that defines it.
+private-bindings.carp:13:26 The binding: Foo.bar is private; it may only be used within the module that defines it.

--- a/test/output/test-for-errors/private-bindings.carp.output.expected
+++ b/test/output/test-for-errors/private-bindings.carp.output.expected
@@ -1,0 +1,2 @@
+private-bindings.carp:6:16 The binding: Foo.bar is private; it may only be used within the module that defines it.
+private-bindings.carp:8:26 The binding: Foo.bar is private; it may only be used within the module that defines it.


### PR DESCRIPTION
This implements private by adding a simple check to the evaluator and expander. If a
binding is found in the global context, we check if it's marked as
private. If so, we inform the user that it can't be called from outside
of its module.

Note that we don't perform this check if the binding is found in the
internal env, since that means it's a function called within the same
module and thus is ok (even if marked as private).

After this change, something like the following works, granting us
proper encapsulation:

```
;; File Foo.carp
(deftype Foo [bar Int])

(private Foo.bar)

(defmodule Foo
  (defn get [foo]
    (Foo.bar foo))
)

;; Enter REPL
(load "Foo.carp")
(Foo.bar &(Foo.init 1))
The binding: Foo.bar is private; it may only be used within the module
that defines it. at REPL:1:2.
@(Foo.get &(Foo.init 1))
Compiled to 'out/Untitled' (executable)
1
=> 0
```

N.B. I also had to remove a private declaration from fmt-internal--this
declaration didn't really make much sense anyway, as fmt-internal is a
global function, so module-based privacy is not enforceable.