### PR TITLE
Honor project logo and url during module doc gen

### DIFF
--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -94,6 +94,8 @@ envBinderToHtml envBinder ctx moduleName moduleNames =
   let (env, meta) = getEnvAndMetaFromBinder envBinder
       title = projectTitle ctx
       css = projectDocsStyling ctx
+      url = projectDocsURL ctx
+      logo = projectDocsLogo ctx
       moduleDescription = case Meta.get "doc" meta of
                             Just (XObj (Str s) _ _) -> s
                             Nothing -> ""
@@ -103,8 +105,8 @@ envBinderToHtml envBinder ctx moduleName moduleNames =
               H.body $
                 H.div ! A.class_ "content" $
                   do H.div ! A.class_ "logo" $
-                       do H.a ! A.href "http://github.com/carp-lang/Carp" $
-                            H.img ! A.src "logo.png"
+                       do H.a ! A.href (H.stringValue url) $
+                            H.img ! A.src (H.stringValue logo)
                           --span_ "CARP DOCS FOR"
                           H.div  ! A.class_ "title" $ toHtml title
                           moduleIndex moduleNames


### PR DESCRIPTION
Previously, some of the documentation generations specific to Carp's
core library doc generation were hardcoded in renderdocs, thus, even
though users could set their own logo and url, these weren't honored
during the generation of module documentation, resulting in a bunch of
docs pointing to logos and urls that weren't intended.

This change updates the rendering code to honor the url and logo set in
the user's Project config.