### PR TITLE
Add a `with-copy` macro

### DIFF
--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -26,6 +26,14 @@
           false
           (Dynamic.= (Symbol.from "command") (car s)))))
 
+  (doc primitive?
+    "Is this binding a primitive?")
+  (defndynamic primitive? [binding]
+    (let [s (s-expr binding)]
+      (if (empty? s)
+          false
+          (Dynamic.= (Symbol.from "primitive") (car s)))))
+
   (doc variable?
     "Is this binding a variable?")
   (defndynamic variable? [binding]
@@ -62,6 +70,8 @@
     "What's the arity of this binding?
 
     - When `binding` is a function, returns the number of arguments.
+    - When `binding` is a command, returns the number of arguments.
+    - When `binding` is a primitive, returns the number of arguments.
     - When `binding` is an interface, returns the number of arguments.
     - When `binding` is a struct, returns the number of fields.
     - When `binding` is a sumtype, returns a list of the number of type
@@ -72,6 +82,7 @@
         0
     (cond
         (Introspect.command? binding) (length (caddr s))
+        (Introspect.primitive? binding) (length (caddr s))
         (Introspect.interface? binding) (length (car (cdaddr s)))
         (Introspect.function? binding) (length (caddr s))
         (Introspect.struct? binding) (/ (length (caddr s)) 2)

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -127,42 +127,38 @@
           false
           (Dynamic.= (Symbol.from "definterface") (car s)))))
 
-  (doc proxy
-    "Returns an reference to an anonymous 'proxied' variant of `function` in
+  (doc with-copy
+    "Returns a reference to an anonymous 'proxied' variant of `function` in
   which the argument in position `arg` is *copied* from a reference before being
-  passed to `function`.
-
-  This is most useful when using higher orders that operate over structures that
-  return references to their inhabitants, such as arrays or structs. It allows
-  you to use a function over values without writing a custom anonymous function
-  to handle copying, for example:
+  passed to `function`:
 
   ```
-  (defn add [x y] (+ x y))
   ;; Array.reduce expects a function that takes a *ref* in its second argument:
   ;;   (Fn [a (Ref b c)] ...)
-  ;; so we can't use a function like `add` directly.
-  (reduce (proxy add-one 2) 0 &[1 2 3])
+  ;; so we can't use a function like `+` directly; enter proxy
+  (reduce (with-copy + 2) 0 &[1 2 3])
   => 6
   ;; compare this with an inline anonymous function that achieves the same thing:
-  (reduce &(fn [x y] (+ x @y)) 0 &[1 2 3])
+  (reduce &(fn [x y] (+ x @y)) 0 &[1 2 3]) === (reduce (with-copy + 2) 0 &[1 2 3])
   ```
 
-  Using `proxy` instead of in-situ anonymous functions may enhance readability in
-  some situations.
+  This is useful when using higher-order functions that operate over structures that
+  return *references* to their inhabitants, such as arrays or structs. It allows
+  you to use a function over values without writing a custom anonymous function
+  to handle copying.
 
   Furthermore, one can define bespoke variants for working with particular
-  higher-order functions, for instace, `reduce` always expacts a reference in the
+  higher-order functions. For instace, `reduce` always expacts a reference in the
   second positon:
 
   ```
   (defmacro reducer [function]
-    (eval (list proxy function 2)))
-  (reduce (reducer add) 0 &[1 2 3])
+    (eval (list with-copy function 2)))
+  (reduce (reducer +) 0 &[1 2 3])
   => 6
   ```
   ")
-  (defmacro proxy [function arg]
+  (defmacro with-copy [function arg]
     ;; The calls to `eval` around `function` are necessary to ensure we can execute arity.
     (let [arg-arr (Dynamic.unreduce inc 0 (Introspect.arity (eval function)) (array))
           local-names (list-to-array-internal (map gensym-local (map Symbol.from arg-arr)) [])

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -129,8 +129,8 @@
 
   (doc with-copy
     "Returns a reference to an anonymous 'proxied' variant of `function` in
-  which the argument in position `arg` is *copied* from a reference before being
-  passed to `function`:
+  which the argument in position `arg` (indexed from 0) is *copied* from a
+  reference before being passed to `function`:
 
   ```
   ;; Array.reduce expects a function that takes a *ref* in its second argument:
@@ -161,11 +161,14 @@
   (defmacro with-copy [function arg]
     ;; The calls to `eval` around `function` are necessary to ensure we can execute arity.
     (let [arg-arr (Dynamic.unreduce inc 0 (Introspect.arity (eval function)) (array))
+         ;; increment arg by 1 to simulate indexing from 0--since the
+         ;; functions we rely on here return counts
+          pos (+ arg 1)
           local-names (list-to-array-internal (map gensym-local (map Symbol.from arg-arr)) [])
-          target (gensym-local (Symbol.from arg))
+          target (gensym-local (Symbol.from pos))
           prox (list 'copy target)
           call (cons function (map (fn [x] (if (= target x) prox x)) local-names))]
-      (if (> arg (Introspect.arity (eval function)))
-          (macro-error "proxy error: the specified argument position is greater than the given function's arity.")
+      (if (> pos (Introspect.arity (eval function)))
+          (macro-error "with-copy error: the specified argument position is greater than the given function's arity.")
           (list 'ref (list 'fn local-names call)))))
 )

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -94,4 +94,50 @@
       (if (empty? s)
           false
           (Dynamic.= (Symbol.from "definterface") (car s)))))
+
+  (doc proxy
+    "Returns an reference to an anonymous 'proxied' variant of `function` in
+  which the argument in position `arg` is *copied* from a reference before being
+  passed to `function`.
+
+  This is most useful when using higher orders that operate over structures that
+  return references to their inhabitants, such as arrays or structs. It allows
+  you to use a function over values without writing a custom anonymous function
+  to handle copying, for example:
+
+  ```
+  (defn add [x y] (+ x y))
+  ;; Array.reduce expects a function that takes a *ref* in its second argument:
+  ;;   (Fn [a (Ref b c)] ...)
+  ;; so we can't use a function like `add` directly.
+  (reduce (proxy add-one 2) 0 &[1 2 3])
+  => 6
+  ;; compare this with an inline anonymous function that achieves the same thing:
+  (reduce &(fn [x y] (+ x @y)) 0 &[1 2 3])
+  ```
+
+  Using `proxy` instead of in-situ anonymous functions may enhance readability in
+  some situations.
+
+  Furthermore, one can define bespoke variants for working with particular
+  higher-order functions, for instace, `reduce` always expacts a reference in the
+  second positon:
+
+  ```
+  (defmacro reducer [function]
+    (eval (list proxy function 2)))
+  (reduce (reducer add) 0 &[1 2 3])
+  => 6
+  ```
+  ")
+  (defmacro proxy [function arg]
+    ;; The calls to `eval` around `function` are necessary to ensure we can execute arity.
+    (let [arg-arr (Dynamic.unreduce inc 0 (Introspect.arity (eval function)) (array))
+          local-names (list-to-array-internal (map gensym-local (map Symbol.from arg-arr)) [])
+          target (gensym-local (Symbol.from arg))
+          prox (list 'copy target)
+          call (cons function (map (fn [x] (if (= target x) prox x)) local-names))]
+      (if (> arg (Introspect.arity (eval function)))
+          (macro-error "proxy error: the specified argument position is greater than the given function's arity.")
+          (list 'ref (list 'fn local-names call)))))
 )

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -34,6 +34,14 @@
           false
           (Dynamic.= (Symbol.from "primitive") (car s)))))
 
+(doc external?
+    "Is this binding external?")
+  (defndynamic external? [binding]
+    (let [s (s-expr binding)]
+      (if (empty? s)
+          false
+          (Dynamic.= (Symbol.from "external") (car s)))))
+
   (doc variable?
     "Is this binding a variable?")
   (defndynamic variable? [binding]
@@ -81,6 +89,10 @@
     (if (empty? s)
         0
     (cond
+        (Introspect.external? binding)
+          (if (list? (caddr s))
+              (length (car (cdaddr s)))
+              0)
         (Introspect.command? binding) (length (caddr s))
         (Introspect.primitive? binding) (length (caddr s))
         (Introspect.interface? binding) (length (car (cdaddr s)))

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -18,6 +18,14 @@
           false
           (Dynamic.= (Symbol.from "defn") (car s)))))
 
+  (doc command?
+    "Is this binding a command?")
+  (defndynamic command? [binding]
+    (let [s (s-expr binding)]
+      (if (empty? s)
+          false
+          (Dynamic.= (Symbol.from "command") (car s)))))
+
   (doc variable?
     "Is this binding a variable?")
   (defndynamic variable? [binding]
@@ -63,6 +71,7 @@
     (if (empty? s)
         0
     (cond
+        (Introspect.command? binding) (length (caddr s))
         (Introspect.interface? binding) (length (car (cdaddr s)))
         (Introspect.function? binding) (length (caddr s))
         (Introspect.struct? binding) (/ (length (caddr s)) 2)

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -724,6 +724,9 @@ The expression must be evaluable at compile time.")
 (doc *gensym-counter* "is a helper counter for `gensym`.")
 (defdynamic *gensym-counter* 1000)
 
+(defndynamic gensym-local [x]
+  (Symbol.concat ['gensym-generated x]))
+
 (doc gensym-with "generates symbols dynamically, based on a symbol name.")
 (defndynamic gensym-with [x]
   (do

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -954,4 +954,5 @@ toSymbols (XObj (Interface _ _) i t) = (XObj (Sym (SymPath [] "definterface") Sy
 toSymbols (XObj Macro i t) = (XObj (Sym (SymPath [] "defmacro") Symbol) i t)
 toSymbols (XObj (Command _) i t) = (XObj (Sym (SymPath [] "command") Symbol) i t)
 toSymbols (XObj (Primitive _) i t) = (XObj (Sym (SymPath [] "primitive") Symbol) i t)
+toSymbols (XObj (External _) i t) = (XObj (Sym (SymPath [] "external") Symbol) i t)
 toSymbols x = x

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -58,7 +58,7 @@ addCommandConfigurable :: SymPath -> Maybe Int -> CommandCallback -> String -> S
 addCommandConfigurable path maybeArity callback doc example =
   let cmd = XObj (Lst [XObj (Command (CommandFunction f)) (Just dummyInfo) Nothing
                       ,XObj (Sym path Symbol) Nothing Nothing
-                      ,unreduceArgList
+                      ,unfoldArgs
                       ])
             (Just dummyInfo) (Just DynamicTy)
       SymPath _ name = path
@@ -74,22 +74,12 @@ addCommandConfigurable path maybeArity callback doc example =
             then callback ctx args
             else
               return (evalError ctx ("Invalid args to '" ++ show path ++ "' command: " ++ joinWithComma (map pretty args) ++ "\n\n" ++ exampleUsage) Nothing)
-        unreduceArgList =
+        unfoldArgs =
           case maybeArity of
             Just arity ->
               let tosym x = (XObj (Sym (SymPath [] x) Symbol) Nothing Nothing)
-              in  XObj (Arr (map (tosym . toArg) [1..arity])) Nothing Nothing
+              in  XObj (Arr (map (tosym . intToArgName) [1..arity])) Nothing Nothing
             Nothing -> XObj (Arr [(XObj (Sym (SymPath [] "") Symbol) Nothing Nothing)]) Nothing Nothing
-            where toArg 1 = "x"
-                  toArg 2 = "y"
-                  toArg 3 = "z"
-                  toArg 4 = "w"
-                  toArg 5 = "v"
-                  toArg 6 = "u"
-                  toArg 7 = "t"
-                  toArg 8 = "s"
-                  toArg 9 = "r"
-                  toArg n = toArg 1 ++ toArg (n `div` 10)
 
 presentError :: MonadIO m => String -> a -> m a
 presentError msg ret =
@@ -963,4 +953,5 @@ toSymbols (XObj (DefSumtype _) i t) = (XObj (Sym (SymPath [] "deftype") Symbol) 
 toSymbols (XObj (Interface _ _) i t) = (XObj (Sym (SymPath [] "definterface") Symbol) i t)
 toSymbols (XObj Macro i t) = (XObj (Sym (SymPath [] "defmacro") Symbol) i t)
 toSymbols (XObj (Command _) i t) = (XObj (Sym (SymPath [] "command") Symbol) i t)
+toSymbols (XObj (Primitive _) i t) = (XObj (Sym (SymPath [] "primitive") Symbol) i t)
 toSymbols x = x

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -58,6 +58,7 @@ addCommandConfigurable :: SymPath -> Maybe Int -> CommandCallback -> String -> S
 addCommandConfigurable path maybeArity callback doc example =
   let cmd = XObj (Lst [XObj (Command (CommandFunction f)) (Just dummyInfo) Nothing
                       ,XObj (Sym path Symbol) Nothing Nothing
+                      ,unreduceArgList
                       ])
             (Just dummyInfo) (Just DynamicTy)
       SymPath _ name = path
@@ -73,6 +74,22 @@ addCommandConfigurable path maybeArity callback doc example =
             then callback ctx args
             else
               return (evalError ctx ("Invalid args to '" ++ show path ++ "' command: " ++ joinWithComma (map pretty args) ++ "\n\n" ++ exampleUsage) Nothing)
+        unreduceArgList =
+          case maybeArity of
+            Just arity ->
+              let tosym x = (XObj (Sym (SymPath [] x) Symbol) Nothing Nothing)
+              in  XObj (Arr (map (tosym . toArg) [1..arity])) Nothing Nothing
+            Nothing -> XObj (Arr [(XObj (Sym (SymPath [] "") Symbol) Nothing Nothing)]) Nothing Nothing
+            where toArg 1 = "x"
+                  toArg 2 = "y"
+                  toArg 3 = "z"
+                  toArg 4 = "w"
+                  toArg 5 = "v"
+                  toArg 6 = "u"
+                  toArg 7 = "t"
+                  toArg 8 = "s"
+                  toArg 9 = "r"
+                  toArg n = toArg 1 ++ toArg (n `div` 10)
 
 presentError :: MonadIO m => String -> a -> m a
 presentError msg ret =
@@ -945,4 +962,5 @@ toSymbols (XObj (Deftype _) i t) = (XObj (Sym (SymPath [] "deftype") Symbol) i t
 toSymbols (XObj (DefSumtype _) i t) = (XObj (Sym (SymPath [] "deftype") Symbol) i t)
 toSymbols (XObj (Interface _ _) i t) = (XObj (Sym (SymPath [] "definterface") Symbol) i t)
 toSymbols (XObj Macro i t) = (XObj (Sym (SymPath [] "defmacro") Symbol) i t)
+toSymbols (XObj (Command _) i t) = (XObj (Sym (SymPath [] "command") Symbol) i t)
 toSymbols x = x

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -554,6 +554,13 @@ concretizeDefinition allowAmbiguity typeEnv globalEnv visitedDefinitions definit
       XObj (Lst (XObj (Deftemplate (TemplateCreator templateCreator)) _ _ : _)) _ _ ->
         let template = templateCreator typeEnv globalEnv
         in  Right (instantiateTemplate newPath concreteType template)
+      XObj (Lst [XObj (External _) _ _, _, _]) _ _ ->
+        if name == "NULL"
+        then Right (definition, []) -- A hack to make all versions of NULL have the same name
+        else let withNewPath = setPath definition newPath
+                 withNewType = withNewPath { ty = Just concreteType }
+             in  Right (withNewType, [])
+      -- TODO: This old form shouldn't be necessary, but somehow, some External xobjs are still registered without a ty xobj position.
       XObj (Lst [XObj (External _) _ _, _]) _ _ ->
         if name == "NULL"
         then Right (definition, []) -- A hack to make all versions of NULL have the same name

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -218,7 +218,7 @@ eval ctx xobj@(XObj o i t) =
               Right okArgs -> getCommand callback ctx okArgs
               Left err -> return (ctx, Left err)
 
-       x@(XObj (Lst [XObj (Primitive prim) _ _, _]) _ _):args -> (getPrimitive prim) x ctx args
+       x@(XObj (Lst [XObj (Primitive prim) _ _, _, _]) _ _):args -> (getPrimitive prim) x ctx args
 
        XObj (Lst (XObj (Defn _) _ _:_)) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))
        XObj (Lst (XObj (Interface _ _) _ _:_)) _ _:_ -> return (ctx, Left (HasStaticCall xobj i))

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -212,7 +212,7 @@ eval ctx xobj@(XObj o i t) =
               Right xobj -> macroExpand ctx' xobj
               Left err -> return (ctx, res)
 
-       XObj (Lst [XObj (Command callback) _ _, _]) _ _:args ->
+       XObj (Lst [XObj (Command callback) _ _, _, _]) _ _:args ->
          do (newCtx, evaledArgs) <- foldlM successiveEval (ctx, Right []) args
             case evaledArgs of
               Right okArgs -> getCommand callback ctx okArgs

--- a/src/Interfaces.hs
+++ b/src/Interfaces.hs
@@ -63,7 +63,7 @@ registerInInterface ctx xobj interface =
       -- Global variables can also be part of an interface
       registerInInterfaceIfNeeded ctx path interface t
       -- So can externals!
-    XObj (Lst [XObj (External _) _ _, XObj (Sym path _) _ _]) _ (Just t) ->
+    XObj (Lst [XObj (External _) _ _, XObj (Sym path _) _ _, _]) _ (Just t) ->
       registerInInterfaceIfNeeded ctx path interface t
       -- And instantiated/auto-derived type functions! (e.g. Pair.a)
     XObj (Lst [XObj (Instantiate _) _ _, XObj (Sym path _) _ _]) _ (Just t) ->

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -252,8 +252,8 @@ getPath x = SymPath [] (pretty x)
 setPath :: XObj -> SymPath -> XObj
 setPath (XObj (Lst (defn@(XObj (Defn _) _ _) : XObj (Sym _ _) si st : rest)) i t) newPath =
   XObj (Lst (defn : XObj (Sym newPath Symbol) si st : rest)) i t
-setPath (XObj (Lst [extr@(XObj (External _) _ _), XObj (Sym _ _) si st]) i t) newPath =
-  XObj (Lst [extr, XObj (Sym newPath Symbol) si st]) i t
+setPath (XObj (Lst [extr@(XObj (External _) _ _), XObj (Sym _ _) si st, ty]) i t) newPath =
+  XObj (Lst [extr, XObj (Sym newPath Symbol) si st, ty]) i t
 setPath x _ =
   error ("Can't set path on " ++ show x)
 

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -449,8 +449,10 @@ registerInternal ctx name ty override =
                                  "'") (info ty)
         -- TODO: Retroactively register in interface if implements metadata is present.
         validType t = let path = SymPath pathStrings name
-                          registration = XObj (Lst [XObj (External override) Nothing Nothing,
-                                         XObj (Sym path Symbol) Nothing Nothing]) (info ty) (Just t)
+                          registration = XObj (Lst [XObj (External override) Nothing Nothing
+                                                   ,XObj (Sym path Symbol) Nothing Nothing
+                                                   ,ty
+						   ]) (info ty) (Just t)
                           meta = existingMeta globalEnv registration
                           env' = envInsertAt globalEnv path (Binder meta registration)
                       in  (ctx { contextGlobalEnv = env' }, dynamicNil)

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -50,6 +50,7 @@ makePrim' name maybeArity docString example callback =
   let path = SymPath [] name
       prim = XObj (Lst [ XObj (Primitive (PrimitiveFunction wrapped)) (Just dummyInfo) Nothing
                        , XObj (Sym path Symbol) Nothing Nothing
+                       , unfoldArgs
                        ])
             (Just dummyInfo) (Just DynamicTy)
       meta = Meta.set "doc" (XObj (Str doc) Nothing Nothing) emptyMeta
@@ -68,6 +69,12 @@ makePrim' name maybeArity docString example callback =
             " arguments, but got " ++ show l ++ ".\n\n" ++ exampleUsage) (info x))
         doc = docString ++ "\n\n" ++ exampleUsage
         exampleUsage = "Example Usage:\n```\n" ++ example ++ "\n```\n"
+        unfoldArgs =
+          case maybeArity of
+            Just arity ->
+              let tosym x = (XObj (Sym (SymPath [] x) Symbol) Nothing Nothing)
+              in  XObj (Arr (map (tosym . intToArgName) [1..arity])) Nothing Nothing
+            Nothing -> XObj (Arr [(XObj (Sym (SymPath [] "") Symbol) Nothing Nothing)]) Nothing Nothing
 
 primitiveFile :: Primitive
 primitiveFile x@(XObj _ i t) ctx args =

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -96,3 +96,17 @@ lambdaToCName :: String -> Int -> String
 lambdaToCName name nestLevel = if nestLevel > 0
                                then name
                                else "NAKED_LAMBDA"
+
+-- Given an integer, create a dummy argument name for it.
+-- Called by XObj producing functions such as addCommand.
+intToArgName :: Int -> String
+intToArgName 1 = "x"
+intToArgName 2 = "y"
+intToArgName 3 = "z"
+intToArgName 4 = "w"
+intToArgName 5 = "v"
+intToArgName 6 = "u"
+intToArgName 7 = "t"
+intToArgName 8 = "s"
+intToArgName 9 = "r"
+intToArgName n = intToArgName 1 ++ intToArgName (n `div` 10)

--- a/test/introspect.carp
+++ b/test/introspect.carp
@@ -55,6 +55,6 @@
     "arity works as expected")
   (assert-equal test
     6
-    (Array.reduce (Introspect.with-copy add 2) 0 &[1 2 3])
+    (Array.reduce (Introspect.with-copy add 1) 0 &[1 2 3])
     "with-copy works as expected")
 )

--- a/test/introspect.carp
+++ b/test/introspect.carp
@@ -55,6 +55,6 @@
     "arity works as expected")
   (assert-equal test
     6
-    (Array.reduce (Introspect.proxy add 2) 0 &[1 2 3])
-    "proxy works as expected")
+    (Array.reduce (Introspect.with-copy add 2) 0 &[1 2 3])
+    "with-copy works as expected")
 )

--- a/test/introspect.carp
+++ b/test/introspect.carp
@@ -2,6 +2,7 @@
 (use-all Test Introspect)
 
 (defn foo [x] x)
+(defn add [x y] (+ x y))
 (def bar 2)
 (deftype Foo [x Int])
 (deftype Bar (Of [Int]))
@@ -52,4 +53,8 @@
     1
     (test-arity foo)
     "arity works as expected")
+  (assert-equal test
+    6
+    (Array.reduce (Introspect.proxy add 2) 0 &[1 2 3])
+    "proxy works as expected")
 )


### PR DESCRIPTION
It's a fairly common pattern in Carp to call a higher-order function on
some structure of values, such as an Array. However, these structures,
and their members, all have lifetimes under Carp's memory management
model, which means they expect functions that are mapped over them to
take *a reference to a value* rather than a pure value. Array.reduce is
one example of such a "referential" higher-order, the type of its
function argument is:

```
(Fn [a, (Ref b c)] a)
```

That is, this function takes some pure initial value, then expects to be
called against the members of an array, which are *references* to the
values that are alive throughout the Array's lifetime.

However, one often wants to use a function that operates on pure values
in such contexts, such as +, which forces the programmer to write
anonymous functions that handle copying referenced values to pass them
to the underlying "pure" function:

```
(Array.reduce &(fn [x y] (+ x @y)) 0 &[1 2 3])
```

So, in using some high-order function over some structure in Carp one
usually has to do two things:

1. Wrap the function in a ref
2. Handle copying references into values in order to pass them into some
   simpler function that can also be used outside of memory-bound
   contexts.

The `proxy` macro captures this pattern. It wraps a given function in a
referenced anonymous function and copies an argument of that function at
a designated position before calling the underlying function. For
example, with `proxy`, the above example becomes:

```
(Array.reduce (with-copy + 2) 0 &[1 2 3])
```

The macro effectively gives a name to a common pattern--typically it
will only save the programmer a few characters, but it perhaps makes the
act of using a "function that doesn't care about references" in a
reference dominant context more apparent.

One can also use the macro to develop more specialized macros for
certain higher-orders, since these usually dictate where copying must be
performed. For instance, the `Array.reduce` function argument always
expects the referenced value to occur in the second position, thus one
could write:

```
(defmacro reducer [function] (eval (list with-copy function 2)))
```

Then the above code becomes even simpler:

```
(Array.reduce (reducer +) 0 &[1 2 3])
```

Which roughly means, "use the + function (which has no concept of
references) in this reference dependent context".

N.B. The examples using `+` won't work as of now due to current bugs
related to calling `arity` directly on an interface--but a synonym for
plus `add` defined as an explicit function will make all the above work
as expected.