### PR TITLE
Ensure command last calls handle empty lists

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -554,8 +554,8 @@ commandCdr ctx [x] =
 commandLast :: CommandCallback
 commandLast ctx [x] =
   case x of
-    XObj (Lst lst) _ _ -> return (ctx, Right (last lst))
-    XObj (Arr arr) _ _ -> return (ctx, Right (last arr))
+    XObj (Lst lst@(x:xs)) _ _ -> return (ctx, Right (last lst))
+    XObj (Arr arr@(x:xs)) _ _ -> return (ctx, Right (last arr))
     _ ->
       return (evalError ctx "Applying 'last' to non-list or empty list." (info x))
 


### PR DESCRIPTION
The `last` command relies on Haskell's `Prelude.last`--which will crash
on an empty list input. We report an error for incorrect input to last,
but we didn't handle the empty list case. This small change to our
pattern match ensures errors in carp code produce Carp's last command
error rather than causing `Prelude.last` to throw an error on empty list
input.

fixes #897