### PR TITLE
Add doto and doto-ref

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -774,3 +774,46 @@ the program will be aborted with an error message.")
           msg)))
     (list 'System.abort)
     (list 'bottom)))
+
+(doc doto "evaluates `thing`, then calls all of the functions on `x` and
+returns it. Useful for chaining mutating, imperative functions, and thus
+similar to `->`. If you need `thing` to be passed as a `ref` into `expressions`
+functions, use [`doto-ref`](#doto-ref) instead.
+
+Example:
+
+```
+(let [x @\"hi\"]
+  @(doto &x
+    (string-set! 0 \o)
+    (string-set! 1 \y)))
+```
+")
+(defmacro doto [thing :rest expressions]
+  (let [s (gensym)]
+    (list 'let [s thing]
+      (cons-last
+        s
+        (cons 'do (map (fn [expr] (cons (car expr) (cons s (cdr expr)))) expressions))))))
+
+(doc doto-ref "evaluates `thing`, then calls all of the functions on `x` and
+returns it. Useful for chaining mutating, imperative functions, and thus
+similar to `->`. If you need `thing` not to be passed as a `ref` into
+`expressions` functions, use [`doto`](#doto) instead.
+
+Example:
+
+```
+(doto-ref @\"hi\"
+  (string-set! 0 \o)
+  (string-set! 1 \y))
+```
+")
+(defmacro doto-ref [thing :rest expressions]
+  (let [s (gensym)]
+    (list 'let [s thing]
+      (cons-last
+        s
+        (cons 'do
+          (map (fn [expr] (cons (car expr) (cons (list 'ref s) (cdr expr))))
+          expressions))))))

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -775,7 +775,7 @@ the program will be aborted with an error message.")
     (list 'System.abort)
     (list 'bottom)))
 
-(doc doto "evaluates `thing`, then calls all of the functions on `x` and
+(doc doto "evaluates `thing`, then calls all of the functions on it and
 returns it. Useful for chaining mutating, imperative functions, and thus
 similar to `->`. If you need `thing` to be passed as a `ref` into `expressions`
 functions, use [`doto-ref`](#doto-ref) instead.
@@ -796,7 +796,7 @@ Example:
         s
         (cons 'do (map (fn [expr] (cons (car expr) (cons s (cdr expr)))) expressions))))))
 
-(doc doto-ref "evaluates `thing`, then calls all of the functions on `x` and
+(doc doto-ref "evaluates `thing`, then calls all of the functions on it and
 returns it. Useful for chaining mutating, imperative functions, and thus
 similar to `->`. If you need `thing` not to be passed as a `ref` into
 `expressions` functions, use [`doto`](#doto) instead.

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -183,7 +183,7 @@ Array String_to_MINUS_bytes(const String *s) {
 String String_from_MINUS_bytes(Array *a) {
     String s;
     const char *us = (const char *)a->data;
-    s = CARP_MALLOC(a->len+1);
+    s = CARP_MALLOC(a->len + 1);
     memcpy(s, us, a->len);
     s[a->len] = '\0';
     return s;

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -309,4 +309,17 @@
   (assert-true test
                (test-dynamic-while)
                "while works as expected in dynamic code")
+  (assert-ref-equal test
+                    @"oy"
+                    (let [x @"hi"]
+                      @(doto &x
+                        (string-set! 0 \o)
+                        (string-set! 1 \y)))
+                    "doto works as expected")
+  (assert-ref-equal test
+                    @"oy"
+                    (doto-ref @"hi"
+                      (string-set! 0 \o)
+                      (string-set! 1 \y))
+                    "doto-ref works as expected")
 )


### PR DESCRIPTION
This PR adds `doto` and `doto-ref`, which are imperative versions of `->`.

Example:

```clojure
(doto-ref @\"hi\"
  (string-set! 0 \o)
  (string-set! 1 \y)) ; => "oy"
```

Test cases are included.

Cheers