### PR TITLE
Use pre-included image stack in macOS CI

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -15,9 +15,6 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/setup-haskell@v1.1
-        with:
-          stack-version: 'latest'
-          enable-stack: true
 
       - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
         shell: bash

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,6 +19,9 @@ jobs:
       - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
         shell: bash
 
+      - run:   echo stack --version 
+        shell: bash
+
       - name: Build
         run: stack build
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -22,6 +22,13 @@ jobs:
 
       - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
         shell: bash
+      
+      - uses: actions/cache@v1
+        name: Cache ~/.stack
+        with:	
+          path: ~/.stack	
+          key: ${{ runner.os }}-stack-${{ env.GITHUB_SHA }}	
+          restore-keys: ${{ runner.os }}-stack-
 
       - run:   echo stack --version 
         shell: bash

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,13 +19,6 @@ jobs:
       - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
         shell: bash
 
-      - uses: actions/cache@v1
-        name: Cache ~/.stack
-        with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-${{ env.GITHUB_SHA }}
-          restore-keys: ${{ runner.os }}-stack-
-
       - name: Build
         run: stack build
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,9 +16,9 @@ jobs:
 
       - uses: actions/setup-haskell@v1.1
         with:
-	  stack-version: '2.3.1'
-	  ghc-version: '8.8.2'
-	  enable-stack: true
+          stack-version: '2.3.1'
+          ghc-version: '8.8.2'
+          enable-stack: true
 
       - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
         shell: bash

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/setup-haskell@v1.1
+        with:
+	  stack-version: '2.3.1'
+	  ghc-version: '8.8.2'
+	  enable-stack: true
 
       - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
         shell: bash


### PR DESCRIPTION
I'm not certain that this will fix the recent build issues with the MacOS CI, but it follows the set up of the Linux CI, which has been more consistent.

I can't completely decipher the logs, but it seems like there may be some issue stemming from the fact that github's macos images [include stack](https://github.com/actions/virtual-environments/blob/macos-10.15/20200916.1/images/macos/macos-10.15-Readme.md#tools) and that we were downloading another version of stack using [setup-haskell](https://github.com/actions/setup-haskell). 

My theory is that somehow this is leading to conflicts.