### PR TITLE
Use explicit stack and GHC versions in macOS CI

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,7 +16,8 @@ jobs:
 
       - uses: actions/setup-haskell@v1.1
         with:
-          stack-version: 'latest'
+          stack-version: '2.3.1'
+          ghc-version: '8.8.2'
           enable-stack: true
 
       - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA


### PR DESCRIPTION
After some investigation, I've found that setting these versions explicitly seems to make the CI work again. I'm unfortunately not certain as to why--I think it has something to do with the cached dependencies and compatibility w/ stack and ghc versions.

At any rate, this *should* enable the CI to build successfully again.