### PR TITLE
Expand comparables in dynamic =

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -620,30 +620,49 @@ commandMacroLog ctx msgs = do
 
 commandEq :: CommandCallback
 commandEq ctx [a, b] =
-  return $ case (a, b) of
-    (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) ->
-      if (round aNum :: Int) == (round bNum :: Int)
-      then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Num LongTy aNum) _ _, XObj (Num LongTy bNum) _ _) ->
-      if (round aNum :: Int) == (round bNum :: Int)
-      then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Num FloatTy aNum) _ _, XObj (Num floatTy bNum) _ _) ->
-      if aNum == bNum
-      then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Num DoubleTy aNum) _ _, XObj (Num DoubleTy bNum) _ _) ->
-      if aNum == bNum
-      then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Str sa) _ _, XObj (Str sb) _ _) ->
-      if sa == sb then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Chr ca) _ _, XObj (Chr cb) _ _) ->
-      if ca == cb then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Sym sa _) _ _, XObj (Sym sb _) _ _) ->
-      if sa == sb then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Bol xa) _ _, XObj (Bol xb) _ _) ->
-      if xa == xb then (ctx, Right trueXObj) else (ctx, Right falseXObj)
-    (XObj (Lst []) _ _, XObj (Lst []) _ _) ->
-      (ctx, Right trueXObj)
-    _ -> evalError ctx ("Can't compare " ++ pretty a ++ " with " ++ pretty b) (info a)
+  return $ case cmp (a, b) of
+    Left (a, b) -> evalError ctx ("Can't compare " ++ pretty a ++ " with " ++ pretty b) (info a)
+    Right True -> (ctx, Right trueXObj)
+    Right False -> (ctx, Right falseXObj)
+  where
+    cmp (XObj (Num IntTy aNum) _ _, XObj (Num IntTy bNum) _ _) =
+      Right $ (round aNum :: Int) == (round bNum :: Int)
+    cmp (XObj (Num LongTy aNum) _ _, XObj (Num LongTy bNum) _ _) =
+      Right $ (round aNum :: Int) == (round bNum :: Int)
+    cmp (XObj (Num FloatTy aNum) _ _, XObj (Num floatTy bNum) _ _) =
+      Right $ aNum == bNum
+    cmp (XObj (Num DoubleTy aNum) _ _, XObj (Num DoubleTy bNum) _ _) =
+      Right $ aNum == bNum
+    cmp (XObj (Str sa) _ _, XObj (Str sb) _ _) = Right $ sa == sb
+    cmp (XObj (Chr ca) _ _, XObj (Chr cb) _ _) = Right $ ca == cb
+    cmp (XObj (Sym sa _) _ _, XObj (Sym sb _) _ _) = Right $ sa == sb
+    cmp (XObj (Bol xa) _ _, XObj (Bol xb) _ _) = Right $ xa == xb
+    cmp (XObj Def _ _, XObj Def _ _) = Right $ True
+    cmp (XObj Do _ _, XObj Do _ _) = Right $ True
+    cmp (XObj Let _ _, XObj Let _ _) = Right $ True
+    cmp (XObj While _ _, XObj While _ _) = Right $ True
+    cmp (XObj Break _ _, XObj Break _ _) = Right $ True
+    cmp (XObj If _ _, XObj If _ _) = Right $ True
+    cmp (XObj With _ _, XObj With _ _) = Right $ True
+    cmp (XObj DocStub _ _, XObj DocStub _ _) = Right $ True
+    cmp (XObj Address _ _, XObj Address _ _) = Right $ True
+    cmp (XObj SetBang _ _, XObj SetBang _ _) = Right $ True
+    cmp (XObj Macro _ _, XObj Macro _ _) = Right $ True
+    cmp (XObj Dynamic _ _, XObj Dynamic _ _) = Right $ True
+    cmp (XObj DefDynamic _ _, XObj DefDynamic _ _) = Right $ True
+    cmp (XObj The _ _, XObj The _ _) = Right $ True
+    cmp (XObj Ref _ _, XObj Ref _ _) = Right $ True
+    cmp (XObj Deref _ _, XObj Deref _ _) = Right $ True
+    cmp (XObj (Lst []) _ _, XObj (Lst []) _ _) = Right True
+    cmp (XObj (Lst elemsA) _ _, XObj (Lst elemsB) _ _) =
+      foldr cmp' (Right True) (zip elemsA elemsB)
+    cmp (XObj (Arr []) _ _, XObj (Arr []) _ _) = Right True
+    cmp (XObj (Arr elemsA) _ _, XObj (Arr elemsB) _ _) =
+      foldr cmp' (Right True) (zip elemsA elemsB)
+    cmp invalid = Left invalid
+    cmp' _ invalid@(Left _) = invalid
+    cmp' _ (Right False) = Right False
+    cmp' elem (Right True) = cmp elem
 
 commandLt :: CommandCallback
 commandLt ctx [a, b] =

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -655,10 +655,14 @@ commandEq ctx [a, b] =
     cmp (XObj Deref _ _, XObj Deref _ _) = Right $ True
     cmp (XObj (Lst []) _ _, XObj (Lst []) _ _) = Right True
     cmp (XObj (Lst elemsA) _ _, XObj (Lst elemsB) _ _) =
-      foldr cmp' (Right True) (zip elemsA elemsB)
+      if length elemsA == length elemsB
+      then foldr cmp' (Right True) (zip elemsA elemsB)
+      else Right False
     cmp (XObj (Arr []) _ _, XObj (Arr []) _ _) = Right True
     cmp (XObj (Arr elemsA) _ _, XObj (Arr elemsB) _ _) =
-      foldr cmp' (Right True) (zip elemsA elemsB)
+      if length elemsA == length elemsB
+      then foldr cmp' (Right True) (zip elemsA elemsB)
+      else Right False
     cmp invalid = Left invalid
     cmp' _ invalid@(Left _) = invalid
     cmp' _ (Right False) = Right False


### PR DESCRIPTION
This PR adds a few comparable classes to dynamic `=`: arrays, non-empty lists, and all AST types without arguments (because they’re trivially comparable).

Cheers