### PR TITLE
Eval: Make expand return the expanded form

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -798,9 +798,7 @@ commandReload ctx args = do
 
 -- | Command for expanding a form and its macros.
 commandExpand :: CommandCallback
-commandExpand ctx [xobj] = do
-  (newCtx, result) <- macroExpand ctx xobj
-  return (newCtx, result)
+commandExpand ctx [xobj] = macroExpand ctx xobj
 
 -- | This function will show the resulting C code from an expression.
 -- | i.e. (Int.+ 2 3) => "_0 = 2 + 3"

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -800,11 +800,7 @@ commandReload ctx args = do
 commandExpand :: CommandCallback
 commandExpand ctx [xobj] = do
   (newCtx, result) <- macroExpand ctx xobj
-  case result of
-    Left e -> return (newCtx, Left e)
-    Right expanded ->
-      liftIO $ do putStrLnWithColor Yellow (pretty expanded)
-                  return (newCtx, dynamicNil)
+  return (newCtx, result)
 
 -- | This function will show the resulting C code from an expression.
 -- | i.e. (Int.+ 2 3) => "_0 = 2 + 3"


### PR DESCRIPTION
Previously, `expand` only printed the results of a macro expansion to
the console. However, there are legitimate use cases for having expand
return the expanded form, particularly, when nested macro calls should
be expanded but not evaluated. Consider the following:

```clojure
(defmacro reff [] '(Ref Int <q>))

(defndynamic lt [x]
  (last x))

(defmacro wrapped [x] (lt x))
```

The above, when called with the `reff` macro as an argument, won't work
as expected, since macros don't evaluate their arguments:

```clojure
(wrapped (reff))
=> reff
```

Currently, the solution is to wrap the `lt` argument in `eval`, but this
won't work, since even though it will expand the macro, it will try to
evaluate `Ref` after the expansion!

```clojure
(defmacro wrapped [x] (lt (eval x)))

(wrapped (reff))
=> Can't find symbol 'Ref' at REPL:1:21.
```

Bummer. However, once we change expand to return a macro form instead of
echoing, we have a solution that allows us to expand a macro without
forcing an evaluation:

```clojure
(defmacro wrapped [x] (lt (expand x)))

(wrapped (reff))
=> <q>
```

This allows programmers to define macros that can take expanded macros
as arguments. Because macros never evaluate their arguments, all calls
to `expand` need to be in the body of the wrapping macro to work:

```clojure
(defmacro wrapped [x] (lt x))
(wrapped (expand (reff)))
=> (Ref Int <q>) ;; because:
;; (wrapped (expand (reff))) === (lt (expand (reff)))
;; (lt (expand (reff))) === (last (expand (reff)))
;; (last (expand (reff))) === (reff)
;; (reff) === (Ref Int <q>)
```

Expansion of values and symbols works as one might expect:

```clojure
(expand 1)
=> 1
(expand \a)
=> \a
(expand "foo")
=> "foo"
(expand [])
=> []
...etc.
```

So, if a macro designer expects a macro to be used in combination with
some other macros, `expand` can typically be applied to all arguments
without penalty.