### PR TITLE
Fixes inline-c and makes last argument optional

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -723,8 +723,7 @@
 
 (doc inline-c "Inlines some custom C code.")
 (defmacro inline-c [name defcode declcode]
-  (list 'deftemplate name (list) (eval defcode) (eval declcode)))
-
+  (eval (list 'deftemplate name (list) defcode declcode)))
 
 (deftemplate bottom (Fn [] a) "$a $NAME()" "$DECL { abort(); }")
 

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -722,8 +722,8 @@
     (list 'fn [x] (comp-internal x fns))))
 
 (doc inline-c "Inlines some custom C code.")
-(defmacro inline-c [name defcode declcode]
-  (eval (list 'deftemplate name (list) defcode declcode)))
+(defmacro inline-c [name defcode :rest declcode]
+  (eval (list 'deftemplate name (list) defcode (if (empty? declcode) "" (car declcode)))))
 
 (deftemplate bottom (Fn [] a) "$a $NAME()" "$DECL { abort(); }")
 


### PR DESCRIPTION
It seems at some point inline-c became a noop (I believe when the way macros are evaluated has changed), this PR restores the functionality.

It also makes the last argument optional as, looking through the original PR, it seems that was the original intent.

