### PR TITLE
register-type: fix for void

### DIFF
--- a/core/String.carp
+++ b/core/String.carp
@@ -459,3 +459,8 @@
   (implements prn Uint64Extra.prn)
 )
 
+(defmodule Pointer
+  (register str (Fn [(Ptr a)] String) "Pointer_str")
+  (implements str Pointer.str)
+  (defn prn [x] (Pointer.str x))
+)

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -354,3 +354,10 @@ int String_index_MINUS_of(const String *s, char c) {
      */
     return String_index_MINUS_of_MINUS_from(s, c, -1);
 }
+
+String Pointer_str(void* in) {
+    int size = snprintf(NULL, 0, "%p", in) + 1;
+    String buffer = CARP_MALLOC(size);
+    sprintf(buffer, "%p", in);
+    return buffer;
+}

--- a/docs/core/Pointer.html
+++ b/docs/core/Pointer.html
@@ -300,6 +300,44 @@
                 </p>
             </div>
             <div class="binder">
+                <a class="anchor" href="#prn">
+                    <h3 id="prn">
+                        prn
+                    </h3>
+                </a>
+                <div class="description">
+                    defn
+                </div>
+                <p class="sig">
+                    (Fn [(Ptr a)] String)
+                </p>
+                <pre class="args">
+                    (prn x)
+                </pre>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
+                <a class="anchor" href="#str">
+                    <h3 id="str">
+                        str
+                    </h3>
+                </a>
+                <div class="description">
+                    external
+                </div>
+                <p class="sig">
+                    (Fn [(Ptr a)] String)
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    
+                </p>
+            </div>
+            <div class="binder">
                 <a class="anchor" href="#sub">
                     <h3 id="sub">
                         sub

--- a/src/Validate.hs
+++ b/src/Validate.hs
@@ -45,6 +45,7 @@ canBeUsedAsMemberType typeEnv typeVariables t xobj =
     PatternTy -> return ()
     CharTy    -> return ()
     FuncTy{} -> return ()
+    PointerTy UnitTy -> return ()
     PointerTy inner -> do _ <- canBeUsedAsMemberType typeEnv typeVariables inner xobj
                           return ()
     StructTy (ConcreteNameTy "Array") [inner] -> do _ <- canBeUsedAsMemberType typeEnv typeVariables inner xobj


### PR DESCRIPTION
This PR fixes `deftype` and `register-type` for `(Ptr ())`, which is a special case. It also adds `Pointer.str` and `Pointer.prn`. @Kampouse reported this bug in #534.

Cheers