### PR TITLE
eval: catch static call error

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -899,7 +899,11 @@ primitiveEval _ ctx [val] = do
       (newCtx', expanded) <- macroExpand ctx evald
       case expanded of
         Left err -> return (newCtx', Left err)
-        Right ok -> evalDynamic newCtx' ok
+        Right ok -> do
+          (finalCtx, res) <- evalDynamic newCtx' ok
+          case res of
+            Left (HasStaticCall x i) -> return (evalError ctx ("Unexpected static call in " ++ pretty x) i)
+            _ -> return (finalCtx, res)
 
 dynamicOrMacro :: Context -> Obj -> Ty -> String -> XObj -> XObj -> IO (Context, Either EvalError XObj)
 dynamicOrMacro ctx pat ty name params body = do


### PR DESCRIPTION
This PR fixes an error in `eval` that would lead to a confusing error message being spit out: basically, if a `HasStaticCall` exception was raised, the evaluator would try again, and the error message would be that `eval` is not defined, because it isn’t, in the static context. This PR fixes the error message to actually say what the user might think.

This also means that if I define my own static function called `eval` in the REPL it will no longer be chosen as a backup, but I think this rarely happens and it would go through the primitive first, anyway, leading to confusing behavior.

Cheers