### PR TITLE
Adds unsafe-raw to StaticArray module

### DIFF
--- a/core/StaticArray.carp
+++ b/core/StaticArray.carp
@@ -212,4 +212,10 @@ If the array is empty, returns `Nothing`")
           (do
             (set! result true)
             (break))))
-      result)))
+      result))
+
+  (doc unsafe-raw "returns an array a as a raw pointer—useful for interacting with C.")
+  (deftemplate unsafe-raw (Fn [(Ref (StaticArray t))] (Ptr t))
+    "$t* $NAME(Array *a)"
+    "$DECL { return a->data; }"))
+

--- a/docs/core/StaticArray.html
+++ b/docs/core/StaticArray.html
@@ -788,6 +788,26 @@
 
                 </p>
             </div>
+            <div class="binder">
+                <a class="anchor" href="#unsafe-raw">
+                    <h3 id="unsafe-raw">
+                        unsafe-raw
+                    </h3>
+                </a>
+                <div class="description">
+                    template
+                </div>
+                <p class="sig">
+                    (Fn [(Ref (StaticArray a) b)] (Ptr a))
+                </p>
+                <span>
+                    
+                </span>
+                <p class="doc">
+                    <p>returns an array a as a raw pointer—useful for interacting with C.</p>
+
+                </p>
+            </div>
         </div>
     </body>
 </html>

--- a/test/static_array.carp
+++ b/test/static_array.carp
@@ -208,4 +208,15 @@
 
   (assert-false test
                 (contains? $[0 1 2] &100)
-                "contains? works as expected II"))
+                "contains? works as expected II")
+
+  (assert-equal test
+                &1
+                (Pointer.to-ref (unsafe-raw $[1 2 3]))
+                "unsafe-raw works as expected")
+
+  (assert-equal test
+                &2
+                (Pointer.to-ref (Pointer.inc (unsafe-raw $[1 2 3])))
+                "unsafe-raw works as expected II"))
+


### PR DESCRIPTION
Adds `unsafe-raw` to StaticArray.

Allows to use a StaticArray when interfacing with C.

