### PR TITLE
Removes usage of set-env & add-path from Github Actions workflows

### DIFF
--- a/.github/workflows/carp.yml
+++ b/.github/workflows/carp.yml
@@ -15,14 +15,11 @@ jobs:
 
     - uses: actions/setup-haskell@v1
 
-    - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
-      shell: bash
-
     - uses: actions/cache@v1
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-stack-${{ env.GITHUB_SHA }}
+        key: ${{ runner.os }}-stack-${{ github.sha }}
         restore-keys: ${{ runner.os }}-stack-
 
     - name: Build
@@ -33,3 +30,4 @@ jobs:
 
     - name: Run Carp Tests
       run: ./run_carp_tests.sh --no_sdl
+

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Linux CI
 
 on:
   push:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
-        name: Cache ~/.stack
-        with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-stack-
+      # - uses: actions/cache@v1
+      #   name: Cache ~/.stack
+      #   with:
+      #     path: ~/.stack
+      #     key: ${{ runner.os }}-stack-${{ github.sha }}
+      #     restore-keys: ${{ runner.os }}-stack-
 
       - uses: actions/setup-haskell@v1.1
         with:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,15 +13,12 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v2
-      
-      - run:   echo ::set-env name=GITHUB_SHA::$GITHUB_SHA
-        shell: bash
-      
+
       - uses: actions/cache@v1
         name: Cache ~/.stack
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-stack-${{ github.sha }}
           restore-keys: ${{ runner.os }}-stack-
 
       - uses: actions/setup-haskell@v1.1
@@ -40,3 +37,4 @@ jobs:
 
       - name: Run Carp Tests
         run: ./run_carp_tests.sh --no_sdl
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,10 +14,6 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
 
-      - name: Save git commit SHA
-        run: echo ::set-env name=GITHUB_SHA::%GITHUB_SHA%
-        shell: cmd
-
       - name: Install Scoop
         run: |
           iwr -useb get.scoop.sh | iex
@@ -31,14 +27,14 @@ jobs:
         name: Cache stack dependencies
         with:
           path: C:\\Users\\runneradmin\\AppData\\Local\\Programs\\stack
-          key: ${{ runner.os }}-stack-deps-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-stack-deps-${{ github.sha }}
           restore-keys: ${{ runner.os }}-stack-deps
 
       - uses: actions/cache@v1
         name: Cache stack build
         with:
           path: C:\\Users\\runneradmin\\AppData\\Roaming\\stack\
-          key: ${{ runner.os }}-stack-build-${{ env.GITHUB_SHA }}
+          key: ${{ runner.os }}-stack-build-${{ github.sha }}
           restore-keys: ${{ runner.os }}-stack-build
 
       - name: Install Clang

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Install Scoop
         run: |
           iwr -useb get.scoop.sh | iex
-          echo "::add-path::~\scoop\shims"
-          echo "::add-path::C:\ProgramData\scoop\shims"
+          echo "~\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\ProgramData\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Stack
         run: scoop install stack

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Carp
 
 [![Join the chat at https://gitter.im/eriksvedang/Carp](https://badges.gitter.im/eriksvedang/Carp.svg)](https://gitter.im/eriksvedang/Carp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![CI](https://github.com/carp-lang/Carp/workflows/CI/badge.svg)](https://github.com/carp-lang/Carp/actions?query=workflow%3ACI)
+[![Linux CI](https://github.com/carp-lang/Carp/workflows/Linux%20CI/badge.svg)](https://github.com/carp-lang/Carp/actions?query=workflow%3A%22Linux+CI%22)
 [![MacOS CI](https://github.com/carp-lang/Carp/workflows/MacOS%20CI/badge.svg)](https://github.com/carp-lang/Carp/actions?query=workflow%3A"MacOS+CI")
 [![Windows CI](https://github.com/carp-lang/Carp/workflows/Windows%20CI/badge.svg)](https://github.com/carp-lang/Carp/actions?query=workflow%3A"Windows+CI")
 


### PR DESCRIPTION
Both set-env and add-path are being deprecated as they are security vulnaribilities, see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
