### PR TITLE
Allow Unit to be used as a member type in deftypes

### DIFF
--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -315,7 +315,7 @@ tokensForInit allocationMode typeName membersXObjs =
                        , assignments membersXObjs
                        , "    return instance;"
                        , "}"]
-  where assignments [] =  "    instance = {0};"
+  where assignments [] = "    instance.__dummy = 0;"
         assignments xobjs = go $ unitless
           where go [] = ""
                 go xobjs = joinLines $ memberAssignment allocationMode . fst <$> xobjs

--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -309,7 +309,7 @@ tokensForInit allocationMode typeName membersXObjs =
                                            -- if this is truly a memberless struct, init it to 0;
                                            -- This can happen, e.g. in cases where *all* members of the struct are of type Unit.
                                            -- Since we do not generate members for Unit types.
-                                           [] ->  "    $p instance = {0};"
+                                           [] ->  "    $p instance = {};"
                                            _  -> "    $p instance;"
                            HeapAlloc ->  "    $p instance = CARP_MALLOC(sizeof(" ++ typeName ++ "));"
                        , assignments membersXObjs

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -582,6 +582,7 @@ incrementEnvNestLevel env = let current = envFunctionNestingLevel env
 
 -- | Converts an S-expression to one of the Carp types.
 xobjToTy :: XObj -> Maybe Ty
+xobjToTy (XObj (Sym (SymPath _ "Unit") _) _ _) = Just UnitTy
 xobjToTy (XObj (Sym (SymPath _ "Int") _) _ _) = Just IntTy
 xobjToTy (XObj (Sym (SymPath _ "Float") _) _ _) = Just FloatTy
 xobjToTy (XObj (Sym (SymPath _ "Double") _) _ _) = Just DoubleTy

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -20,6 +20,7 @@ module Types ( TypeMappings
              , consPath
              , Kind
              , tyToKind
+             , notUnit
              ) where
 
 import qualified Data.Map as Map
@@ -260,3 +261,7 @@ isFullyGenericType _ = False
 -- | The type of environments sent to Lambdas (used in emitted C code)
 lambdaEnvTy :: Ty
 lambdaEnvTy = StructTy (ConcreteNameTy "LambdaEnv") []
+
+notUnit :: Ty -> Bool
+notUnit UnitTy = False
+notUnit _ = True

--- a/src/Validate.hs
+++ b/src/Validate.hs
@@ -35,6 +35,7 @@ okXObjForType typeEnv typeVariables xobj =
 canBeUsedAsMemberType :: TypeEnv -> [Ty] -> Ty -> XObj -> Either TypeError ()
 canBeUsedAsMemberType typeEnv typeVariables t xobj =
   case t of
+    UnitTy    -> return ()
     IntTy     -> return ()
     FloatTy   -> return ()
     DoubleTy  -> return ()


### PR DESCRIPTION
This commit enables support for using values of type () (Unit) in
user-defined types such as product and sumtypes. After this commit,
types such as:

    (deftype Units [action-one () action-two ()])

Are valid, and can be instantiated in the obvious way:

    (Units.init (IO.println "foo") ())

Some important things to note about the implementation:

- The C structs emitted for types containing Unit members *completely
  omit all unit members*. If a type in Carp has N members, the
  corresponding C struct will have (N-U) members where U is the number of
  members with the type `Unit`.

  For example, this type:
   
      (deftype (Foo [one Unit two Int]))

  will produce the following typedef in C:

      typedef struct {
        int two;
      } Foo;

  As a special case, types that *only* have Units as members are represented and
  initialized as completely empty structs:

      (deftype Foo [empty Unit])

      // emits

      typedef struct {
      } Foo;

      Foo Foo_init() {
        Foo instance = {};

        return instance;
      }

   Such a type is merely a container for side effects.

- Side effects are not stored at all in the types that contain Unit
  members. Instead, any side effects will be lifted out of the emitted C
  struct and called prior to initialization.

  For example, initializing `(deftype Foo [empty Unit])` with `(Foo.init
  (IO.println "foo"))` will produce the following C:

      main(...) {
        //...
        static String _10 = "foo";
        String *_10_ref = &_10;
        IO_println(_10_ref);
        Foo _12 = Foo_init();
        //...
      }

- The typical operations on product fields are supported on Unit type
  members, but they have slightly custom semantics. Since we don't
  actually store any values of type Unit in custom types, most
  updaters/getters/setters simply run a side effect.

  This is mostly only supported to make the use of such members more
  intuitive and allow programmers to chain side-effects within some
  context, much like monadic IO in Haskell.

- Match forms also work on Unit types for parity, but again, there is no
  meaningful behavior here, since Unit only has a single type
  inhabitant.

As a bonus, this commit also makes it possible to use `Unit` and `()`
interchangeably in type signatures.