### PR TITLE
Reify: Add Unit as a special case

### DIFF
--- a/src/Reify.hs
+++ b/src/Reify.hs
@@ -35,4 +35,5 @@ instance Reifiable Ty where
   reify (PointerTy t) = XObj (Lst [literal "Ptr", reify t]) Nothing (Just TypeTy)
   reify (FuncTy ats rt lt) = XObj (Lst [literal "Fn", array ats, reify rt, lifetime lt]) Nothing (Just TypeTy)
   reify TypeTy = XObj (Sym (SymPath [] (show TypeTy)) Symbol) Nothing (Just Universe)
+  reify UnitTy = XObj (Sym (SymPath [] "Unit") Symbol) Nothing (Just TypeTy)
   reify t = XObj (Sym (SymPath [] (show t)) Symbol) Nothing (Just TypeTy)


### PR DESCRIPTION
Unit's show implementation defaults to the empty list `()`--this
presents problems when validating types, since generic type members are
replaced by the reification (a type literal) of their arguments. In the
`Unit` case, `()` yields some surprising invalid types.

So, we reify UnitTy as `Unit` instead to ensure consistency. This
permits using  Unit as a member in generic types like Result.