### PR TITLE
More Unit type member enhancements

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -50,6 +50,7 @@
 (load-once "Binary.carp")
 (load-once "Control.carp")
 (load-once "Opaque.carp")
+(load-once "Unit.carp")
 
 (posix-only
  (system-include "sys/wait.h")

--- a/core/Unit.carp
+++ b/core/Unit.carp
@@ -1,0 +1,21 @@
+(defmodule Unit
+  (implements prn prn)
+  (sig prn (Fn [Unit] String))
+  (defn prn [unit]
+    @"()")
+
+  (doc copy 
+    "'copies' a reference to a Unit value."
+    "This function just returns a fresh value of type Unit.")
+  (implements copy copy)
+  (sig copy (Fn [(Ref Unit)] Unit))
+  (defn copy [unit-ref]
+    ())
+
+  (doc zero 
+    "Returns a fresh value of type Unit (this value performs no side-effects).")
+  (implements zero zero)
+  (sig zero (Fn [] Unit))
+  (defn zero []
+    ())
+)

--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -163,10 +163,15 @@ templateGenericSetter pathStrings originalStructTy@(StructTy (ConcreteNameTy typ
           \typeEnv env ->
             Template
             t
-            (const (toTemplate "$p $NAME($p p, $t newValue)"))
+            (\(FuncTy [_, memberTy] _ _) ->
+              case memberTy of
+                UnitTy -> (toTemplate "$p $NAME($p p)")
+                _ -> (toTemplate "$p $NAME($p p, $t newValue)"))
             (\(FuncTy [_, memberTy] _ _) ->
                let callToDelete = memberDeletion typeEnv env (memberName, memberTy)
-               in  toTemplate (unlines ["$DECL {"
+               in  case memberTy of
+                   UnitTy -> toTemplate "$DECL { return p; }\n"
+                   _ -> toTemplate (unlines ["$DECL {"
                                        ,callToDelete
                                        ,"    p." ++ memberName ++ " = newValue;"
                                        ,"    return p;"
@@ -207,10 +212,15 @@ templateGenericMutatingSetter pathStrings originalStructTy@(StructTy (ConcreteNa
           \typeEnv env ->
             Template
             t
-            (const (toTemplate "void $NAME($p* pRef, $t newValue)"))
+            (\(FuncTy [_, memberTy] _ _) ->
+              case memberTy of
+                UnitTy -> (toTemplate "void $NAME($p* pRef)")
+                _ -> (toTemplate "void $NAME($p* pRef, $t newValue)"))
             (\(FuncTy [_, memberTy] _ _) ->
                let callToDelete = memberRefDeletion typeEnv env (memberName, memberTy)
-               in  toTemplate (unlines ["$DECL {"
+               in  case memberTy of
+                     UnitTy -> (toTemplate "$DECL { return; }\n")
+                     _ -> toTemplate (unlines ["$DECL {"
                                        ,callToDelete
                                        ,"    pRef->" ++ memberName ++ " = newValue;"
                                        ,"}\n"]))

--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -120,12 +120,14 @@ templateGetter member memberTy =
   Template
     (FuncTy [RefTy (VarTy "p") (VarTy "q")] (VarTy "t") StaticLifetimeTy)
     (const (toTemplate "$t $NAME($(Ref p) p)"))
-    (const $
-     let fixForVoidStarMembers =
-           if isFunctionType memberTy && not (isTypeGeneric memberTy)
-           then "(" ++ tyToCLambdaFix (RefTy memberTy (VarTy "q")) ++ ")"
-           else ""
-     in  toTemplate ("$DECL { return " ++ fixForVoidStarMembers ++ "(&(p->" ++ member ++ ")); }\n"))
+    (\(FuncTy [_] retTy _) ->
+     case retTy of
+       (RefTy UnitTy _) -> toTemplate " $DECL { void* ptr = NULL; return ptr; }\n"
+       _ -> let fixForVoidStarMembers =
+                  if isFunctionType memberTy && not (isTypeGeneric memberTy)
+                  then "(" ++ tyToCLambdaFix (RefTy memberTy (VarTy "q")) ++ ")"
+                  else ""
+            in  toTemplate ("$DECL { return " ++ fixForVoidStarMembers ++ "(&(p->" ++ member ++ ")); }\n"))
     (const [])
 
 -- | The template for setters of a concrete deftype.

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -471,12 +471,14 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
               do var <- visit indent value
                  let Just t' = t
                      fresh = mangle (freshVar i)
-                 if isNumericLiteral value
-                   then do let literal = freshVar i ++ "_lit";
-                               Just literalTy = ty value
-                           appendToSrc (addIndent indent ++ "static " ++ tyToCLambdaFix literalTy ++ " " ++ literal ++ " = " ++ var ++ ";\n")
-                           appendToSrc (addIndent indent ++ tyToCLambdaFix t' ++ " " ++ fresh ++ " = &" ++ literal ++ "; // ref\n")
-                   else appendToSrc (addIndent indent ++ tyToCLambdaFix t' ++ " " ++ fresh ++ " = &" ++ var ++ "; // ref\n")
+                 case t' of
+                   (RefTy UnitTy _) -> appendToSrc ""
+                   _ -> if isNumericLiteral value
+                          then do let literal = freshVar i ++ "_lit";
+                                      Just literalTy = ty value
+                                  appendToSrc (addIndent indent ++ "static " ++ tyToCLambdaFix literalTy ++ " " ++ literal ++ " = " ++ var ++ ";\n")
+                                  appendToSrc (addIndent indent ++ tyToCLambdaFix t' ++ " " ++ fresh ++ " = &" ++ literal ++ "; // ref\n")
+                          else appendToSrc (addIndent indent ++ tyToCLambdaFix t' ++ " " ++ fresh ++ " = &" ++ var ++ "; // ref\n")
                  return fresh
 
             -- Deref

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -552,7 +552,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
                                _ -> error ("No type on func " ++ show func)
                      FuncTy argTys retTy _ = funcTy
                      callFunction = overriddenName ++ "(" ++ argListAsC ++ ");\n"
-                 if retTy == UnitTy
+                 if not (notUnit retTy)
                    then do appendToSrc (addIndent indent ++ callFunction)
                            return ""
                    else do let varName = freshVar i
@@ -564,7 +564,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
               do argListAsC <- createArgList indent (mode == ExternalCode) args
                  let Just (FuncTy _ retTy _) = ty func
                      funcToCall = pathToC path
-                 if retTy == UnitTy
+                 if not (notUnit retTy)
                    then do appendToSrc (addIndent indent ++ funcToCall ++ "(" ++ argListAsC ++ ");\n")
                            return ""
                    else do let varName = freshVar i
@@ -591,7 +591,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
                        then tyToCLambdaFix retTy ++ "(*)(" ++ joinWithComma (map tyToCRawFunctionPtrFix (StructTy (ConcreteNameTy "LambdaEnv") [] : argTys)) ++ ")"
                        else tyToCLambdaFix retTy ++ "(*)(" ++ joinWithComma (map tyToCLambdaFix (StructTy (ConcreteNameTy "LambdaEnv") [] : argTys)) ++ ")"
                      callLambda = funcToCall ++ ".env ? ((" ++ castToFnWithEnv ++ ")" ++ funcToCall ++ ".callback)" ++ "(" ++ funcToCall ++ ".env" ++ (if null args then "" else ", ") ++ argListAsC ++ ") : ((" ++ castToFn ++ ")" ++ funcToCall ++ ".callback)(" ++ argListAsC ++ ");\n"
-                 if retTy == UnitTy
+                 if not (notUnit retTy)
                    then do appendToSrc (addIndent indent ++ callLambda)
                            return ""
                    else do let varName = freshVar i

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -275,4 +275,5 @@ lambdaEnvTy = StructTy (ConcreteNameTy "LambdaEnv") []
 
 notUnit :: Ty -> Bool
 notUnit UnitTy = False
+notUnit (RefTy UnitTy _) = False
 notUnit _ = True


### PR DESCRIPTION
- Specialize generic setter functions against Unit members
- Specialize calls to str/prn against Unit members in StructUtils
  (rather than accessing the struct member, which doesn't exist in the
  Unit case, we simple call Unit's prn function.)
- Don't bind references to Unit values to variables. This fixes an error
  whereby a reference to a Unit would generate invalid C such as:
  `void* _9 = &;`
  Likewise, we omit references to Units from function arguments just as
  we omit Unit values.

- Add `prn`, `copy`, and `zero` implementations for `Unit`