### PR TITLE
Split integer/floating point number representation.

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -819,27 +819,19 @@ commandPathAbsolute ctx [a] =
 commandPlus :: CommandCallback
 commandPlus ctx [a, b] =
   return $ case (a, b) of
-    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (INum aty (aNum + bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call + with " ++ pretty a ++ " and " ++ pretty b) (info a)
-    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (FNum aty (aNum + bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call + with " ++ pretty a ++ " and " ++ pretty b) (info a)
+    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (INum aty (aNum + bNum)) (Just dummyInfo) (Just aty)))
+    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (FNum aty (aNum + bNum)) (Just dummyInfo) (Just aty)))
     _ -> evalError ctx ("Can't call + with " ++ pretty a ++ " and " ++ pretty b) (info a)
 
 commandMinus :: CommandCallback
 commandMinus ctx [a, b] =
   return $ case (a, b) of
-    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (INum aty (aNum - bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call - with " ++ pretty a ++ " and " ++ pretty b) (info a)
-    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (FNum aty (aNum - bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call - with " ++ pretty a ++ " and " ++ pretty b) (info a)
+    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (INum aty (aNum - bNum)) (Just dummyInfo) (Just aty)))
+    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (FNum aty (aNum - bNum)) (Just dummyInfo) (Just aty)))
     _ -> evalError ctx ("Can't call - with " ++ pretty a ++ " and " ++ pretty b) (info a)
 
 commandDiv :: CommandCallback
@@ -847,27 +839,19 @@ commandDiv ctx [a, b] =
   return $ case (a, b) of
     (XObj (INum IntTy aNum) _ _, XObj (INum IntTy bNum) _ _) ->
       (ctx, Right (XObj (INum IntTy (quot aNum bNum)) (Just dummyInfo) (Just IntTy)))
-    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (INum aty (aNum `div` bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call / with " ++ pretty a ++ " and " ++ pretty b) (info a)
-    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (FNum aty (aNum / bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call / with " ++ pretty a ++ " and " ++ pretty b) (info a)
+    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (INum aty (aNum `div` bNum)) (Just dummyInfo) (Just aty)))
+    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (FNum aty (aNum / bNum)) (Just dummyInfo) (Just aty)))
     _ -> evalError ctx ("Can't call / with " ++ pretty a ++ " and " ++ pretty b) (info a)
 
 commandMul :: CommandCallback
 commandMul ctx [a, b] =
   return $ case (a, b) of
-    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (INum aty (aNum * bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call * with " ++ pretty a ++ " and " ++ pretty b) (info a)
-    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) ->
-      if aty == bty
-      then (ctx, Right (XObj (FNum aty (aNum * bNum)) (Just dummyInfo) (Just aty)))
-      else evalError ctx ("Can't call * with " ++ pretty a ++ " and " ++ pretty b) (info a)
+    (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (INum aty (aNum * bNum)) (Just dummyInfo) (Just aty)))
+    (XObj (FNum aty aNum) _ _, XObj (FNum bty bNum) _ _) | aty == bty ->
+      (ctx, Right (XObj (FNum aty (aNum * bNum)) (Just dummyInfo) (Just aty)))
     _ -> evalError ctx ("Can't call * with " ++ pretty a ++ " and " ++ pretty b) (info a)
 
 commandStr :: CommandCallback

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -547,9 +547,9 @@ commandLength :: CommandCallback
 commandLength ctx [x] =
   case x of
     XObj (Lst lst) _ _ ->
-      return (ctx, (Right (XObj (INum IntTy (fromIntegral (length lst))) Nothing Nothing)))
+      return (ctx, (Right (XObj (INum IntTy (length lst)) Nothing Nothing)))
     XObj (Arr arr) _ _ ->
-      return (ctx, (Right (XObj (INum IntTy (fromIntegral (length arr))) Nothing Nothing)))
+      return (ctx, (Right (XObj (INum IntTy (length arr)) Nothing Nothing)))
     _ ->
       return (evalError ctx ("Applying 'length' to non-list: " ++ pretty x) (info x))
 
@@ -728,7 +728,7 @@ commandIndexOf ctx [a, b] =
     (XObj (Str s) _ _, XObj (Chr c) _ _) ->
       (ctx, Right (XObj (INum IntTy (getIdx c s)) (Just dummyInfo) (Just IntTy)))
     _ -> evalError ctx ("Can't call index-of with " ++ pretty a ++ " and " ++ pretty b) (info a)
-  where getIdx c s = fromIntegral $ fromMaybe (-1) $ elemIndex c s
+  where getIdx c s = fromMaybe (-1) $ elemIndex c s
 
 commandSubstring :: CommandCallback
 commandSubstring ctx [a, b, c] =
@@ -741,7 +741,7 @@ commandStringLength :: CommandCallback
 commandStringLength ctx [a] =
   return $ case a of
     XObj (Str s) _ _ ->
-      (ctx, Right (XObj (INum IntTy (fromIntegral (length s))) (Just dummyInfo) (Just IntTy)))
+      (ctx, Right (XObj (INum IntTy (length s)) (Just dummyInfo) (Just IntTy)))
     _ -> evalError ctx ("Can't call length with " ++ pretty a) (info a)
 
 commandStringConcat :: CommandCallback
@@ -846,7 +846,7 @@ commandDiv :: CommandCallback
 commandDiv ctx [a, b] =
   return $ case (a, b) of
     (XObj (INum IntTy aNum) _ _, XObj (INum IntTy bNum) _ _) ->
-      (ctx, Right (XObj (INum IntTy (fromIntegral (quot aNum bNum))) (Just dummyInfo) (Just IntTy)))
+      (ctx, Right (XObj (INum IntTy (quot aNum bNum)) (Just dummyInfo) (Just IntTy)))
     (XObj (INum aty aNum) _ _, XObj (INum bty bNum) _ _) ->
       if aty == bty
       then (ctx, Right (XObj (INum aty (aNum `div` bNum)) (Just dummyInfo) (Just aty)))
@@ -922,7 +922,7 @@ commandWriteFile ctx [filename, contents] =
 
 commandHostBitWidth :: CommandCallback
 commandHostBitWidth ctx [] =
-  let bitSize = fromIntegral (finiteBitSize (undefined :: Int))
+  let bitSize = finiteBitSize (undefined :: Int)
   in return (ctx, Right (XObj (INum IntTy bitSize) (Just dummyInfo) (Just IntTy)))
 
 commandSaveDocsInternal :: CommandCallback

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -102,12 +102,13 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             Lst _   -> visitList indent xobj
             Arr _   -> visitArray indent xobj
             StaticArr _ -> visitStaticArray indent xobj
-            Num IntTy num -> return (show (round num :: Int))
-            Num LongTy num -> return (show (round num :: Int) ++ "l")
-            Num ByteTy num -> return (show (round num :: Int))
-            Num FloatTy num -> return (show num ++ "f")
-            Num DoubleTy num -> return (show num)
-            Num _ _ -> error "Can't emit invalid number type."
+            INum IntTy num -> return (show num)
+            INum LongTy num -> return (show num ++ "l")
+            INum ByteTy num -> return (show num)
+            INum _ _ -> error "Can't emit invalid number type."
+            FNum FloatTy num -> return (show num ++ "f")
+            FNum DoubleTy num -> return (show num)
+            FNum _ _ -> error "Can't emit invalid number type."
             Bol b -> return (if b then "true" else "false")
             Str _ -> visitString indent xobj
             Pattern _ -> visitString indent xobj

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -858,7 +858,7 @@ buildMainFunction xobj =
                                                  XObj (Lst [XObj Ref di Nothing, xobj])
                                                  di (Just UnitTy)])
                                       di (Just UnitTy)
-                        , XObj (Num IntTy 0) di Nothing
+                        , XObj (INum IntTy 0) di Nothing
                         ]) di Nothing]) di (Just (FuncTy [] UnitTy StaticLifetimeTy))
   where di = Just dummyInfo
 

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -68,7 +68,8 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
   where
     visit :: Env -> XObj -> State Integer (Either TypeError XObj)
     visit env xobj = case obj xobj of
-                       (Num t _)          -> return (Right (xobj { ty = Just t }))
+                       (INum t _)         -> return (Right (xobj { ty = Just t }))
+                       (FNum t _)         -> return (Right (xobj { ty = Just t }))
                        (Bol _)            -> return (Right (xobj { ty = Just BoolTy }))
                        (Str _)            -> do lt <- genVarTy
                                                 return (Right (xobj { ty = Just (RefTy StringTy lt) }))

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -63,7 +63,7 @@ double = do (i, num) <- maybeSigned
             incColumn 1
             decimals <- Parsec.many1 Parsec.digit
             incColumn (length decimals)
-            return (XObj (Num DoubleTy (read (num ++ "." ++ decimals))) i Nothing)
+            return (XObj (FNum DoubleTy (read (num ++ "." ++ decimals))) i Nothing)
 
 float :: Parsec.Parsec String ParseState XObj
 float = do (i, num) <- maybeSigned
@@ -73,30 +73,30 @@ float = do (i, num) <- maybeSigned
            incColumn (length decimals)
            _ <- Parsec.char 'f'
            incColumn 1
-           return (XObj (Num FloatTy (read (num ++ "." ++ decimals))) i Nothing)
+           return (XObj (FNum FloatTy (read (num ++ "." ++ decimals))) i Nothing)
 
 floatNoPeriod :: Parsec.Parsec String ParseState XObj
 floatNoPeriod =
   do (i, num) <- withBases
      _ <- Parsec.char 'f'
      incColumn 1
-     return (XObj (Num FloatTy (read num)) i Nothing)
+     return (XObj (FNum FloatTy (read num)) i Nothing)
 
 integer :: Parsec.Parsec String ParseState XObj
 integer = do (i, num) <- withBases
-             return (XObj (Num IntTy (read num)) i Nothing)
+             return (XObj (INum IntTy (read num)) i Nothing)
 
 byte :: Parsec.Parsec String ParseState XObj
 byte = do (i, num) <- withBases
           _ <- Parsec.char 'b'
           incColumn 1
-          return (XObj (Num ByteTy (read num)) i Nothing)
+          return (XObj (INum ByteTy (read num)) i Nothing)
 
 long :: Parsec.Parsec String ParseState XObj
 long = do (i, num) <- withBases
           _ <- Parsec.char 'l'
           incColumn 1
-          return (XObj (Num LongTy (read num)) i Nothing)
+          return (XObj (INum LongTy (read num)) i Nothing)
 
 number :: Parsec.Parsec String ParseState XObj
 number = Parsec.try float <|>

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -104,7 +104,7 @@ primitiveLine x@(XObj _ i t) ctx args =
                             ("`line` expected 0 or 1 arguments, but got " ++ show (length args))
                             (info x)
   where err = evalError ctx ("No information about object " ++ pretty x) (info x)
-        go  = maybe err (\info -> (ctx, Right (XObj (INum IntTy (fromIntegral (infoLine info))) i t)))
+        go  = maybe err (\info -> (ctx, Right (XObj (INum IntTy (infoLine info)) i t)))
 
 primitiveColumn :: Primitive
 primitiveColumn x@(XObj _ i t) ctx args =
@@ -115,7 +115,7 @@ primitiveColumn x@(XObj _ i t) ctx args =
                  ("`column` expected 0 or 1 arguments, but got " ++ show (length args))
                  (info x)
   where err = evalError ctx ("No information about object " ++ pretty x) (info x)
-        go  = maybe err (\info -> (ctx, Right (XObj (INum IntTy (fromIntegral (infoColumn info))) i t)))
+        go  = maybe err (\info -> (ctx, Right (XObj (INum IntTy (infoColumn info)) i t)))
 
 primitiveImplements :: Primitive
 primitiveImplements xobj ctx [x@(XObj (Sym interface@(SymPath _ _) _) _ _), i@(XObj (Sym impl@(SymPath _ _) _) _ _)] =

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -104,7 +104,7 @@ primitiveLine x@(XObj _ i t) ctx args =
                             ("`line` expected 0 or 1 arguments, but got " ++ show (length args))
                             (info x)
   where err = evalError ctx ("No information about object " ++ pretty x) (info x)
-        go  = maybe err (\info -> (ctx, Right (XObj (Num IntTy (fromIntegral (infoLine info))) i t)))
+        go  = maybe err (\info -> (ctx, Right (XObj (INum IntTy (fromIntegral (infoLine info))) i t)))
 
 primitiveColumn :: Primitive
 primitiveColumn x@(XObj _ i t) ctx args =
@@ -115,7 +115,7 @@ primitiveColumn x@(XObj _ i t) ctx args =
                  ("`column` expected 0 or 1 arguments, but got " ++ show (length args))
                  (info x)
   where err = evalError ctx ("No information about object " ++ pretty x) (info x)
-        go  = maybe err (\info -> (ctx, Right (XObj (Num IntTy (fromIntegral (infoColumn info))) i t)))
+        go  = maybe err (\info -> (ctx, Right (XObj (INum IntTy (fromIntegral (infoColumn info))) i t)))
 
 primitiveImplements :: Primitive
 primitiveImplements xobj ctx [x@(XObj (Sym interface@(SymPath _ _) _) _ _), i@(XObj (Sym impl@(SymPath _ _) _) _ _)] =


### PR DESCRIPTION
Something like this would help with problems like the one mentioned in #995, since 64bit integers won't be representable with a `Double`.