### PR TITLE
Pointer: Add utility functions

### DIFF
--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -23,7 +23,7 @@ The user will have to ensure themselves that this is a safe operation.")
   (doc unsafe-set
     "Sets the value of a pointer to a value of any type."
     "The user will have to ensure this operation is safe.")
-  (deftemplate unsafe-set (Fn [(Ptr p) (Ref a b)] (Ptr p)) "$p* $NAME($p* p, void* a)" "$DECL { *p = *($p*)a; return p;}")
+  (deftemplate unsafe-set (Fn [(Ptr p) a] (Ptr p)) "$p* $NAME($p* p, $a a)" "$DECL { *p = ($p)a; return p;}")
 
   (doc unsafe-alloc
      "Allocate a new pointer to the value `a`."

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -23,7 +23,7 @@ The user will have to ensure themselves that this is a safe operation.")
   (doc unsafe-set
     "Sets the value of a pointer to a value of any type."
     "The user will have to ensure this operation is safe.")
-  (deftemplate unsafe-set (Fn [(Ptr p) a] (Ptr p)) "$p* $NAME($p* p, $a a)" "$DECL { *p = ($p)a; return p;}")
+  (deftemplate unsafe-set (Fn [(Ptr p) a] Unit) "void $NAME($p* p, $a a)" "$DECL { *p = ($p)a; }")
 
   (doc unsafe-alloc
      "Allocate a new pointer to the value `a`."

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -32,7 +32,11 @@ The user will have to ensure themselves that this is a safe operation.")
      ""
      ("See `Unsafe.leak` if you want to prevent Carp's automatic destructuring " false)
      "on a value without performing an allocation.")
-  (deftemplate unsafe-alloc (Fn [a] (Ptr a)) "$a* $NAME($a r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); leak = r; return ($a*)leak;}")
+  (deftemplate unsafe-alloc (Fn [a] (Ptr a)) "$a* $NAME($a r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); *($a*)leak= r; return ($a*)leak;}")
+
+  (doc unsafe-realloc
+    "Reallocate an existing pointer in-place.")
+  (deftemplate unsafe-realloc (Fn [(Ptr p) a] Unit) "$void $NAME($p* p, $a x)" "$DECL { *($a*)p = CARP_MALLOC(sizeof($a)); }")
 
   (doc free
      "Free a pointer."

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -34,10 +34,6 @@ The user will have to ensure themselves that this is a safe operation.")
      "on a value without performing an allocation.")
   (deftemplate unsafe-alloc (Fn [a] (Ptr a)) "$a* $NAME($a r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); *($a*)leak= r; return ($a*)leak;}")
 
-  (doc unsafe-realloc
-    "Reallocate an existing pointer in-place.")
-  (deftemplate unsafe-realloc (Fn [(Ptr p) a] Unit) "$void $NAME($p* p, $a x)" "$DECL { *($a*)p = CARP_MALLOC(sizeof($a)); }")
-
   (doc free
      "Free a pointer."
      "Users need to manually verify that this operation is safe.")

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -20,20 +20,19 @@ The user will have to ensure themselves that this is a safe operation.")
   (doc from-long "converts a long integer to a pointer.")
   (deftemplate from-long (Fn [Long] (Ptr p)) "$p* $NAME(Long p)" " $DECL { return ($p*)p; }")
 
-  (doc set-unsafe
-    "Sets the value of a pointer."
+  (doc unsafe-set
+    "Sets the value of a pointer to a value of any type."
     "The user will have to ensure this operation is safe.")
-  (deftemplate set-unsafe (Fn [(Ptr p) (Ref a b)] (Ptr p)) "$p* $NAME($p* p, void* a)" "$DECL { *p = *($p*)a; return p;}")
+  (deftemplate unsafe-set (Fn [(Ptr p) (Ref a b)] (Ptr p)) "$p* $NAME($p* p, void* a)" "$DECL { *p = *($p*)a; return p;}")
 
-  (doc cast
-     "Cast a pointer to type p to a pointer to type a."
-     "The value of the `a` argument is ignored.")
-  (deftemplate cast (Fn [(Ptr p) a] (Ptr a)) "$a* $NAME($p* p, $a a)" "$DECL { *($a*)p = CARP_MALLOC(sizeof($a)); return ($a*)p;}")
-
-  (doc leak
-     "Allocate a new pointer that's a copy of the value of `Ref`"
-     "The Carp borrow checker won't delete this pointer. You will need to delete it manually by calling `Pointer.free`.")
-  (deftemplate leak (Fn [a] (Ptr a)) "$a* $NAME($a r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); leak = r; return ($a*)leak;}")
+  (doc unsafe-alloc
+     "Allocate a new pointer to the value `a`."
+     ("This pointer won't be managed by Carp's borrow checker and will cause leaks " false)
+     "unless explicitly freed."
+     ""
+     ("See `Unsafe.leak` if you want to prevent Carp's automatic destructuring " false)
+     "on a value without performing an allocation.")
+  (deftemplate unsafe-alloc (Fn [a] (Ptr a)) "$a* $NAME($a r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); leak = r; return ($a*)leak;}")
 
   (doc free
      "Free a pointer."

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -20,6 +20,29 @@ The user will have to ensure themselves that this is a safe operation.")
   (doc from-long "converts a long integer to a pointer.")
   (deftemplate from-long (Fn [Long] (Ptr p)) "$p* $NAME(Long p)" " $DECL { return ($p*)p; }")
 
+  (doc set-unsafe
+    "Sets the value of a pointer."
+    "The user will have to ensure this operation is safe.")
+  (deftemplate set-unsafe (Fn [(Ptr p) (Ref a b)] (Ptr p)) "$p* $NAME($p* p, void* a)" "$DECL { *p = *($p*)a; return p;}")
+
+  (doc cast
+     "Cast a pointer to type p to a pointer to type a."
+     "The value of the `a` argument is ignored.")
+  (deftemplate cast (Fn [(Ptr p) a] (Ptr a)) "$a* $NAME($p* p, $a a)" "$DECL { *($a*)p = CARP_MALLOC(sizeof($a)); return ($a*)p;}")
+
+  (doc leak
+     "Allocate a new pointer that's a copy of the value of `Ref`"
+     "The Carp borrow checker won't delete this pointer. You will need to delete it manually by calling `Pointer.free`.")
+  (deftemplate leak (Fn [(Ref a b)] (Ptr a)) "$a* $NAME($a* r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); memcpy(leak, r, sizeof($a)); return ($a*)leak;}")
+
+  (doc free
+     "Free a pointer."
+     "Users need to manually verify that this operation is safe.")
+  (deftemplate free (Fn [(Ptr p)] Unit) "void $NAME($p* p)" "$DECL {CARP_FREE(p);}")
+
+  (doc set "Sets the value of a pointer.")
+  (deftemplate set (Fn [(Ptr p) p] (Ptr p)) "$p* $NAME($p* p, $p a)" "$DECL { *p = a; return p;}")
+
   (defn inc [a] (Pointer.add a 1l))
   (implements inc Pointer.inc)
   (defn dec [a] (Pointer.sub a 1l))

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -44,7 +44,7 @@ The user will have to ensure themselves that this is a safe operation.")
   (deftemplate free (Fn [(Ptr p)] Unit) "void $NAME($p* p)" "$DECL {CARP_FREE(p);}")
 
   (doc set "Sets the value of a pointer.")
-  (deftemplate set (Fn [(Ptr p) p] (Ptr p)) "$p* $NAME($p* p, $p a)" "$DECL { *p = a; return p;}")
+  (deftemplate set (Fn [(Ptr p) p] Unit) "void $NAME($p* p, $p a)" "$DECL { *p = a; }")
 
   (defn inc [a] (Pointer.add a 1l))
   (implements inc Pointer.inc)

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -33,7 +33,7 @@ The user will have to ensure themselves that this is a safe operation.")
   (doc leak
      "Allocate a new pointer that's a copy of the value of `Ref`"
      "The Carp borrow checker won't delete this pointer. You will need to delete it manually by calling `Pointer.free`.")
-  (deftemplate leak (Fn [(Ref a b)] (Ptr a)) "$a* $NAME($a* r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); memcpy(leak, r, sizeof($a)); return ($a*)leak;}")
+  (deftemplate leak (Fn [a] (Ptr a)) "$a* $NAME($a r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); leak = r; return ($a*)leak;}")
 
   (doc free
      "Free a pointer."

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -27,16 +27,33 @@ The user will have to ensure themselves that this is a safe operation.")
 
   (doc unsafe-alloc
      "Allocate a new pointer to the value `a`."
-     ("This pointer won't be managed by Carp's borrow checker and will cause leaks " false)
-     "unless explicitly freed."
+     ("This pointer won't be managed by Carp's borrow checker and will cause " false)
+     "memory leaks unless explicitly freed using `Pointer.free`."
      ""
-     ("See `Unsafe.leak` if you want to prevent Carp's automatic destructuring " false)
-     "on a value without performing an allocation.")
+     ("See `Unsafe.leak` if you want to prevent Carp's automatic memory management " false)
+     "from deallocating a value without performing an allocation."
+     ""
+     "```"
+     "(let-do [x (Pointer.unsafe-alloc @\"c\")]"
+     "  (Pointer.set x @\"carp\")"
+     "  (println* (Pointer.to-value x))"
+     "  (Pointer.free x))"
+     "```")
   (deftemplate unsafe-alloc (Fn [a] (Ptr a)) "$a* $NAME($a r)" "$DECL { void *leak = CARP_MALLOC(sizeof($a)); *($a*)leak= r; return ($a*)leak;}")
 
   (doc free
-     "Free a pointer."
-     "Users need to manually verify that this operation is safe.")
+     "Free a pointer, deallocating the memory associated with it."
+     ("Carp's borrow checker handles deallocation automatically for managed types. " false)
+     ("The Ptr type is unmanaged, so pointers allocated with functions " false)
+     "such as `Pointer.unsafe-alloc` need to be deallocated manually using this function."
+     "Users need to manually verify that this operation is safe."
+     ""
+     "```"
+     "(let-do [x (Pointer.unsafe-alloc @\"c\")]"
+     "  (Pointer.set x @\"carp\")"
+     "  (println* (Pointer.to-value x))"
+     "  (Pointer.free x))"
+     "```")
   (deftemplate free (Fn [(Ptr p)] Unit) "void $NAME($p* p)" "$DECL {CARP_FREE(p);}")
 
   (doc set "Sets the value of a pointer.")

--- a/core/System.carp
+++ b/core/System.carp
@@ -4,8 +4,6 @@
 (defmodule System
   (doc carp-init-globals "Initializes all global variables (in correct order, based on interdependencies). Called automatically by `main` if the project is compiled as an executable. Client code needs to call this function manually when using a library written in Carp.")
   (register carp-init-globals (Fn [Int Int] ()) "carp_init_globals")
-  (doc free "Frees an object. Should not be called except in direst circumstances.")
-  (register free (Fn [t] ()))
   (doc time "Gets the current system time as an integer.")
   (register time (Fn [] Int))
   (doc nanotime "Gets the current system time in nanoseconds as a long.")


### PR DESCRIPTION
This commit adds a few more utility functions to `Pointer.carp`.

- Pointer.set-unsafe: Sets the value of a pointer to some arbitrary Carp
  value, without type checking. Users need to ensure this operation is
  safe.
- Pointer.set: Sets the value of a pointer to a value of type t to a
  value that has the same type.
- Pointer.unsafe-alloc: Copies a Carp reference to a new pointer to the same
  value. This creates a leak since Carp will not automatically clean up
  this memory.
- Pointer.free: Frees a pointer p. Users need to ensure calls to this
  function are safe and do not produce errors like a double free.
  Intended for use with leak.

Here's an example of some of these functions in action:

```
(defn foo []
  (let-do [p (Pointer.leak "leaky")] ;; create a new pointer
    (ignore (Pointer.set p @"foo")) ;; set the pointer to "foo"
    (println* (Pointer.to-value p)) ;; convert to a Carp val to print
    (Pointer.free p) ;; finally, free it.
    0))
(foo)
=> Compiled to 'out/Untitled' (executable)
foo
0
```

And the C of interest:

```
int foo() {
    int _35;
    /* let */ {
        static String _6 = "leaky";
        String *_6_ref = &_6;
        String* _7 = Pointer_leak__String(_6_ref);
        String* p = _7;
        /* let */ {
            static String _15 = "foo";
            String *_15_ref = &_15;
            String _16 = String_copy(_15_ref);
            String* _17 = Pointer_set__String(p, _16);
            String* _ = _17;
            /* () */
        }
        String _26 = Pointer_to_MINUS_value__String(p);
        String _27 = StringCopy_str(_26);
        String* _28 = &_27; // ref
        IO_println(_28);
        Pointer_free__String(p);
        int _34 = 0;
        _35 = _34;
        String_delete(_27);
    }
    return _35;
}
```

As mentioned, and as w/ other Pointer functions users need to ensure the
safety of these operations themselves. For example, calling `free` on
`p` twice in the example above produces the expected double free:

```
(defn foo []
  (let-do [p (Pointer.leak "leaky")] ;; create a new pointer
    (ignore (Pointer.set p @"foo")) ;; set the pointer to "foo"
    (println* (Pointer.to-value p)) ;; convert to a Carp val to print
    (Pointer.free p) ;; finally, free it.
    (Pointer.free p) ;; !Double free!
    0))
(foo)
Compiled to 'out/Untitled' (executable)
foo
Untitled(38328,0x10d9a1dc0) malloc: *** error for object 0x7feb86c01790:
pointer being freed was not allocated
Untitled(38328,0x10d9a1dc0) malloc: *** set a breakpoint in
malloc_error_break to debug
[RUNTIME ERROR] '"out/Untitled"' exited with return value -6.
```

Still, these should come in handy in rare cases in which users need to
circumvent the type checker or borrow checker.