### PR TITLE
Adds functions to help with callbacks based C interop

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -21,6 +21,7 @@
 (load-once "Introspect.carp")
 (load-once "Pointer.carp")
 (load-once "Unsafe.carp")
+(load-once "Function.carp")
 (load-once "Generics.carp")
 (load-once "Maybe.carp")
 (load-once "Result.carp")

--- a/core/Function.carp
+++ b/core/Function.carp
@@ -1,0 +1,7 @@
+(defmodule Function
+  (doc unsafe-ptr "returns void pointer to the function passed in."
+                 "This is unsafe as unsafe-ptr can't check the value passed in is a function.")
+  (deftemplate unsafe-ptr (Fn [(Ref a)] (Ptr ())) "void* $NAME($a *fn)" "$DECL { return fn->callback; }")
+  (doc unsafe-env-ptr "returns void pointer to the environment captured by a lambda."
+                   "This is unsafe as unsafe-env-ptr can't check the value passed in is a function.")
+  (deftemplate unsafe-env-ptr (Fn [(Ref a)] (Ptr ())) "void* $NAME($a *fn)" "$DECL { return fn->env; }"))

--- a/test/function.carp
+++ b/test/function.carp
@@ -1,0 +1,20 @@
+(load-and-use Test)
+
+(deftemplate runner (Fn [(Ptr ()) (Ptr ())] a)
+                    "$a $NAME(void* fn, void* args)"
+                    "$a $NAME(void* fnptr, void* args) {
+                       return (($a(*)(void*))fnptr)(args);
+                    }")
+
+(deftest test
+  (assert-equal test
+                (let [x 42 fnfn (fn [] @&x)]
+                  (runner (Function.unsafe-ptr &fnfn) (Function.unsafe-env-ptr &fnfn)))
+                42
+                "Function.unsafe-ptr & Function.unsafe-env-ptr works as expected")
+
+  (assert-equal test
+                (let [x 42 fnfn (fn [y] (Int.copy y))]
+                  (runner (Function.unsafe-ptr &fnfn) (Unsafe.coerce &x)))
+                42
+                "Function.unsafe-ptr & Unsafe.coerce works as expected"))


### PR DESCRIPTION
I'm not sure if this the best way to go at it. This PR is more of a request for feedback.

Enables to bind to callback based API, like `pthread_create`:

```clojure
(register create-c (Fn [(Ref Thread) (Ptr ()) (Ptr ()) (Ptr ())] Int) "pthread_create")

(sig create-from-handle (Fn [(Ref Thread) (Ref (Fn [] ()))] (Result () Int)))
(defn create-from-handle [thread fun]
  (let [error-code (create-c thread
                             NULL
                             (Pointer.from-fn fun)
                             (Pointer.env-from-fn fun))]
    (if (= 0 error-code)
        (Success ())
        (Error error-code))))
```