### PR TITLE
Refactor error reporting and add CARP_DIR check

### DIFF
--- a/scripts/carp.sh
+++ b/scripts/carp.sh
@@ -9,4 +9,5 @@ then
     fi
     CARP="$CARP $BUILD_OPTS --"
 fi
+export CARP_DIR=`pwd`
 $CARP $CARP_OPTS "$@"

--- a/src/ColorText.hs
+++ b/src/ColorText.hs
@@ -1,6 +1,7 @@
 module ColorText where
 
 import System.Console.ANSI hiding (Blue, Red, Yellow, Green, White)
+import System.Exit (exitFailure)
 import System.IO
 
 import Util
@@ -28,3 +29,23 @@ putStrWithColor color str =
 
 putStrLnWithColor :: TextColor -> String -> IO ()
 putStrLnWithColor color str = putStrWithColor color (str ++ "\n")
+
+labelStr :: String -> String -> String
+labelStr label str = "[" ++ label ++ "] " ++ str
+
+emitWarning :: String -> IO ()
+emitWarning str = putStrLnWithColor Blue (labelStr "WARNING" str)
+
+emitErrorWithLabel :: String -> String -> IO ()
+emitErrorWithLabel label str = putStrLnWithColor Red (labelStr label str)
+
+emitError :: String -> IO ()
+emitError str = emitErrorWithLabel "ERROR" str
+
+emitErrorBare :: String -> IO ()
+emitErrorBare str = putStrLnWithColor Red str
+
+emitErrorAndExit :: String -> IO a
+emitErrorAndExit str = do
+  _ <- emitError str
+  exitFailure

--- a/src/Interfaces.hs
+++ b/src/Interfaces.hs
@@ -8,6 +8,7 @@ module Interfaces (registerInInterfaceIfNeeded,
 
 import Data.Either (isRight)
 
+import ColorText
 import Obj
 import Lookup
 import Types
@@ -20,12 +21,18 @@ data InterfaceError = KindMismatch SymPath Ty Ty
                     | NonInterface SymPath
 
 instance Show InterfaceError where
-  show (KindMismatch path definitionSignature interfaceSignature) = "[INTERFACE ERROR] " ++ show path ++ ":" ++ " One or more types in the interface implementation " ++
-                                                                    show definitionSignature ++ " have kinds that do not match the kinds of the types in the interface signature " ++
-                                                                    show interfaceSignature ++ "\n" ++ "Types of the form (f a) must be matched by constructor types such as (Maybe a)"
-  show (TypeMismatch path definitionSignature interfaceSignature) = "[INTERFACE ERROR] " ++ show path ++ " : " ++ show definitionSignature ++
-                                                                  " doesn't match the interface signature " ++ show interfaceSignature
-  show (NonInterface path) = "[INTERFACE ERROR] " ++ show path ++ "Cant' implement the non-interface `" ++ show path ++ "`"
+  show (KindMismatch path definitionSignature interfaceSignature) =
+    labelStr "INTERFACE ERROR"
+      (show path ++ ":" ++ " One or more types in the interface implementation " ++
+       show definitionSignature ++ " have kinds that do not match the kinds of the types in the interface signature " ++
+       show interfaceSignature ++ "\n" ++ "Types of the form (f a) must be matched by constructor types such as (Maybe a)")
+  show (TypeMismatch path definitionSignature interfaceSignature) =
+    labelStr "INTERFACE ERROR"
+      (show path ++ " : " ++ show definitionSignature ++
+       " doesn't match the interface signature " ++ show interfaceSignature)
+  show (NonInterface path) =
+    labelStr "INTERFACE ERROR"
+      (show path ++ "Cant' implement the non-interface `" ++ show path ++ "`")
 
 -- TODO: This is currently called once outside of this module--try to remove that call and make this internal.
 -- Checks whether a given form's type matches an interface, and if so, registers the form with the interface.

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -124,10 +124,9 @@ primitiveImplements xobj ctx [x@(XObj (Sym interface@(SymPath _ _) _) _ _), inne
       def = lookupInEnv impl global
   in  maybe notFound found def
   where (SymPath modules _) = consPath (union (contextPath ctx) prefixes) (SymPath [] name)
-        checkInterface = let warn = do putStrWithColor Blue ("[WARNING] The interface " ++ show interface ++ " implemented by " ++ show impl ++
-                                                              " at " ++ prettyInfoFromXObj xobj ++ " is not defined." ++
-                                                              " Did you define it using `definterface`?")
-                                       putStrLnWithColor White "" -- To restore color for sure.
+        checkInterface = let warn = do emitWarning ("The interface " ++ show interface ++ " implemented by " ++ show impl ++
+                                                    " at " ++ prettyInfoFromXObj xobj ++ " is not defined." ++
+                                                    " Did you define it using `definterface`?")
                              tyEnv = getTypeEnv . contextTypeEnv $ ctx
                          in maybe warn (\_ -> pure ()) (lookupInEnv interface tyEnv)
         -- If the implementation binding doesn't exist yet, set the implements
@@ -191,9 +190,8 @@ define hidden ctx@(Context globalEnv _ typeEnv _ proj _ _ _) annXObj =
             case previousType of
               Just previousTypeUnwrapped ->
                 unless (areUnifiable (forceTy annXObj) previousTypeUnwrapped) $
-                  do putStrWithColor Blue ("[WARNING] Definition at " ++ prettyInfoFromXObj annXObj ++ " changed type of '" ++ show (getPath annXObj) ++
-                                           "' from " ++ show previousTypeUnwrapped ++ " to " ++ show (forceTy annXObj))
-                     putStrLnWithColor White "" -- To restore color for sure.
+                  do emitWarning ("Definition at " ++ prettyInfoFromXObj annXObj ++ " changed type of '" ++ show (getPath annXObj) ++
+                                  "' from " ++ show previousTypeUnwrapped ++ " to " ++ show (forceTy annXObj))
               Nothing -> pure ()
             case Meta.get "implements" previousMeta of
               Just (XObj (Lst interfaces) _ _) ->


### PR DESCRIPTION
This PR fixes #1002 by adding checking for `CARP_DIR` being set. If it’s not set, it will emit a warning. If it isn’t set and `--no-core` isn’t set either, it will also emit an error and exit.

While @TimDeve and I were at it, we also refactored the error printing to make it a little more ergonomic.

Cheers