### PR TITLE
feat: better error messages for invalid objects

### DIFF
--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -317,6 +317,13 @@ setPath (XObj (Lst [extr@(XObj (External _) _ _), XObj (Sym _ _) si st, ty]) i t
 setPath x _ =
   error ("Can't set path on " ++ show x)
 
+
+-- | Convert an Obj to a pretty string representation.
+-- | Reuses `pretty`.
+prettyObj :: Obj -> String
+prettyObj = pretty . buildXObj
+  where buildXObj o = XObj o Nothing Nothing
+
 -- | Convert an XObj to a pretty string representation.
 pretty :: XObj -> String
 pretty = visit 0

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -17,6 +17,7 @@ data TypeError
   | ExpressionMissingType XObj
   | SymbolNotDefined SymPath XObj Env
   | InvalidObj Obj XObj
+  | InvalidObjExample Obj XObj String
   | CantUseDerefOutsideFunctionApplication XObj
   | NotAType XObj
   | WrongArgCount XObj Int Int
@@ -100,9 +101,13 @@ instance Show TypeError where
     "I didn’t understand the `if` statement at " ++ prettyInfoFromXObj xobj
       ++ ".\n\nIs it valid? Every `if` needs to follow the form `(if cond iftrue iffalse)`."
   show (InvalidObj o xobj) =
-    "I didn’t understand the form `" ++ show o ++ "` at "
+    "I didn’t understand the form `" ++ prettyObj o ++ "` at "
       ++ prettyInfoFromXObj xobj
       ++ ".\n\nIs it valid?"
+  show (InvalidObjExample o xobj example) =
+    "I didn’t understand the form `" ++ prettyObj o ++ "` at "
+      ++ prettyInfoFromXObj xobj
+      ++ ".\n\nIs it valid? It needs to follow the form `" ++ example ++ "`."
   show (WrongArgCount xobj expected actual) =
     "You used the wrong number of arguments in '" ++ getName xobj ++ "' at "
       ++ prettyInfoFromXObj xobj


### PR DESCRIPTION
This PR adds better error messages for invalid AST objects by introducing `InvalidObjExample`, which is a type error that carries an example invocation with it. It also improves `InvalidObj` by calling `pretty` on the code inside it instead of `show`.

Cheers