### PR TITLE
Primitive refactors

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -55,6 +55,7 @@ library
                        StructUtils,
                        Path,
                        Interfaces,
+                       PrimitiveError
                        Primitives,
                        Validate,
                        Reify,

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -2,10 +2,10 @@ module Lookup where
 
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes, mapMaybe)
+import Env
 import qualified Meta
 import Obj
 import Types
-import Env
 
 -- | The type of generic lookup functions.
 type LookupFunc a b = a -> Env -> [b]
@@ -32,17 +32,17 @@ lookupInEnv path@(SymPath (p : ps) name) env =
 lookupInterfaceOrType :: Context -> SymPath -> Maybe Binder
 lookupInterfaceOrType ctx path =
   let typeEnv = (getTypeEnv (contextTypeEnv ctx))
-  in  lookupBinder path typeEnv
+   in lookupBinder path typeEnv
 
 lookupGlobalBinding :: Context -> SymPath -> Maybe Binder
 lookupGlobalBinding ctx path =
   let global = (contextGlobalEnv ctx)
-  in lookupBinder path global
+   in lookupBinder path global
 
 lookupContextualBinding :: Context -> SymPath -> Maybe Binder
 lookupContextualBinding ctx path =
   let ctxEnv = contextEnv ctx
-  in lookupBinder path ctxEnv
+   in lookupBinder path ctxEnv
 
 lookupEverywhere :: Context -> SymPath -> Maybe [Binder]
 lookupEverywhere ctx (SymPath _ name) =

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -5,6 +5,7 @@ import Data.Maybe (catMaybes, mapMaybe)
 import qualified Meta
 import Obj
 import Types
+import Env
 
 -- | The type of generic lookup functions.
 type LookupFunc a b = a -> Env -> [b]
@@ -27,6 +28,27 @@ lookupInEnv path@(SymPath (p : ps) name) env =
       case envParent env of
         Just parent -> lookupInEnv path parent
         Nothing -> Nothing
+
+lookupInterfaceOrType :: Context -> SymPath -> Maybe Binder
+lookupInterfaceOrType ctx path =
+  let typeEnv = (getTypeEnv (contextTypeEnv ctx))
+  in  lookupBinder path typeEnv
+
+lookupGlobalBinding :: Context -> SymPath -> Maybe Binder
+lookupGlobalBinding ctx path =
+  let global = (contextGlobalEnv ctx)
+  in lookupBinder path global
+
+lookupContextualBinding :: Context -> SymPath -> Maybe Binder
+lookupContextualBinding ctx path =
+  let ctxEnv = contextEnv ctx
+  in lookupBinder path ctxEnv
+
+lookupEverywhere :: Context -> SymPath -> Maybe [Binder]
+lookupEverywhere ctx (SymPath _ name) =
+  case map snd (multiLookupEverywhere name (contextEnv ctx)) of
+    [] -> Nothing
+    xs -> Just xs
 
 -- | Like 'lookupInEnv' but only returns the Binder (no Env)
 lookupBinder :: SymPath -> Env -> Maybe Binder

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -29,23 +29,28 @@ lookupInEnv path@(SymPath (p : ps) name) env =
         Just parent -> lookupInEnv path parent
         Nothing -> Nothing
 
-lookupInterfaceOrType :: Context -> SymPath -> Maybe Binder
-lookupInterfaceOrType ctx path =
+-- | Lookup a binder in a context's typeEnv.
+lookupBinderInTypeEnv :: Context -> SymPath -> Maybe Binder
+lookupBinderInTypeEnv ctx path =
   let typeEnv = (getTypeEnv (contextTypeEnv ctx))
    in lookupBinder path typeEnv
 
-lookupGlobalBinding :: Context -> SymPath -> Maybe Binder
-lookupGlobalBinding ctx path =
+-- | Lookup a binder in a context's globalEnv.
+lookupBinderInGlobalEnv :: Context -> SymPath -> Maybe Binder
+lookupBinderInGlobalEnv ctx path =
   let global = (contextGlobalEnv ctx)
    in lookupBinder path global
 
-lookupContextualBinding :: Context -> SymPath -> Maybe Binder
-lookupContextualBinding ctx path =
+-- | Lookup a binder in a context's contextEnv.
+lookupBinderInContextEnv :: Context -> SymPath -> Maybe Binder
+lookupBinderInContextEnv ctx path =
   let ctxEnv = contextEnv ctx
    in lookupBinder path ctxEnv
 
-lookupEverywhere :: Context -> SymPath -> Maybe [Binder]
-lookupEverywhere ctx (SymPath _ name) =
+-- | Performs a multiLookupEverywhere but drops envs from the result and wraps
+-- the results in a Maybe.
+multiLookupBinderEverywhere :: Context -> SymPath -> Maybe [Binder]
+multiLookupBinderEverywhere ctx (SymPath _ name) =
   case map snd (multiLookupEverywhere name (contextEnv ctx)) of
     [] -> Nothing
     xs -> Just xs

--- a/src/PrimitiveError.hs
+++ b/src/PrimitiveError.hs
@@ -1,0 +1,57 @@
+module PrimitiveError where
+
+import Obj
+import Types
+import TypeError
+
+data PrimitiveError
+  = ArgumentTypeError String String String XObj
+  | ArgumentArityError XObj String [XObj] 
+  | MissingInfo XObj
+  | ForewardImplementsMeta
+  | RegisterTypeError 
+  | SymbolNotFoundError SymPath
+
+data PrimitiveWarning 
+  = NonExistentInterfaceWarning XObj
+  | DefinitionTypeChangeWarning XObj Ty
+
+instance Show PrimitiveError where
+  show (ArgumentTypeError fun ty position actual) =
+     "`" ++ fun ++ "` expected " ++ ty ++ " as its " ++ position
+         ++ " argument, but got `"
+         ++ pretty actual
+         ++ "`"
+  show (ArgumentArityError fun numberExpected args) =
+    "`" ++ (show (getPath fun)) ++ "`" ++ "expected " ++ numberExpected 
+        ++ " arguments " ++ ", but got " ++ show (length args)
+  show (MissingInfo x) =
+    "No information about object: " ++ pretty x
+  show (ForewardImplementsMeta) = 
+    "Can't set the `implements` meta on a global definition before it is declared."
+  show (RegisterTypeError) =
+    "I don't understand this usage of `register-type`.\n\n"
+    ++ "Valid usages :\n"
+    ++ "  (register-type Name)\n"
+    ++ "  (register-type Name [field0 Type, ...])\n"
+    ++ "  (register-type Name c-name)\n"
+    ++ "  (register-type Name c-name [field0 Type, ...]"
+  show (SymbolNotFoundError path) =
+    "I can’t find the symbol `" ++ show path ++ "`"   
+
+instance Show PrimitiveWarning where
+  show (NonExistentInterfaceWarning x) =
+    "The interface "
+    ++ show (getPath x)
+    ++ " is not defined."
+    ++ " Did you define it using `definterface`?"
+  show (DefinitionTypeChangeWarning annXObj previousType) = 
+    "Definition at " ++ prettyInfoFromXObj annXObj ++ " changed type of '" ++ show (getPath annXObj)
+    ++ "' from "
+    ++ show previousType
+    ++ " to "
+    ++ show (forceTy annXObj)
+
+toEvalError :: Context -> XObj -> PrimitiveError -> (Context, Either EvalError XObj)
+toEvalError ctx xobj perr =
+  evalError ctx (show perr) (xobjInfo xobj)

--- a/src/PrimitiveError.hs
+++ b/src/PrimitiveError.hs
@@ -1,56 +1,58 @@
 module PrimitiveError where
 
 import Obj
-import Types
 import TypeError
+import Types
 
 data PrimitiveError
   = ArgumentTypeError String String String XObj
-  | ArgumentArityError XObj String [XObj] 
+  | ArgumentArityError XObj String [XObj]
   | MissingInfo XObj
   | ForewardImplementsMeta
-  | RegisterTypeError 
+  | RegisterTypeError
   | SymbolNotFoundError SymPath
 
-data PrimitiveWarning 
+data PrimitiveWarning
   = NonExistentInterfaceWarning XObj
   | DefinitionTypeChangeWarning XObj Ty
 
 instance Show PrimitiveError where
   show (ArgumentTypeError fun ty position actual) =
-     "`" ++ fun ++ "` expected " ++ ty ++ " as its " ++ position
-         ++ " argument, but got `"
-         ++ pretty actual
-         ++ "`"
+    "`" ++ fun ++ "` expected " ++ ty ++ " as its " ++ position
+      ++ " argument, but got `"
+      ++ pretty actual
+      ++ "`"
   show (ArgumentArityError fun numberExpected args) =
-    "`" ++ (show (getPath fun)) ++ "`" ++ "expected " ++ numberExpected 
-        ++ " arguments " ++ ", but got " ++ show (length args)
+    "`" ++ (show (getPath fun)) ++ "`" ++ "expected " ++ numberExpected
+      ++ " arguments "
+      ++ ", but got "
+      ++ show (length args)
   show (MissingInfo x) =
     "No information about object: " ++ pretty x
-  show (ForewardImplementsMeta) = 
+  show (ForewardImplementsMeta) =
     "Can't set the `implements` meta on a global definition before it is declared."
   show (RegisterTypeError) =
     "I don't understand this usage of `register-type`.\n\n"
-    ++ "Valid usages :\n"
-    ++ "  (register-type Name)\n"
-    ++ "  (register-type Name [field0 Type, ...])\n"
-    ++ "  (register-type Name c-name)\n"
-    ++ "  (register-type Name c-name [field0 Type, ...]"
+      ++ "Valid usages :\n"
+      ++ "  (register-type Name)\n"
+      ++ "  (register-type Name [field0 Type, ...])\n"
+      ++ "  (register-type Name c-name)\n"
+      ++ "  (register-type Name c-name [field0 Type, ...]"
   show (SymbolNotFoundError path) =
-    "I can’t find the symbol `" ++ show path ++ "`"   
+    "I can’t find the symbol `" ++ show path ++ "`"
 
 instance Show PrimitiveWarning where
   show (NonExistentInterfaceWarning x) =
     "The interface "
-    ++ show (getPath x)
-    ++ " is not defined."
-    ++ " Did you define it using `definterface`?"
-  show (DefinitionTypeChangeWarning annXObj previousType) = 
+      ++ show (getPath x)
+      ++ " is not defined."
+      ++ " Did you define it using `definterface`?"
+  show (DefinitionTypeChangeWarning annXObj previousType) =
     "Definition at " ++ prettyInfoFromXObj annXObj ++ " changed type of '" ++ show (getPath annXObj)
-    ++ "' from "
-    ++ show previousType
-    ++ " to "
-    ++ show (forceTy annXObj)
+      ++ "' from "
+      ++ show previousType
+      ++ " to "
+      ++ show (forceTy annXObj)
 
 toEvalError :: Context -> XObj -> PrimitiveError -> (Context, Either EvalError XObj)
 toEvalError ctx xobj perr =

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -295,15 +295,15 @@ primitiveInfo :: Primitive
 primitiveInfo _ ctx [target@(XObj (Sym path@(SymPath _ _) _) _ _)] = do
   case path of
     SymPath [] _ ->
-      (printIfFound (lookupInterfaceOrType ctx path))
+      (printIfFound (lookupBinderInTypeEnv ctx path))
         >> maybe
           (notFound ctx target path)
           (\binders -> foldM (\_ binder -> printer binder) (ctx, dynamicNil) binders)
-          ( (fmap (: []) (lookupContextualBinding ctx path))
-              <|> (lookupEverywhere ctx path)
+          ( (fmap (: []) (lookupBinderInContextEnv ctx path))
+              <|> (multiLookupBinderEverywhere ctx path)
           )
     _ ->
-      case lookupContextualBinding ctx path of
+      case lookupBinderInContextEnv ctx path of
         Nothing -> notFound ctx target path
         Just found -> printer found
   where

--- a/src/Reify.hs
+++ b/src/Reify.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+
 -- | Module Reify provides a typeclass and instances for turning internal compiler types and data into
 -- corresponding representations in the Carp language.
 module Reify where
 
+import System.FilePath
 import Obj
 import Types
+import Info
+
 
 -- | The Reifiable class ranges over internal Carp compiler types that
 -- may have corresponding representations in Carp itself.
@@ -37,3 +42,22 @@ instance Reifiable Ty where
   reify TypeTy = XObj (Sym (SymPath [] (show TypeTy)) Symbol) Nothing (Just Universe)
   reify UnitTy = XObj (Sym (SymPath [] "Unit") Symbol) Nothing (Just TypeTy)
   reify t = XObj (Sym (SymPath [] (show t)) Symbol) Nothing (Just TypeTy)
+
+instance Reifiable String where
+  reify s = (XObj (Str s) Nothing (Just StringTy))
+
+instance Reifiable Int where
+  reify i = (XObj (Num IntTy (fromIntegral i)) Nothing (Just IntTy))
+
+getInfoAsXObj :: (Reifiable a) => (Info -> a) ->  Maybe Info -> Maybe XObj
+getInfoAsXObj f i = fmap (reify . f) i
+
+getFileAsXObj :: FilePathPrintLength -> Maybe Info -> Maybe XObj
+getFileAsXObj FullPath = getInfoAsXObj infoFile
+getFileAsXObj ShortPath = getInfoAsXObj (takeFileName . infoFile)
+
+getLineAsXObj :: Maybe Info -> Maybe XObj
+getLineAsXObj = getInfoAsXObj infoLine
+
+getColumnAsXObj :: Maybe Info -> Maybe XObj
+getColumnAsXObj = getInfoAsXObj infoColumn

--- a/src/Reify.hs
+++ b/src/Reify.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 -- | Module Reify provides a typeclass and instances for turning internal compiler types and data into
 -- corresponding representations in the Carp language.
 module Reify where
 
-import System.FilePath
-import Obj
-import Types
 import Info
-
+import Obj
+import System.FilePath
+import Types
 
 -- | The Reifiable class ranges over internal Carp compiler types that
 -- may have corresponding representations in Carp itself.
@@ -49,7 +49,7 @@ instance Reifiable String where
 instance Reifiable Int where
   reify i = (XObj (Num IntTy (fromIntegral i)) Nothing (Just IntTy))
 
-getInfoAsXObj :: (Reifiable a) => (Info -> a) ->  Maybe Info -> Maybe XObj
+getInfoAsXObj :: (Reifiable a) => (Info -> a) -> Maybe Info -> Maybe XObj
 getInfoAsXObj f i = fmap (reify . f) i
 
 getFileAsXObj :: FilePathPrintLength -> Maybe Info -> Maybe XObj


### PR DESCRIPTION
This commit is the first in what will hopefully be a series of helpful
primitive refactors. To start, we:

- Move some inline `evalError` strings into a `PrimitiveError` module,
  (similar to the `TypeError`/`Types` module relationship
- Add `Reifiable` instances for String and Int types to take these
  types to their XObj representation.
- Add info utility functions for converting Info data to an XObj
- Refactor the `info` primitive:

  - Use monadic combinators + `maybe` instead of nested cases.
  - Use helper lookup functions that take a *context*--nearly *all*
    lookup calls currently extract some env, typically without doing
    anything to it, to pass it to lookup. This is a sign the boundary is
    incorrect and lookups should take the context instead--this will allow
    us to eliminate a ton of local `globalEnv`, `typeEnv`, etc. bindings.
  - Don't print hidden bindings
  - Indent printed meta information.
  - Color bindings blue

## Some examples of info output changes

**Binders are now printed blue (hopefully easier to read on black/white bgs?)**
<img width="708" alt="Screen Shot 2020-12-14 at 5 25 01 PM" src="https://user-images.githubusercontent.com/11237600/102143125-7c05b300-3e31-11eb-9013-021348397a59.png">
**When signatures and privacy meta are present, they are printed.**
<img width="655" alt="Screen Shot 2020-12-14 at 5 25 08 PM" src="https://user-images.githubusercontent.com/11237600/102143135-8031d080-3e31-11eb-914b-ccc01c4bc495.png">
**More binders**
<img width="652" alt="Screen Shot 2020-12-14 at 5 25 16 PM" src="https://user-images.githubusercontent.com/11237600/102143141-82942a80-3e31-11eb-8d74-c32dc87f2641.png">

**Hidden binders are no longer printed**

<img width="661" alt="Screen Shot 2020-12-14 at 5 25 59 PM" src="https://user-images.githubusercontent.com/11237600/102143146-858f1b00-3e31-11eb-98d8-01e603aa6334.png">

