### PR TITLE
feat: Add drop interface

### DIFF
--- a/docs/Drop.md
+++ b/docs/Drop.md
@@ -1,0 +1,23 @@
+# Drop
+
+One of the “special” interfaces implementable by any type in Carp is `drop`,
+the signature of which is `(Fn [&a] ())`. It takes a reference to a type and
+is run before that type is deleted. This is meant for types that need special
+treatment before being deallocated, such as files that need to be closed.
+
+```clojure
+(deftype A [])
+
+(defmodule A
+  (sig drop (Fn [(Ref A)] ()))
+  (defn drop [a]
+    (IO.println "Hi from drop!"))
+)
+
+(defn main []
+  (let [a (A)]
+    ()))
+```
+
+In the case above, `A.drop` will be  run and `Hi from drop` will be printed
+when the `let` scope ends.

--- a/docs/Memory.md
+++ b/docs/Memory.md
@@ -1,5 +1,9 @@
 # Memory Management - a closer look
 
+### Related pages
+
+* [Drop](Drop.md) - a deeper look at the `drop` interface
+
 The goals of the memory management system in Carp are the following:
 
 * Predictable

--- a/examples/drop.carp
+++ b/examples/drop.carp
@@ -1,0 +1,11 @@
+(deftype A [])
+
+(defmodule A
+  (sig drop (Fn [(Ref A)] ()))
+  (defn drop [a]
+    (IO.println "Hi from drop!"))
+)
+
+(defn main []
+  (let [a (A)]
+    ()))

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -773,6 +773,8 @@ delete indent i = mapM_ deleterToC (infoDelete i)
       pure ()
     deleterToC deleter@ProperDeleter {} =
       appendToSrc $ addIndent indent ++ "" ++ pathToC (deleterPath deleter) ++ "(" ++ mangle (deleterVariable deleter) ++ ");\n"
+    deleterToC dropfun@Drop {} =
+      appendToSrc $ addIndent indent ++ "" ++ pathToC (dropPath dropfun) ++ "(&" ++ mangle (dropVariable dropfun) ++ ");\n"
 
 defnToDeclaration :: MetaData -> SymPath -> [XObj] -> Ty -> String
 defnToDeclaration meta path@(SymPath _ name) argList retTy =

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -761,7 +761,6 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
         appendToSrc (addIndent indent ++ arrayDataVar ++ "[" ++ show index ++ "] = " ++ visited ++ ";\n")
         pure ()
 
--- the chaining here ensures that drop is emitted before delete
 delete :: Int -> Info -> State EmitterState ()
 delete indent i = mapM_ deleterToC (infoDelete i)
   where

--- a/src/Info.hs
+++ b/src/Info.hs
@@ -35,6 +35,11 @@ data Deleter
       { deleterPath :: SymPath,
         deleterVariable :: String
       }
+  | -- used for facilitating "drop", code that runs before a deleter
+    Drop
+      { dropPath :: SymPath,
+        dropVariable :: String
+      }
   | -- used for external types with no delete function
     FakeDeleter
       { deleterVariable :: String
@@ -50,6 +55,7 @@ data Deleter
 
 instance Show Deleter where
   show (ProperDeleter path var) = "(ProperDel " ++ show path ++ " " ++ show var ++ ")"
+  show (Drop path var) = "(Drop " ++ show path ++ " " ++ show var ++ ")"
   show (FakeDeleter var) = "(FakeDel " ++ show var ++ ")"
   show (PrimDeleter var) = "(PrimDel " ++ show var ++ ")"
   show (RefDeleter var) = "(RefDel " ++ show var ++ ")"

--- a/src/Info.hs
+++ b/src/Info.hs
@@ -33,12 +33,8 @@ data Info = Info
 data Deleter
   = ProperDeleter
       { deleterPath :: SymPath,
+        dropPath :: Maybe SymPath, -- used for facilitating "drop", code that runs before a deleter
         deleterVariable :: String
-      }
-  | -- used for facilitating "drop", code that runs before a deleter
-    Drop
-      { dropPath :: SymPath,
-        dropVariable :: String
       }
   | -- used for external types with no delete function
     FakeDeleter
@@ -54,8 +50,8 @@ data Deleter
   deriving (Eq, Ord)
 
 instance Show Deleter where
-  show (ProperDeleter path var) = "(ProperDel " ++ show path ++ " " ++ show var ++ ")"
-  show (Drop path var) = "(Drop " ++ show path ++ " " ++ show var ++ ")"
+  show (ProperDeleter path dropper var) =
+    "(ProperDel " ++ show path ++ " " ++ maybe "" show dropper ++ " " ++ show var ++ ")"
   show (FakeDeleter var) = "(FakeDel " ++ show var ++ ")"
   show (PrimDeleter var) = "(PrimDel " ++ show var ++ ")"
   show (RefDeleter var) = "(RefDel " ++ show var ++ ")"


### PR DESCRIPTION
his PR adds support for a `drop` interface, i.e. an interface that gets run before a value is deleted. It should not do any memory cleanup, but other cleanup, like closing OS handles, can be done here. It fixes #954.

Cheers