### PR TITLE
Make sure output directory is right in test

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -136,7 +136,7 @@ main = do
   _ <-
     ifCarpDirSet
       ( pure startingContext
-          >>= load [carpProfile | hasProfile]
+          >>= load [carpProfile | hasProfile && profile]
           >>= execStrs "Preload" preloads
           >>= loadOnce coreModulesToLoad
           >>= load argFilesToLoad

--- a/test/execute.sh
+++ b/test/execute.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Runs the executable and compares its output to the .expected file
-./scripts/carp.sh $1 --log-memory -b && \
+./scripts/carp.sh $1 --log-memory -b --eval-preload '(Project.config "output-directory" "out")' && \
   ./out/Untitled > test/output/$1.output.actual 2>&1
 echo $1
 

--- a/test/execute.sh
+++ b/test/execute.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
 # Runs the executable and compares its output to the .expected file
-./scripts/carp.sh $1 --log-memory -b --eval-preload '(Project.config "output-directory" "out")' && \
+export CARP_OPTS="$CARP_OPTS  $1 --log-memory -b --no-profile"
+./scripts/carp.sh && \
   ./out/Untitled > test/output/$1.output.actual 2>&1
 echo $1
 


### PR DESCRIPTION
This PR uses `--eval-preload` to make sure the output directory in test is as expected when running the test script. This makes sure that having a different config set in `profile.carp` doesn’t conflict with running the tests.

Cheers