### PR TITLE
feat: Evaluate symbols for statics in REPL

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -38,12 +38,12 @@ data LookupPreference
   | PreferGlobal
 
 -- Prefer dynamic bindings
-evalDynamic :: Context -> XObj -> IO (Context, Either EvalError XObj)
-evalDynamic ctx xobj = eval ctx xobj PreferDynamic
+evalDynamic :: Bool -> Context -> XObj -> IO (Context, Either EvalError XObj)
+evalDynamic shouldResolve ctx xobj = eval ctx xobj PreferDynamic shouldResolve
 
 -- Prefer global bindings
-evalStatic :: Context -> XObj -> IO (Context, Either EvalError XObj)
-evalStatic ctx xobj = eval ctx xobj PreferGlobal
+evalStatic :: Bool -> Context -> XObj -> IO (Context, Either EvalError XObj)
+evalStatic shouldResolve ctx xobj = eval ctx xobj PreferGlobal shouldResolve
 
 -- | Dynamic (REPL) evaluation of XObj:s (s-expressions)
 -- Note: You might find a bunch of code of the following form both here and in
@@ -59,24 +59,28 @@ evalStatic ctx xobj = eval ctx xobj PreferGlobal
 -- it gets real weird with laziness. (Note to the note: this code is mostly a
 -- remnant of us using StateT, and might not be necessary anymore since we
 -- switched to more explicit state-passing.)
-eval :: Context -> XObj -> LookupPreference -> IO (Context, Either EvalError XObj)
-eval ctx xobj@(XObj o info ty) preference =
+eval :: Context -> XObj -> LookupPreference -> Bool -> IO (Context, Either EvalError XObj)
+eval ctx xobj@(XObj o info ty) preference shouldResolve =
   case o of
     Lst body -> eval' body
     Sym spath@(SymPath p n) _ ->
-      pure $
-        case tryAllLookups of
-          Just (_, (Right (XObj (Lst ((XObj Def _ _) : _)) _ _))) ->
-            (ctx, Left (HasStaticCall xobj info))
-          Just (_, (Right (XObj (Lst ((XObj (Defn _) _ _) : _)) _ _))) ->
-            (ctx, Left (HasStaticCall xobj info))
-          Just (_, (Right (XObj (Lst ((XObj (External _) _ _) : _)) _ _))) ->
-            (ctx, Left (HasStaticCall xobj info))
-          val ->
-            fromMaybe
-              (evalError ctx ("Can't find symbol '" ++ show n ++ "'") info) -- all else failed, error.
-              val
+      if shouldResolve
+      then
+        pure $
+          case tryAllLookups of
+            Just (_, (Right (XObj (Lst ((XObj Def _ _) : _)) _ _))) ->
+              (ctx, Left (HasStaticCall xobj info))
+            Just (_, (Right (XObj (Lst ((XObj (Defn _) _ _) : _)) _ _))) ->
+              (ctx, Left (HasStaticCall xobj info))
+            Just (_, (Right (XObj (Lst ((XObj (External _) _ _) : _)) _ _))) ->
+              (ctx, Left (HasStaticCall xobj info))
+            val -> unwrapLookup val
+      else pure $ unwrapLookup tryAllLookups
       where
+        unwrapLookup v =
+          fromMaybe
+            (evalError ctx ("Can't find symbol '" ++ show n ++ "'") info) -- all else failed, error.
+            v
         tryAllLookups =
           ( case preference of
                 PreferDynamic -> tryDynamicLookup
@@ -133,11 +137,11 @@ eval ctx xobj@(XObj o info ty) preference =
     eval' form =
       case form of
         [XObj If _ _, mcond, mtrue, mfalse] -> do
-          (newCtx, evd) <- eval ctx mcond preference
+          (newCtx, evd) <- eval ctx mcond preference False
           case evd of
             Right cond ->
               case xobjObj cond of
-                Bol b -> eval newCtx (if b then mtrue else mfalse) preference
+                Bol b -> eval newCtx (if b then mtrue else mfalse) preference False
                 _ ->
                   pure
                     ( evalError
@@ -219,7 +223,7 @@ eval ctx xobj@(XObj o info ty) preference =
                 )
         [the@(XObj The _ _), t, value] ->
           do
-            (newCtx, evaledValue) <- expandAll evalDynamic ctx value -- TODO: Why expand all here?
+            (newCtx, evaledValue) <- expandAll (evalDynamic False) ctx value -- TODO: Why expand all here?
             pure
               ( newCtx,
                 do
@@ -263,7 +267,7 @@ eval ctx xobj@(XObj o info ty) preference =
               case eitherCtx of
                 Left err -> pure (ctx, Left err)
                 Right newCtx -> do
-                  (finalCtx, evaledBody) <- eval newCtx body preference
+                  (finalCtx, evaledBody) <- eval newCtx body preference False
                   let Just e = contextInternalEnv finalCtx
                   pure
                     ( finalCtx {contextInternalEnv = envParent e},
@@ -279,7 +283,7 @@ eval ctx xobj@(XObj o info ty) preference =
               \case
                 err@(Left _) -> pure err
                 Right ctx' -> do
-                  (newCtx, res) <- eval ctx' x preference
+                  (newCtx, res) <- eval ctx' x preference False
                   case res of
                     Right okX -> do
                       let binder = Binder emptyMeta (XObj (Lst [(XObj LetDef Nothing Nothing), XObj (Sym (SymPath [] n) Symbol) Nothing Nothing, okX]) Nothing (xobjTy okX))
@@ -367,17 +371,17 @@ eval ctx xobj@(XObj o info ty) preference =
         XObj (Match _) _ _ : _ -> pure (ctx, Left (HasStaticCall xobj info))
         [XObj Ref _ _, _] -> pure (ctx, Left (HasStaticCall xobj info))
         l@(XObj (Lst _) i t) : args -> do
-          (newCtx, f) <- eval ctx l preference
+          (newCtx, f) <- eval ctx l preference False
           case f of
             Right fun -> do
-              (newCtx', res) <- eval (pushFrame newCtx xobj) (XObj (Lst (fun : args)) i t) preference
+              (newCtx', res) <- eval (pushFrame newCtx xobj) (XObj (Lst (fun : args)) i t) preference False
               pure (popFrame newCtx', res)
             x -> pure (newCtx, x)
         x@(XObj (Sym _ _) i _) : args -> do
-          (newCtx, f) <- eval ctx x preference
+          (newCtx, f) <- eval ctx x preference False
           case f of
             Right fun -> do
-              (newCtx', res) <- eval (pushFrame ctx xobj) (XObj (Lst (fun : args)) i ty) preference
+              (newCtx', res) <- eval (pushFrame ctx xobj) (XObj (Lst (fun : args)) i ty) preference False
               pure (popFrame newCtx', res)
             Left err -> pure (newCtx, Left err)
         XObj With _ _ : xobj'@(XObj (Sym path _) _ _) : forms ->
@@ -392,7 +396,7 @@ eval ctx xobj@(XObj o info ty) preference =
             successiveEval' (ctx', acc) x =
               case acc of
                 err@(Left _) -> pure (ctx', err)
-                Right _ -> eval ctx' x preference
+                Right _ -> eval ctx' x preference False
         [XObj While _ _, cond, body] ->
           specialCommandWhile ctx cond body
         [XObj Address _ _, value] ->
@@ -436,7 +440,7 @@ eval ctx xobj@(XObj o info ty) preference =
       case acc of
         Left _ -> pure (ctx', acc)
         Right l -> do
-          (newCtx, evald) <- eval ctx' x preference
+          (newCtx, evald) <- eval ctx' x preference False
           pure $ case evald of
             Right res -> (newCtx, Right (l ++ [res]))
             Left err -> (newCtx, Left err)
@@ -460,12 +464,12 @@ macroExpand ctx xobj =
             ok <- expanded
             Right (XObj (StaticArr ok) i t)
         )
-    XObj (Lst [XObj (Lst (XObj Macro _ _ : _)) _ _]) _ _ -> evalDynamic ctx xobj
+    XObj (Lst [XObj (Lst (XObj Macro _ _ : _)) _ _]) _ _ -> evalDynamic False ctx xobj
     XObj (Lst (x@(XObj (Sym _ _) _ _) : args)) i t -> do
-      (next, f) <- evalDynamic ctx x
+      (next, f) <- evalDynamic False ctx x
       case f of
         Right m@(XObj (Lst (XObj Macro _ _ : _)) _ _) -> do
-          (newCtx', res) <- evalDynamic ctx (XObj (Lst (m : args)) i t)
+          (newCtx', res) <- evalDynamic False ctx (XObj (Lst (m : args)) i t)
           pure (newCtx', res)
         -- TODO: Determine a way to eval primitives generally and remove this special case.
         Right p@(XObj (Lst [(XObj (Primitive prim) _ _), (XObj (Sym (SymPath _ "defmodule") _) _ _), _]) _ _) ->
@@ -531,7 +535,7 @@ apply ctx@Context {contextInternalEnv = internal} body params args =
                   insideEnv'
                   (head rest)
                   (XObj (Lst (drop n args)) Nothing Nothing)
-      (c, r) <- evalDynamic (ctx {contextInternalEnv = Just insideEnv''}) body
+      (c, r) <- evalDynamic False (ctx {contextInternalEnv = Just insideEnv''}) body
       pure (c {contextInternalEnv = internal}, r)
 
 -- | Parses a string and then converts the resulting forms to commands, which are evaluated in order.
@@ -589,7 +593,7 @@ executeCommand ctx@(Context env _ _ _ _ _ _ _) xobj =
       error ("Global env module name is " ++ fromJust (envModuleName env) ++ " (should be Nothing).")
     -- The s-expression command is a special case that prefers global/static bindings over dynamic bindings
     -- when given a naked binding (no path) as an argument; (s-expr inc)
-    (newCtx, result) <- if (xobjIsSexp xobj) then evalStatic ctx xobj else evalDynamic ctx xobj
+    (newCtx, result) <- if (xobjIsSexp xobj) then evalStatic True ctx xobj else evalDynamic True ctx xobj
     case result of
       Left e@(EvalError _ _ _ _) -> do
         reportExecutionError newCtx (show e)
@@ -693,14 +697,14 @@ specialCommandAddress ctx xobj =
 
 specialCommandWhile :: Context -> XObj -> XObj -> IO (Context, Either EvalError XObj)
 specialCommandWhile ctx cond body = do
-  (newCtx, evd) <- evalDynamic ctx cond
+  (newCtx, evd) <- evalDynamic False ctx cond
   case evd of
     Right c ->
       case xobjObj c of
         Bol b ->
           if b
             then do
-              (newCtx', _) <- evalDynamic newCtx body
+              (newCtx', _) <- evalDynamic False newCtx body
               specialCommandWhile newCtx' cond body
             else pure (newCtx, dynamicNil)
         _ ->
@@ -745,7 +749,7 @@ annotateWithinContext qualifyDefn ctx xobj = do
   case sig of
     Left err -> pure (ctx, Left err)
     Right okSig -> do
-      (_, expansionResult) <- expandAll evalDynamic ctx xobj
+      (_, expansionResult) <- expandAll (evalDynamic False) ctx xobj
       case expansionResult of
         Left err -> pure (evalError ctx (show err) Nothing)
         Right expanded ->
@@ -808,7 +812,7 @@ primitiveDefmodule xobj ctx@(Context env i _ pathStrings _ _ _ _) (XObj (Sym (Sy
       (macroExpand ctx' expressions)
         >>= \(ctx'', res) -> case res of
           Left _ -> pure (ctx'', res)
-          Right r -> evalDynamic ctx'' r
+          Right r -> evalDynamic False ctx'' r
 primitiveDefmodule _ ctx (x : _) =
   pure (evalError ctx ("`defmodule` expects a symbol, got '" ++ pretty x ++ "' instead.") (xobjInfo x))
 primitiveDefmodule _ ctx [] =
@@ -1056,7 +1060,7 @@ commandC :: UnaryCommandCallback
 commandC ctx xobj = do
   let globalEnv = contextGlobalEnv ctx
       typeEnv = contextTypeEnv ctx
-  (newCtx, result) <- expandAll evalDynamic ctx xobj
+  (newCtx, result) <- expandAll (evalDynamic False) ctx xobj
   case result of
     Left err -> pure (newCtx, Left err)
     Right expanded ->
@@ -1123,7 +1127,7 @@ buildMainFunction xobj =
 
 primitiveDefdynamic :: Primitive
 primitiveDefdynamic _ ctx [XObj (Sym (SymPath [] name) _) _ _, value] = do
-  (newCtx, result) <- evalDynamic ctx value
+  (newCtx, result) <- evalDynamic False ctx value
   case result of
     Left err -> pure (newCtx, Left err)
     Right evaledBody ->
@@ -1134,7 +1138,7 @@ primitiveDefdynamic _ _ _ = error "primitivedefdynamic"
 
 specialCommandSet :: Context -> [XObj] -> IO (Context, Either EvalError XObj)
 specialCommandSet ctx [(XObj (Sym path@(SymPath mod n) _) _ _), val] = do
-  (newCtx, result) <- evalDynamic ctx val
+  (newCtx, result) <- evalDynamic False ctx val
   case result of
     Left err -> pure (newCtx, Left err)
     Right evald -> do
@@ -1210,7 +1214,7 @@ setStaticOrDynamicVar path env binder value =
 primitiveEval :: Primitive
 primitiveEval _ ctx [val] = do
   -- primitives don’t evaluate their arguments, so this needs to double-evaluate
-  (newCtx, arg) <- evalDynamic ctx val
+  (newCtx, arg) <- evalDynamic False ctx val
   case arg of
     Left err -> pure (newCtx, Left err)
     Right evald -> do
@@ -1218,7 +1222,7 @@ primitiveEval _ ctx [val] = do
       case expanded of
         Left err -> pure (newCtx', Left err)
         Right ok -> do
-          (finalCtx, res) <- evalDynamic newCtx' ok
+          (finalCtx, res) <- evalDynamic False newCtx' ok
           pure $ case res of
             Left (HasStaticCall x i) -> evalError ctx ("Unexpected static call in " ++ pretty x) i
             _ -> (finalCtx, res)
@@ -1248,13 +1252,13 @@ primitiveDefmacro _ _ _ = error "primitivedefmacro"
 
 primitiveAnd :: Primitive
 primitiveAnd _ ctx [a, b] = do
-  (newCtx, evaledA) <- evalDynamic ctx a
+  (newCtx, evaledA) <- evalDynamic False ctx a
   case evaledA of
     Left e -> pure (ctx, Left e)
     Right (XObj (Bol ab) _ _) ->
       if ab
         then do
-          (newCtx', evaledB) <- evalDynamic newCtx b
+          (newCtx', evaledB) <- evalDynamic False newCtx b
           pure $ case evaledB of
             Left e -> (newCtx, Left e)
             Right (XObj (Bol bb) _ _) ->
@@ -1266,14 +1270,14 @@ primitiveAnd _ _ _ = error "primitiveand"
 
 primitiveOr :: Primitive
 primitiveOr _ ctx [a, b] = do
-  (newCtx, evaledA) <- evalDynamic ctx a
+  (newCtx, evaledA) <- evalDynamic False ctx a
   case evaledA of
     Left e -> pure (ctx, Left e)
     Right (XObj (Bol ab) _ _) ->
       if ab
         then pure (newCtx, Right trueXObj)
         else do
-          (newCtx', evaledB) <- evalDynamic newCtx b
+          (newCtx', evaledB) <- evalDynamic False newCtx b
           pure $ case evaledB of
             Left e -> (newCtx, Left e)
             Right (XObj (Bol bb) _ _) ->

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -1024,3 +1024,14 @@ emptyList = XObj (Lst []) Nothing Nothing
 wrapInRefTyIfMatchRef :: MatchMode -> Ty -> Ty
 wrapInRefTyIfMatchRef MatchRef t = RefTy t (VarTy "whatever") -- TODO: Better name for the lifetime variable.
 wrapInRefTyIfMatchRef MatchValue t = t
+
+-- | Check if the Obj is static and resolvable
+isResolvableStaticObj :: Obj -> Bool
+isResolvableStaticObj Def = True
+isResolvableStaticObj (Defn _) = True
+isResolvableStaticObj (External _) = True
+isResolvableStaticObj (Deftemplate _) = True
+isResolvableStaticObj (Instantiate _) = True
+isResolvableStaticObj (Fn _ _) = True
+isResolvableStaticObj (Interface _ _) = True
+isResolvableStaticObj _ = False


### PR DESCRIPTION
This PR changes the default behavior in the REPL from printing symbol info to evaluating that symbol. In order to do this, we needed to add a few special cases to the symbol lookup in `eval` for `def`s, `defn`s, and `external`s.

Please note that that makes a weird problem that we have even weirder. Consider this program:

```clojure
(def x 1)

x

(defn main [] x)
```

Currently, this will print the information of `x` during compilation. Now, this compiles another program and prints `1` before compiling the actual `main` program. This is a somewhat unrelated bug that should probably be fixed—global symbols should probably just be an error in a file—, but it is existing behavior that changes.

Cheers