### PR TITLE
feat: Add parse command

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -845,10 +845,10 @@ commandHash ctx v = pure (ctx, Right (XObj (Num LongTy (Integral (hash v))) (Jus
 
 commandParse :: UnaryCommandCallback
 commandParse ctx (XObj (Str s) i _) =
-  case parse s "command:parse" of
-    Left e -> pure $ evalError ctx (show e) i
-    Right [] -> pure $ evalError ctx "parse did not return an object" i
-    Right [e] -> pure (ctx, Right e)
-    Right (_:_) -> pure $ evalError ctx "parse returned multiple objects" i
+  pure $ case parse s "command:parse" of
+    Left e -> evalError ctx (show e) i
+    Right [] -> evalError ctx "parse did not return an object" i
+    Right [e] -> (ctx, Right e)
+    Right (_:_) -> evalError ctx "parse returned multiple objects" i
 commandParse ctx x =
   pure (evalError ctx ("Argument to `parse` must be a string, but was `" ++ pretty x ++ "`") (xobjInfo x))

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -243,7 +243,8 @@ dynamicModule =
           ]
     unaries =
       let f = addUnaryCommand . spath
-       in [ f "list?" commandIsList "checks whether the argument is a list." "(list? '()) ; => true",
+       in [ f "parse" commandParse "parses a string into an expression" "(parse \"(+ 1 2)\") ; => (+ 1 2)",
+            f "list?" commandIsList "checks whether the argument is a list." "(list? '()) ; => true",
             f "array?" commandIsArray "checks whether the arguments is an array." "(array? []) ; => true",
             f "symbol?" commandIsSymbol "checks whether the argument is a symbol." "(symbol? 'x) ; => true",
             f "length" commandLength "returns the length of the argument (must be an array, string or list)." "(length '(1 2 3)) ; => 3",


### PR DESCRIPTION
This PR adds the command `parse` which takes in a string and returns an expression. Please note that empty strings and strings containing multiple expressions will result in an error.

Cheers