### PR TITLE
chore: Abuse deftemplate to get rid of Address

### DIFF
--- a/core/Blitable.carp
+++ b/core/Blitable.carp
@@ -57,3 +57,7 @@
 (defmodule Uint64
   (defn blit [x] (the Uint64 x))
   (implements blit Uint64.blit))
+
+(defmodule Pointer
+  (defn blit [x] (the (Ptr a) x))
+  (implements blit Pointer.blit))

--- a/core/Core.carp
+++ b/core/Core.carp
@@ -15,7 +15,7 @@
 (system-include "core.h")
 (system-include "carp_memory.h")
 
-(deftemplate address (Fn [a] (Ptr a)) "#define $NAME(a) (&(a))" "")
+(deftemplate address (Fn [(Ref a)] (Ptr a)) "$a * $NAME($a * a)" "$DECL { return a; }")
 
 (load-once "Interfaces.carp")
 (load-once "Blitable.carp")

--- a/core/Core.carp
+++ b/core/Core.carp
@@ -15,6 +15,8 @@
 (system-include "core.h")
 (system-include "carp_memory.h")
 
+(deftemplate address (Fn [a] (Ptr a)) "#define $NAME(a) (&(a))" "")
+
 (load-once "Interfaces.carp")
 (load-once "Blitable.carp")
 (load-once "Bool.carp")

--- a/core/Pointer.carp
+++ b/core/Pointer.carp
@@ -1,6 +1,10 @@
 (defmodule Pointer
   (doc eq "checks two pointers for equality.")
   (deftemplate eq (Fn [(Ptr p) (Ptr p)] Bool) "bool $NAME($p *p1, $p *p2)" " $DECL { return p1 == p2; }")
+  (implements = Pointer.eq)
+  (doc eq "checks two pointer references for equality.")
+  (deftemplate ref-eq (Fn [(Ref (Ptr p)) (Ref (Ptr p))] Bool) "bool $NAME($p **p1, $p **p2)" " $DECL { return *p1 == *p2; }")
+  (implements = Pointer.ref-eq)
   (doc to-ref "converts a pointer to a reference type.
 
 The user will have to ensure themselves that this is a safe operation.")

--- a/core/SDL.carp
+++ b/core/SDL.carp
@@ -83,7 +83,7 @@
     (defn all []
       (let-do [events []
                e (SDL.Event.init)]
-        (while (poll (address e))
+        (while (poll (address &e))
           (set! events (Array.push-back events e)))
         events))
 
@@ -211,7 +211,7 @@
     (defn get []
       (let [x 0
             y 0
-            state (SDL.Mouse.get-mouse-state (address x) (address y))
+            state (SDL.Mouse.get-mouse-state (address &x) (address &y))
             l (/= 0 (Int.bit-and state (SDL.Mouse.button SDL.Mouse.button-left)))
             r (/= 0 (Int.bit-and state (SDL.Mouse.button SDL.Mouse.button-right)))]
         (SDL.MouseState.init x y l r))))
@@ -287,7 +287,7 @@
 
   (defn dimensions [texture]
     (let-do [w 0 h 0]
-      (SDL.query-texture texture NULL NULL (address w) (address h)) ;; TODO: Can't qualify 'query-texture' ??!
+      (SDL.query-texture texture NULL NULL (address &w) (address &h)) ;; TODO: Can't qualify 'query-texture' ??!
       (SDL.rect 0 0 w h)))
 
   (defn draw-texture [rend texture point]
@@ -296,7 +296,7 @@
                          @(SDL_Point.y point)
                          @(SDL_Rect.w &dims)
                          @(SDL_Rect.h &dims))]
-      (SDL.render-copy rend texture (address dims) (address dest))))
+      (SDL.render-copy rend texture (address &dims) (address &dest))))
 
   (defn draw-texture-centered [rend texture point]
     (let [dims (SDL.dimensions texture)
@@ -306,7 +306,7 @@
                          (- @(SDL_Point.y point) (/ h 2))
                          w
                          h)]
-      (SDL.render-copy rend texture (address dims) (address dest))))
+      (SDL.render-copy rend texture (address &dims) (address &dest))))
 
   (defn-do bg [rend color]
     (with Int
@@ -332,7 +332,7 @@
           ren NULL]
       (do (SDL.init SDL.INIT_EVERYTHING)
           (SDL.Hint.set SDL.Hint.render-vsync (cstr "1"))
-          (SDL.create-window-and-renderer width height (bit-or SDL.WindowFlags.window-shown SDL.WindowFlags.window-resizable) (address win) (address ren))
+          (SDL.create-window-and-renderer width height (bit-or SDL.WindowFlags.window-shown SDL.WindowFlags.window-resizable) (address &win) (address &ren))
           (SDL.set-window-title win (cstr title))
           (SDLApp.init win ren 60))))
 

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -73,7 +73,7 @@
             (x)
             0)
           (do
-            (ignore (System.wait (address status)))
+            (ignore (System.wait (address &status)))
             (System.get-exit-status status)))))
 
     (hidden handle-signal)
@@ -93,7 +93,7 @@
             (x)
             0)
           (do
-            (ignore (System.wait (address status)))
+            (ignore (System.wait (address &status)))
             (System.get-exit-status status)))))
 
     (doc assert-exit "Assert that function f exits with exit code exit-code.")

--- a/examples/carp_demo.carp
+++ b/examples/carp_demo.carp
@@ -33,7 +33,7 @@
       (SDL.set-render-draw-color rend 0 0 0 255)
       (SDL.render-clear rend)
       (SDL.set-render-draw-color rend 200 250 255 255)
-      (SDL.render-fill-rect rend (address rect))
+      (SDL.render-fill-rect rend (address &rect))
       (SDL.set-render-draw-color rend 100 50 255 155)
       (let [mouse-state (SDL.MouseState.get)
             x @(SDL.MouseState.x &mouse-state)
@@ -55,10 +55,10 @@
       (let [img @(Images.img1 &images)]
         (SDL.render-copy-ex rend
                             img
-                            (address (SDL.dimensions img))
-                            (address (SDL.rect 100 100 300 300))
+                            (address &(SDL.dimensions img))
+                            (address &(SDL.rect 100 100 300 300))
                             (* 0.1 (from-int (SDL.get-ticks)))
-                            (address (SDL.point 150 150))
+                            (address &(SDL.point 150 150))
                             SDL.flip-none)))))
 
 (defn event-handler [app state event]

--- a/examples/game_of_life.carp
+++ b/examples/game_of_life.carp
@@ -35,7 +35,7 @@
   (let [event (init)
         new-play play]
     (do
-      (while (poll (address event))
+      (while (poll (address &event))
         (let [et (type (ref event))]
           (cond (= et quit) (stop app)
                 (= et key-down) (set! new-play (handle-key app (ref event) play))
@@ -59,7 +59,7 @@
             (if @(unsafe-nth world (cell-index x y))
               (set-render-draw-color rend 255 255 255 255)
               (set-render-draw-color rend 50 50 50 255))
-            (render-fill-rect rend (address square))
+            (render-fill-rect rend (address &square))
             ))))
     (render-present rend)))
 

--- a/examples/langtons_ant.carp
+++ b/examples/langtons_ant.carp
@@ -38,13 +38,13 @@
               (and (= x @(State.x state)) (= y @(State.y state))) (SDL.set-render-draw-color rend 255 0 0 255)
               (get-square state x y) (SDL.set-render-draw-color rend 0 0 0 255)
               (SDL.set-render-draw-color rend 255 255 255 255))
-            (SDL.render-fill-rect rend (address (SDL.rect (* x w) (* y h) (dec w) (dec h))))))))
+            (SDL.render-fill-rect rend (address &(SDL.rect (* x w) (* y h) (dec w) (dec h))))))))
     (SDL.render-present rend)
     ))
 
 (defn handle-events [app rend]
   (let [event (SDL.Event.init)]
-    (while (SDL.Event.poll (address event))
+    (while (SDL.Event.poll (address &event))
       (let [et (SDL.Event.type &event)]
         (cond (= et SDL.Event.quit) (SDLApp.stop app)
               ())))))

--- a/examples/reptile.carp
+++ b/examples/reptile.carp
@@ -36,17 +36,17 @@
         (if (= i 0)
           (do
             (SDL.set-render-draw-color rend 200 255 (+ 100 (* body-length 10)) 255)
-            (SDL.render-fill-rect rend (address (SDL.rect x y grid-size grid-size))))
+            (SDL.render-fill-rect rend (address &(SDL.rect x y grid-size grid-size))))
           (do
             (SDL.set-render-draw-color rend 200 (+ 50 (* i (/ 200 body-length))) 100 255)
-            (SDL.render-fill-rect rend (address (SDL.rect x y grid-size grid-size)))))))))
+            (SDL.render-fill-rect rend (address &(SDL.rect x y grid-size grid-size)))))))))
 
 (defn draw-human [rend human]
   (do
     (SDL.set-render-draw-color rend 100 100 250 255)
     (let [x (* grid-size (to-int @(Vector2.x human)))
           y (* grid-size (to-int @(Vector2.y human)))]
-      (SDL.render-fill-rect rend (address (SDL.rect x y grid-size grid-size))))))
+      (SDL.render-fill-rect rend (address &(SDL.rect x y grid-size grid-size))))))
 
 (defn draw [rend world]
   (do
@@ -62,7 +62,7 @@
 
 (defn handle-events [app rend world]
   (let [event (SDL.Event.init)]
-    (while (SDL.Event.poll (address event))
+    (while (SDL.Event.poll (address &event))
       (let [et (SDL.Event.type &event)]
         (cond (= et SDL.Event.quit) (SDLApp.stop app)
               (= et SDL.Event.key-down) (let [key (SDL.Event.keycode &event)]

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -538,7 +538,6 @@ commandEq ctx a b =
     cmp (XObj If _ _, XObj If _ _) = Right True
     cmp (XObj With _ _, XObj With _ _) = Right True
     cmp (XObj MetaStub _ _, XObj MetaStub _ _) = Right True
-    cmp (XObj Address _ _, XObj Address _ _) = Right True
     cmp (XObj SetBang _ _, XObj SetBang _ _) = Right True
     cmp (XObj Macro _ _, XObj Macro _ _) = Right True
     cmp (XObj Dynamic _ _, XObj Dynamic _ _) = Right True

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -1028,12 +1028,6 @@ manageMemory typeEnv globalEnv root =
                           okValue <- visitedValue
                           _ <- ownsTheVarBefore -- Force Either to fail
                           pure (XObj (Lst [setbangExpr, newVariable, okValue]) i t)
-        [addressExpr@(XObj Address _ _), value] ->
-          do
-            visitedValue <- visit value
-            pure $ do
-              okValue <- visitedValue
-              pure (XObj (Lst [addressExpr, okValue]) i t)
         [theExpr@(XObj The _ _), typeXObj, value] ->
           do
             visitedValue <- visit value

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -13,7 +13,7 @@ where
 import Control.Monad.State
 import Data.Char (ord)
 import Data.Functor ((<&>))
-import Data.List (intercalate, sortOn)
+import Data.List (intercalate, isPrefixOf, sortOn)
 import Data.Maybe (fromJust, fromMaybe)
 import Env
 import Info
@@ -798,7 +798,9 @@ templateToDeclaration template path actualTy =
       e = error "Can't refer to declaration in declaration."
       declaration = templateDeclaration template actualTy
       tokens = concatMap (concretizeTypesInToken mappings (pathToC path) e) declaration
-   in concatMap show tokens ++ ";\n"
+      stokens = concatMap show tokens
+      term = if "#define" `isPrefixOf` stokens then "\n" else ";\n"
+   in stokens ++ term
 
 memberToDecl :: Int -> (XObj, XObj) -> State EmitterState ()
 memberToDecl indent (memberName, memberType) =

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -156,7 +156,6 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             (Defalias _) -> dontVisit
             (MultiSym _ _) -> dontVisit
             (InterfaceSym _) -> dontVisit
-            Address -> dontVisit
             SetBang -> dontVisit
             Macro -> dontVisit
             Dynamic -> dontVisit
@@ -503,11 +502,6 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
                 lastRet <- visit indent lastExpr
                 appendToSrc (addIndent indent ++ tyToCLambdaFix lastTy ++ " " ++ retVar ++ " = " ++ lastRet ++ ";\n")
                 pure retVar
-        -- Address
-        [XObj Address _ _, value] ->
-          do
-            valueVar <- visit indent value
-            pure ("&" ++ valueVar)
         -- Set!
         [XObj SetBang _ _, variable, value] ->
           do

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -404,8 +404,6 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                 Right _ -> eval ctx' x preference ResolveLocal
         [XObj While _ _, cond, body] ->
           specialCommandWhile ctx cond body
-        [XObj Address _ _, value] ->
-          specialCommandAddress ctx value
         [] -> pure (ctx, dynamicNil)
         _ -> pure (evalError ctx ("I did not understand the form `" ++ pretty xobj ++ "`") (xobjInfo xobj))
     badArity name params args i = case checkArity name params args of

--- a/src/GenerateConstraints.hs
+++ b/src/GenerateConstraints.hs
@@ -187,9 +187,6 @@ genConstraints _ root rootSig = fmap sort (gen root)
                           mkConstr _ = Nothing
                           expressionsShouldReturnUnit = mapMaybe mkConstr (init expressions)
                       pure (retConstraint : insideExpressionsConstraints ++ expressionsShouldReturnUnit)
-          -- Address
-          [XObj Address _ _, value] ->
-            gen value
           -- Set!
           [XObj SetBang _ _, variable, value] ->
             do

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -104,7 +104,6 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
       e@(Deftemplate _) -> pure (Left (InvalidObj e xobj))
       e@(Instantiate _) -> pure (Left (InvalidObj e xobj))
       e@(Defalias _) -> pure (Left (InvalidObj e xobj))
-      Address -> pure (Left (InvalidObj Address xobj))
       SetBang -> pure (Left (InvalidObj SetBang xobj))
       Macro -> pure (Left (InvalidObj Macro xobj))
       The -> pure (Left (InvalidObj The xobj))
@@ -343,14 +342,6 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
             pure $ do
               okExpressions <- visitedExpressions
               pure (XObj (Lst (doExpr : okExpressions)) i (Just t))
-        -- Address
-        [addressExpr@(XObj Address _ _), value] ->
-          do
-            visitedValue <- visit env value
-            pure $ do
-              okValue <- visitedValue
-              let Just t' = xobjTy okValue
-              pure (XObj (Lst [addressExpr, okValue]) i (Just (PointerTy t')))
         -- Set!
         [setExpr@(XObj SetBang _ _), variable, value] ->
           do

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -144,7 +144,6 @@ data Obj
   | Deftemplate TemplateCreator
   | Instantiate Template
   | Defalias Ty
-  | Address
   | SetBang
   | Macro
   | Dynamic -- DefnDynamic
@@ -437,7 +436,6 @@ pretty = visit 0
         ExternalType (Just override) -> "external-type (override: " ++ show override ++ ")"
         MetaStub -> "meta-stub"
         Defalias _ -> "defalias"
-        Address -> "address"
         SetBang -> "set!"
         Macro -> "macro"
         Dynamic -> "dynamic"
@@ -502,7 +500,6 @@ prettyUpTo lim xobj =
         ExternalType (Just _) -> ")"
         MetaStub -> ""
         Defalias _ -> ""
-        Address -> ""
         SetBang -> ""
         Macro -> ""
         Dynamic -> ""

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -399,7 +399,6 @@ symbol = do
       "match-ref" -> XObj (Match MatchRef) i Nothing
       "true" -> XObj (Bol True) i Nothing
       "false" -> XObj (Bol False) i Nothing
-      "address" -> XObj Address i Nothing
       "set!" -> XObj SetBang i Nothing
       "the" -> XObj The i Nothing
       "ref" -> XObj Ref i Nothing

--- a/test/address.carp
+++ b/test/address.carp
@@ -1,0 +1,17 @@
+(load "Test.carp")
+
+(use Test)
+
+
+(deftest test
+  (let [arr [1 2 3 4]]
+    (assert-equal test
+                  &(Array.copy-map &address &arr)
+                  &(Array.copy-map &address &arr)
+                  "address works I"))
+  (assert-not-equal test
+                    &(Array.copy-map &address &[1 2 3 4])
+                    &(Array.copy-map &address &[1 2 3 4])
+                    "address works II"
+                    )
+)

--- a/test/maybe.carp
+++ b/test/maybe.carp
@@ -89,7 +89,7 @@
   )
   (assert-equal test
                 &(Just 0)
-                &(from-ptr (address (zero)))
+                &(from-ptr (address &(zero)))
                 "from-ptr works on Ptr/Just"
   )
   (assert-equal test


### PR DESCRIPTION
I don't remember if this has been discussed before. If you think it's worth it I can polish the patch (it emits a double semicolon right now and I don't know where to place the definition).
