### PR TITLE
fix: account for interfaces in function lookups

### DIFF
--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -688,7 +688,7 @@ allFunctionsWithNameAndSignature typeEnv env functionName functionType =
         -- implementations, or hangs). We should be able to use
         -- those here instead of looking up all interface paths
         -- directly, but for now we are stuck with this.
-        case sequence $ map (\p -> lookupInEnv p env) paths of
+        case sequence $ map (\p -> lookupInEnv p env) (paths ++ [(SymPath [] functionName)]) of
           Just found -> found
           Nothing -> (multiLookupEverywhere functionName env)
       -- just a regular function; look for it

--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -671,19 +671,33 @@ concretizeDefinition allowAmbiguity typeEnv globalEnv visitedDefinitions definit
           Left $ CannotConcretize definition
 
 -- | Find ALL functions with a certain name, matching a type signature.
-allFunctionsWithNameAndSignature :: Env -> String -> Ty -> [(Env, Binder)]
-allFunctionsWithNameAndSignature env functionName functionType =
-  filter (predicate . xobjTy . binderXObj . snd) (multiLookupEverywhere functionName env)
+allFunctionsWithNameAndSignature :: TypeEnv -> Env -> String -> Ty -> [(Env, Binder)]
+allFunctionsWithNameAndSignature typeEnv env functionName functionType =
+  filter (predicate . xobjTy . binderXObj . snd) foundBindings
   where
     predicate (Just t) =
       --trace ("areUnifiable? " ++ show functionType ++ " == " ++ show t ++ " " ++ show (areUnifiable functionType t)) $
       areUnifiable functionType t
     predicate Nothing = error "allfunctionswithnameandsignature"
+    foundBindings = case lookupBinder (SymPath [] functionName) (getTypeEnv typeEnv) of
+      -- this function is an interface; lookup implementations
+      Just (Binder _ (XObj (Lst (XObj (Interface _ paths) _ _ : _)) _ _)) ->
+        -- N.B./TODO: There are functions designed for this
+        -- scenario--e.g. lookupImplementations, but they cause
+        -- either entirely unacceptable behavior (not finding
+        -- implementations, or hangs). We should be able to use
+        -- those here instead of looking up all interface paths
+        -- directly, but for now we are stuck with this.
+        case sequence $ map (\p -> lookupInEnv p env) paths of
+          Just found -> found
+          Nothing -> (multiLookupEverywhere functionName env)
+      -- just a regular function; look for it
+      _ -> (multiLookupEverywhere functionName env)
 
 -- | Find all the dependencies of a polymorphic function with a name and a desired concrete type.
 depsOfPolymorphicFunction :: TypeEnv -> Env -> [SymPath] -> String -> Ty -> [XObj]
 depsOfPolymorphicFunction typeEnv env visitedDefinitions functionName functionType =
-  case allFunctionsWithNameAndSignature env functionName functionType of
+  case allFunctionsWithNameAndSignature typeEnv env functionName functionType of
     [] ->
       (trace $ "[Warning] No '" ++ functionName ++ "' function found with type " ++ show functionType ++ ".")
         []
@@ -745,7 +759,7 @@ getConcretizedPath single functionType =
 findFunctionForMember :: TypeEnv -> Env -> String -> Ty -> (String, Ty) -> FunctionFinderResult
 findFunctionForMember typeEnv env functionName functionType (memberName, memberType)
   | isManaged typeEnv env memberType =
-    case allFunctionsWithNameAndSignature env functionName functionType of
+    case allFunctionsWithNameAndSignature typeEnv env functionName functionType of
       [] ->
         FunctionNotFound
           ( "Can't find any '" ++ functionName ++ "' function for member '"
@@ -767,8 +781,8 @@ findFunctionForMember typeEnv env functionName functionType (memberName, memberT
 
 -- | TODO: should this be the default and 'findFunctionForMember' be the specific one
 findFunctionForMemberIncludePrimitives :: TypeEnv -> Env -> String -> Ty -> (String, Ty) -> FunctionFinderResult
-findFunctionForMemberIncludePrimitives _ env functionName functionType (memberName, _) =
-  case allFunctionsWithNameAndSignature env functionName functionType of
+findFunctionForMemberIncludePrimitives typeEnv env functionName functionType (memberName, _) =
+  case allFunctionsWithNameAndSignature typeEnv env functionName functionType of
     [] ->
       FunctionNotFound
         ( "Can't find any '" ++ functionName ++ "' function for member '"


### PR DESCRIPTION
An older version of Carp only allowed users to implement interfaces by
defining a function of the same name. Since PR 769 and roughly commit
040e9e4 however, this was no longer the case, since we added a primitive
for implementing interfaces, allowing users to implement interfaces
  using functions with whatever name they want.

When this happened, the function lookups that happen during
concretization were never updated to reflect the fact that interface
implementations might have different names than their corresponding
interfaces. It's rare, but this can lead to errors for template
functions in the compiler.

For example, registered types automatically get an implementation of
`prn` with the same name. This function takes a ref to the registered
type as an argument. If a user wants to use such a type as an array
member however, they must provide a prn that takes a value argument
instead of a ref. If the user still wants to keep the ref variant handy,
however, they need to give this new prn implementation a different name,
otherwise Carp will think they are redefining the existing function.
However, using an arbitrary name would result in this second prn
instance not being found during the lookup fixed in this commit, since
it did not match the name of the interface exactly.

After this commit, this issue will no longer crop up, as the
concretize.hs function lookup now accounts for the fact that, if the
function it is looking for is an interface, it may need to find
functions with names that differ from the name it received as an
argument; e.g. a lookup for `prn` could result in finding a function
named `foo` that is a valid implementation of `prn`.