### PR TITLE
Fix closure history on dynamic eval

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -302,7 +302,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                 (newCtx, evaledArgs) <- foldlM successiveEval (ctx, Right []) args
                 case evaledArgs of
                   Right okArgs -> do
-                    (_, res) <- apply c body params okArgs
+                    (_, res) <- apply c{contextHistory=contextHistory ctx} body params okArgs
                     pure (newCtx, res)
                   Left err -> pure (newCtx, Left err)
         XObj (Lst [XObj Dynamic _ _, sym, XObj (Arr params) _ _, body]) i _ : args ->


### PR DESCRIPTION
This PR fixes the closure history for dynamic evaluation. Since the history is only used for tracebacks, it wouldn’t make much sense to use the original history—which tells us where the closure was created—to report errors, but rather the history of the call, to tell us where the closure was actually used.

NB: Maybe the history of the closure creation could also be interesting in some cases, though, to trace back where it’s coming from?

Cheers