### PR TITLE
fix: Closure context

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -302,7 +302,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                 (newCtx, evaledArgs) <- foldlM successiveEval (ctx, Right []) args
                 case evaledArgs of
                   Right okArgs -> do
-                    (_, res) <- apply c{contextHistory=contextHistory ctx} body params okArgs
+                    (_, res) <- apply (c {contextHistory = contextHistory ctx} <> ctx) body params okArgs
                     pure (newCtx, res)
                   Left err -> pure (newCtx, Left err)
         XObj (Lst [XObj Dynamic _ _, sym, XObj (Arr params) _ _, body]) i _ : args ->

--- a/src/Map.hs
+++ b/src/Map.hs
@@ -40,3 +40,6 @@ keys (Map m) = M.keys m
 
 map :: (a -> b) -> Map k a -> Map k b
 map f (Map m) = Map $ M.map f m
+
+union :: Ord k => Map k v -> Map k v -> Map k v
+union (Map m) (Map m') = (Map (M.union m m'))

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -1059,7 +1059,14 @@ instance Semigroup Env where
             envUseModules = joinedUseModules
           }
 
--- | Left biased semigroup instance for Contexts
+-- | Semigroup instance for Contexts
+--   - Left biased in internal env combination
+--   - Right biased in global env combination
+--   - Right biased in type env combination
+--  The assumption here is that the context on the LHS is the *older* context
+--  in the case of conflicts, we prefer the bindings on the RHS *except* for
+--  the internal environment, since retaining some bindings from the internal
+--  env is typically the reason you'd call this function.
 instance Semigroup Context where
   c <> c' =
     let global = contextGlobalEnv c
@@ -1069,7 +1076,7 @@ instance Semigroup Context where
         typeEnv = getTypeEnv (contextTypeEnv c)
         typeEnv' = getTypeEnv (contextTypeEnv c')
      in c
-          { contextGlobalEnv = global <> global',
+          { contextGlobalEnv = global' <> global,
             contextInternalEnv = internal <> internal',
-            contextTypeEnv = TypeEnv (typeEnv <> typeEnv')
+            contextTypeEnv = TypeEnv (typeEnv' <> typeEnv)
           }

--- a/test/closure.carp
+++ b/test/closure.carp
@@ -1,0 +1,54 @@
+(load "Test.carp")
+(use Test)
+
+(def x 400)
+
+;; close over a global variable
+(def closure-one
+  (fn [] x))
+
+;; close over an argument
+(def closure-two
+  (the (Fn [Int] Int) (fn [x] x)))
+
+;; close over a let binding
+(def closure-three
+  (fn [] (let [x 4] x)))
+
+;; dynamics can close over a global variable before it is defined
+(defdynamic closure-four
+  (fn [] y))
+
+;; nested closures prefer closed-over internal environments
+(def closure-five
+  (fn [] (let [x 5] (fn [] x))))
+
+(defdynamic y 500)
+
+(defmacro test-closure-four [] (closure-four))
+
+;; Change the global value of x (closed over in closure-one)
+(set! x 1000)
+
+(deftest test
+  (assert-equal test
+    1000
+    (closure-one)
+    "closures over global variables get the global variable's latest state.")
+  (assert-equal test
+    3
+    (closure-two 3)
+    "closures with arguments use argument values")
+  (assert-equal test
+    4
+    (closure-three)
+    "closures with let bindings prefer let bindings over global names")
+  (assert-equal test
+    500
+    (test-closure-four)
+    "dynamic closures can refer to global bindings delcared after the closure")
+  (assert-equal test
+    5
+    ((closure-five))
+    "nested closures prefer closed-over bindings")
+)

--- a/test/dynamic-closures.carp
+++ b/test/dynamic-closures.carp
@@ -1,18 +1,18 @@
 (load "Test.carp")
 (use Test)
 
-(def x 400)
+(defdynamic x 400)
 
 ;; close over a global variable
-(def closure-one
+(defdynamic closure-one
   (fn [] x))
 
 ;; close over an argument
-(def closure-two
-  (the (Fn [Int] Int) (fn [x] x)))
+(defdynamic closure-two
+  (fn [x] x))
 
 ;; close over a let binding
-(def closure-three
+(defdynamic closure-three
   (fn [] (let [x 4] x)))
 
 ;; dynamics can close over a global variable before it is defined
@@ -20,12 +20,16 @@
   (fn [] y))
 
 ;; nested closures prefer closed-over internal environments
-(def closure-five
+(defdynamic closure-five
   (fn [] (let [x 5] (fn [] x))))
 
 (defdynamic y 500)
 
+(defmacro test-closure-one [] (closure-one))
+(defmacro test-closure-two [] (closure-two 3))
+(defmacro test-closure-three [] (closure-three))
 (defmacro test-closure-four [] (closure-four))
+(defmacro test-closure-five [] ((closure-five)))
 
 ;; Change the global value of x (closed over in closure-one)
 (set! x 1000)
@@ -33,15 +37,15 @@
 (deftest test
   (assert-equal test
     1000
-    (closure-one)
+    (test-closure-one)
     "closures over global variables get the global variable's latest state.")
   (assert-equal test
     3
-    (closure-two 3)
+    (test-closure-two)
     "closures with arguments use argument values")
   (assert-equal test
     4
-    (closure-three)
+    (test-closure-three)
     "closures with let bindings prefer let bindings over global names")
   (assert-equal test
     500
@@ -49,6 +53,6 @@
     "dynamic closures can refer to global bindings delcared after the closure")
   (assert-equal test
     5
-    ((closure-five))
+    (test-closure-five)
     "nested closures prefer closed-over bindings")
 )


### PR DESCRIPTION
This PR does two things:

1. Adds `Semigroup` instances for `Env` and `Context` to offer a way to combine each of these types, respectively. Envs are combined using the left-biased union of the maps containing their bindings.
2. Updates our handling of closures to evaluate them under the *semigroup combination* of the context captured during their creation and the context under which they are evaluated, biasing toward the creation-context. This allows us to ensure closures have access to the latest global definitions, fixing #1101, while also ensuring that, in the case of conflicts, they prefer the local definitions captured during the creation context.