### PR TITLE
fix: don't combine internal envs in closures

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -313,7 +313,9 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                 (newCtx, evaledArgs) <- foldlM successiveEval (ctx, Right []) args
                 case evaledArgs of
                   Right okArgs -> do
-                    (_, res) <- apply (c {contextHistory = contextHistory ctx} <> ctx) body params okArgs
+                    let newGlobals = (contextGlobalEnv newCtx) <> (contextGlobalEnv c)
+                        newTypes = TypeEnv $ (getTypeEnv (contextTypeEnv newCtx)) <> (getTypeEnv (contextTypeEnv c))
+                    (_, res) <- apply (c {contextHistory = contextHistory ctx, contextGlobalEnv = newGlobals, contextTypeEnv = newTypes}) body params okArgs
                     pure (newCtx, res)
                   Left err -> pure (newCtx, Left err)
         XObj (Lst [XObj Dynamic _ _, sym, XObj (Arr params) _ _, body]) i _ : args ->


### PR DESCRIPTION
This fixes a bug whereby closures would mistakenly capture bindings of
other scopes because they'd combine internal environments.

In particular:

```
(defndynamic sum-with [f]
 (fn [] (reduce (fn [acc m] (+ acc (* m f))) 0 [1 2 3])))
((sum-with 10))
```

Would lead to `f` in the function passed to reduce being bound to the
function itself, instead of the expected `10` since reduce *also*
defines an `f` as an argument, and these would collide when combining
the internal envs.

We now keep internal envs separate, which prevents this issue. The
combination of type and global envs is retained, ensuring closures have
access to the latest global values.