### PR TITLE
DRAFT: Closure side effects

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -313,7 +313,9 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                 (newCtx, evaledArgs) <- foldlM successiveEval (ctx, Right []) args
                 case evaledArgs of
                   Right okArgs -> do
-                    (_, res) <- apply (c {contextHistory = contextHistory ctx} <> ctx) body params okArgs
+                    let newGlobals = (contextGlobalEnv newCtx) <> (contextGlobalEnv c)
+                        newTypes = TypeEnv $ (getTypeEnv (contextTypeEnv newCtx)) <> (getTypeEnv (contextTypeEnv c))
+                    (_, res) <- apply (c {contextHistory = contextHistory ctx, contextGlobalEnv = newGlobals, contextTypeEnv = newTypes}) body params okArgs
                     pure (newCtx, res)
                   Left err -> pure (newCtx, Left err)
         XObj (Lst [XObj Dynamic _ _, sym, XObj (Arr params) _ _, body]) i _ : args ->

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -315,8 +315,8 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                   Right okArgs -> do
                     let newGlobals = (contextGlobalEnv newCtx) <> (contextGlobalEnv c)
                         newTypes = TypeEnv $ (getTypeEnv (contextTypeEnv newCtx)) <> (getTypeEnv (contextTypeEnv c))
-                    (_, res) <- apply (c {contextHistory = contextHistory ctx, contextGlobalEnv = newGlobals, contextTypeEnv = newTypes}) body params okArgs
-                    pure (newCtx, res)
+                    (ct, res) <- apply (c {contextHistory = contextHistory ctx, contextGlobalEnv = newGlobals, contextTypeEnv = newTypes}) body params okArgs
+                    pure (ct {contextInternalEnv = (contextInternalEnv newCtx)}, res)
                   Left err -> pure (newCtx, Left err)
         XObj (Lst [XObj Dynamic _ _, sym, XObj (Arr params) _ _, body]) i _ : args ->
           case checkArity (getName sym) params args of

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -7,7 +7,7 @@ import Control.Applicative
 import Control.Monad.State
 import Data.Char
 import Data.Hashable
-import Data.List (intercalate)
+import Data.List (intercalate, nub)
 import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import Info
@@ -1052,7 +1052,7 @@ instance Semigroup Env where
         joinedParents =
           (envParent e >>= \p -> (pure p <|> (envParent e' >>= \p' -> pure (p <> p'))))
             <|> envParent e'
-        joinedUseModules = envUseModules e <> envUseModules e'
+        joinedUseModules = nub $ envUseModules e <> envUseModules e'
      in e
           { envBindings = Map.union bindings bindings',
             envParent = joinedParents,


### PR DESCRIPTION
This PR depends on #1126.

This commit enables dynamic closures to update the global and type
environments, an example use case is using a closure to define a new
type:

```
> ((fn [] (eval '(deftype X []))))
> :i X
> X : Type
  Defined at line 1, column 25 in 'REPL'
  X : Module = {
        copy : (Fn [(Ref X q)] X)
            delete : (Fn [X] ())
                init : (Fn [] X)
                    prn : (Fn [(Ref X q)] String)
                        str : (Fn [(Ref X q)] String)
  }
    Defined at line 1, column 25 in 'REPL'
```

Previously, we ignored the context resulting from the evaluation of a
closure, preventing such environment manipulations. This gives users more
flexibility in dynamic code.