### PR TITLE
feat: add deprecation meta

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -22,9 +22,11 @@
       (cons-last (thread-last-internal (all-but-last xs)) (last xs))
       (list (last xs) (thread-last-internal (all-but-last xs))))))
 
+(deprecated =>)
 (defmacro => [:rest forms]
   (thread-first-internal forms))
 
+(deprecated ==>)
 (defmacro ==> [:rest forms]
   (thread-last-internal forms))
 

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -22,11 +22,11 @@
       (cons-last (thread-last-internal (all-but-last xs)) (last xs))
       (list (last xs) (thread-last-internal (all-but-last xs))))))
 
-(deprecated =>)
+(deprecated => "deprecated in favor of `->`.")
 (defmacro => [:rest forms]
   (thread-first-internal forms))
 
-(deprecated ==>)
+(deprecated ==> "deprecated in favor of `==>`.")
 (defmacro ==> [:rest forms]
   (thread-last-internal forms))
 

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -102,9 +102,10 @@
 (defmacro annotate [name annotation]
   (eval (list 'meta-set! name "annotations" (eval (annotate-helper name annotation)))))
 
-(doc deprecated "Declares that a binding is deprecated.")
-(defmacro deprecated [name]
-  (eval (list 'meta-set! name "deprecated" true)))
+(doc deprecated "Declares that a binding is deprecated, using an optional explanation.")
+(defmacro deprecated [name :rest explanation]
+  (let [v (if (empty? explanation) true (car explanation))]
+    (eval (list 'meta-set! name "deprecated" v))))
 
 (defmodule Dynamic
 

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -104,7 +104,7 @@
 
 (doc deprecated "Declares that a binding is deprecated, using an optional explanation.")
 (defmacro deprecated [name :rest explanation]
-  (let [v (if (empty? explanation) true (car explanation))]
+  (let [v (if (= (length explanation) 0) true (car explanation))]
     (eval (list 'meta-set! name "deprecated" v))))
 
 (defmodule Dynamic

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -102,6 +102,10 @@
 (defmacro annotate [name annotation]
   (eval (list 'meta-set! name "annotations" (eval (annotate-helper name annotation)))))
 
+(doc deprecated "Declares that a binding is deprecated.")
+(defmacro deprecated [name]
+  (eval (list 'meta-set! name "deprecated" true)))
+
 (defmodule Dynamic
 
   (defndynamic quoted [x]

--- a/docs/core/carp_style.css
+++ b/docs/core/carp_style.css
@@ -75,6 +75,14 @@ h3 {
     margin: 3.5em 0em 0em 0em;
 }
 
+.deprecation {
+  background-color: #f99;
+  text-transform: uppercase;
+  float: right;
+  padding: 5px;
+  margin: -5px;
+}
+
 .sig {
     font-family: "Hasklig", "Source Code Pro", "Lucida Console", monospace;
 }

--- a/docs/core/carp_style.css
+++ b/docs/core/carp_style.css
@@ -75,12 +75,18 @@ h3 {
     margin: 3.5em 0em 0em 0em;
 }
 
-.deprecation {
+.deprecation-notice {
   background-color: #f99;
   text-transform: uppercase;
   float: right;
   padding: 5px;
   margin: -5px;
+}
+
+.deprecation-text {
+  background-color: #f99;
+  padding-left: 5px;
+  padding-right: 5px;
 }
 
 .sig {

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -343,12 +343,17 @@ primitiveInfo _ ctx target@(XObj (Sym path@(SymPath _ _) _) _ _) =
         >> maybe (pure ()) (printMetaBool "Private") (Meta.get "private" metaData)
         >> maybe (pure ()) (printMetaBool "Hidden") (Meta.get "hidden" metaData)
         >> maybe (pure ()) (printMetaVal "Signature" pretty) (Meta.get "sig" metaData)
-        >> maybe (pure ()) (printMetaBool "Deprecated") (Meta.get "deprecated" metaData)
+        >> maybe (pure ()) printDeprecated (Meta.get "deprecated" metaData)
         >> when (projectPrintTypedAST proj) (putStrLnWithColor Yellow (prettyTyped x))
 
     printMetaBool :: String -> XObj -> IO ()
     printMetaBool s (XObj (Bol True) _ _) = putStrLn ("  " ++ s)
     printMetaBool _ _ = return ()
+
+    printDeprecated :: XObj -> IO ()
+    printDeprecated (XObj (Bol True) _ _) = putStrLn "  Deprecated"
+    printDeprecated (XObj (Str v) _ _) = putStrLn ("  Deprecated: " ++ v)
+    printDeprecated _ = return ()
 
     printMetaVal :: String -> (XObj -> String) -> XObj -> IO ()
     printMetaVal s f xobj = putStrLn ("  " ++ s ++ ": " ++ f xobj)

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -343,6 +343,7 @@ primitiveInfo _ ctx target@(XObj (Sym path@(SymPath _ _) _) _ _) =
         >> maybe (pure ()) (printMetaVal "Private" pretty) (Meta.get "private" metaData)
         >> maybe (pure ()) (printMetaVal "Hidden" pretty) (Meta.get "hidden" metaData)
         >> maybe (pure ()) (printMetaVal "Signature" pretty) (Meta.get "sig" metaData)
+        >> maybe (pure ()) (printMetaVal "Deprecated" pretty) (Meta.get "deprecated" metaData)
         >> when (projectPrintTypedAST proj) (putStrLnWithColor Yellow (prettyTyped x))
     printMetaVal :: String -> (XObj -> String) -> XObj -> IO ()
     printMetaVal s f xobj = putStrLn ("  " ++ s ++ ": " ++ f xobj)

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -340,11 +340,16 @@ primitiveInfo _ ctx target@(XObj (Sym path@(SymPath _ _) _) _ _) =
     printMeta metaData proj x =
       maybe (pure ()) (printMetaVal "Documentation" (either (const "") id . unwrapStringXObj)) (Meta.get "doc" metaData)
         >> maybe (pure ()) (printMetaVal "Implements" getName) (Meta.get "implements" metaData)
-        >> maybe (pure ()) (printMetaVal "Private" pretty) (Meta.get "private" metaData)
-        >> maybe (pure ()) (printMetaVal "Hidden" pretty) (Meta.get "hidden" metaData)
+        >> maybe (pure ()) (printMetaBool "Private") (Meta.get "private" metaData)
+        >> maybe (pure ()) (printMetaBool "Hidden") (Meta.get "hidden" metaData)
         >> maybe (pure ()) (printMetaVal "Signature" pretty) (Meta.get "sig" metaData)
-        >> maybe (pure ()) (printMetaVal "Deprecated" pretty) (Meta.get "deprecated" metaData)
+        >> maybe (pure ()) (printMetaBool "Deprecated") (Meta.get "deprecated" metaData)
         >> when (projectPrintTypedAST proj) (putStrLnWithColor Yellow (prettyTyped x))
+
+    printMetaBool :: String -> XObj -> IO ()
+    printMetaBool s (XObj (Bol True) _ _) = putStrLn ("  " ++ s)
+    printMetaBool _ _ = return ()
+
     printMetaVal :: String -> (XObj -> String) -> XObj -> IO ()
     printMetaVal s f xobj = putStrLn ("  " ++ s ++ ": " ++ f xobj)
 primitiveInfo _ ctx notName =

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -152,6 +152,9 @@ binderToHtml (Binder meta xobj) =
       typeSignature = case xobjTy xobj of
         Just t -> show (beautifyType t) -- NOTE: This destroys user-defined names of type variables!
         Nothing -> ""
+      deprecated = case Meta.get "deprecated" meta of
+        Just (XObj (Bol True) _ _) -> True
+        _ -> False
       docString = case Meta.get "doc" meta of
         Just (XObj (Str s) _ _) -> s
         Just found -> pretty found
@@ -161,7 +164,11 @@ binderToHtml (Binder meta xobj) =
         do
           H.a ! A.class_ "anchor" ! A.href (H.stringValue ("#" ++ name)) $
             H.h3 ! A.id (H.stringValue name) $
-              H.toHtml name
+              do
+                H.toHtml name
+                when deprecated $
+                  H.span ! A.class_ "deprecation" $
+                    H.toHtml ("deprecated" :: String)
           H.div ! A.class_ "description" $ H.toHtml description
           H.p ! A.class_ "sig" $ H.toHtml typeSignature
           case maybeNameAndArgs of

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -152,9 +152,13 @@ binderToHtml (Binder meta xobj) =
       typeSignature = case xobjTy xobj of
         Just t -> show (beautifyType t) -- NOTE: This destroys user-defined names of type variables!
         Nothing -> ""
-      deprecated = case Meta.get "deprecated" meta of
+      isDeprecated = case Meta.get "deprecated" meta of
         Just (XObj (Bol True) _ _) -> True
+        Just (XObj (Str _) _ _) -> True
         _ -> False
+      deprecationStr = case Meta.get "deprecated" meta of
+        Just (XObj (Str s) _ _) -> commonmarkToHtml [optSafe] $ Text.pack s
+        _ -> ""
       docString = case Meta.get "doc" meta of
         Just (XObj (Str s) _ _) -> s
         Just found -> pretty found
@@ -166,8 +170,8 @@ binderToHtml (Binder meta xobj) =
             H.h3 ! A.id (H.stringValue name) $
               do
                 H.toHtml name
-                when deprecated $
-                  H.span ! A.class_ "deprecation" $
+                when isDeprecated $
+                  H.span ! A.class_ "deprecation-notice" $
                     H.toHtml ("deprecated" :: String)
           H.div ! A.class_ "description" $ H.toHtml description
           H.p ! A.class_ "sig" $ H.toHtml typeSignature
@@ -175,5 +179,8 @@ binderToHtml (Binder meta xobj) =
             Just nameAndArgs -> H.pre ! A.class_ "args" $ H.toHtml nameAndArgs
             Nothing -> H.span $ H.toHtml ("" :: String)
           H.p ! A.class_ "doc" $ H.preEscapedToHtml htmlDoc
+          when isDeprecated $
+            H.div ! A.class_ "deprecation-text" $
+              H.preEscapedToHtml deprecationStr
 
 --p_ (toHtml (description))


### PR DESCRIPTION
This PR adds the `meta` form `deprecated`. It will be rendered in HTML (see the screenshot below) and in the REPL, like so:

```
> :i =>
=> : Macro
  Defined at line 27, column 3 in '/Users/veitheller/Documents/Code/Github/carp/carp/core/ControlMacros.carp'
  Deprecated: true
```

<img width="699" alt="Bildschirmfoto 2021-01-18 um 13 46 44" src="https://user-images.githubusercontent.com/7725188/104917450-b663f200-5993-11eb-9f61-2b381a6a0736.png">

Cheers