### PR TITLE
fix: mark Float.pi as implementor of pi

### DIFF
--- a/core/Float.carp
+++ b/core/Float.carp
@@ -17,6 +17,7 @@
   (register < (Fn [Float Float] Bool))
   (register > (Fn [Float Float] Bool))
 
+  (implements pi Float.pi)
   (implements + Float.+)
   (implements - Float.-)
   (implements * Float.*)


### PR DESCRIPTION
This PR correctly marks `Float.pi` as an implementor of the `pi` interface. It must have gotten lost when we moved towards `implements`.

Cheers