### PR TITLE
feat: a proper dynamic numeric tower

### DIFF
--- a/core/Dynamic.carp
+++ b/core/Dynamic.carp
@@ -9,8 +9,16 @@
   (defndynamic dec [x]
     (- x 1))
 
+  (defndynamic neg [x]
+    (* -1 x))
+
   (defndynamic mod [x y]
-    (- x (* y (/ x y))))
+    (let-do [a (if (< x 0) (neg x) x)
+             b (if (< y 0) (neg y) y)
+             m a]
+      (while (or (> m b) (= m b))
+        (set! m (- m b)))
+      (if (< a 0) (neg m) m)))
 
   (defmodule Project
     (doc no-echo "Turn off debug printing in the compiler.")

--- a/core/List.carp
+++ b/core/List.carp
@@ -3,15 +3,17 @@
   (defndynamic cxr [x pair]
     (if (= (length x) 0)
       (list 'quote pair)
-      (list
-        (if (= 'a (cadr x))
-          'car
-          (if (= 'd (cadr x))
-            'cdr
-            (macro-error "`cxr` expects either `a` or `d` symbols, got " (cadr x))))
-        (if (= 1 (car x))
-          (cxr (cddr x) pair)
-          (cxr (cons (- (car x) 1) (cdr x)) pair)))))
+      (if (= 0 (car x))
+        (cxr (cddr x) pair)
+        (list
+          (if (= 'a (cadr x))
+            'car
+            (if (= 'd (cadr x))
+              'cdr
+              (macro-error "`cxr` expects either `a` or `d` symbols, got " (cadr x))))
+          (if (= 1 (car x))
+            (cxr (cddr x) pair)
+            (cxr (cons (- (car x) 1) (cdr x)) pair))))))
 
   (defndynamic nthcdr [n pair]
     (cxr (list (+ n 1) 'd) pair))

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -67,17 +67,31 @@ data MatchMode = MatchValue | MatchRef deriving (Eq, Show, Generic)
 
 instance Hashable MatchMode
 
-data Number = Floating Double | Integral Int deriving (Eq, Ord, Generic)
+data Number = Floating Double | Integral Int deriving (Generic)
 
 instance Hashable Number
+
+instance Eq Number where
+  (Floating a) == (Floating b) = a == b
+  (Integral a) == (Integral b) = a == b
+  (Floating a) == (Integral b) = a == fromIntegral b
+  (Integral a) == (Floating b) = fromIntegral a == b
+
+instance Ord Number where
+  (Floating a) <= (Floating b) = a <= b
+  (Integral a) <= (Integral b) = a <= b
+  (Floating a) <= (Integral b) = a <= fromIntegral b
+  (Integral a) <= (Floating b) = fromIntegral a <= b
 
 instance Num Number where
   (Floating a) + (Floating b) = Floating (a + b)
   (Integral a) + (Integral b) = Integral (a + b)
-  _ + _ = error "+"
-  (Floating a) * (Floating b) = Floating (a * b)
+  (Floating a) + (Integral b) = Floating (a + fromIntegral b)
+  (Integral a) + (Floating b) = Floating (fromIntegral a + b)
   (Integral a) * (Integral b) = Integral (a * b)
-  _ * _ = error "*"
+  (Floating a) * (Floating b) = Floating (a * b)
+  (Integral a) * (Floating b) = Floating (fromIntegral a * b)
+  (Floating a) * (Integral b) = Floating (a * fromIntegral b)
   negate (Floating a) = Floating (negate a)
   negate (Integral a) = Integral (negate a)
   abs (Floating a) = Floating (abs a)

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -262,7 +262,8 @@ dynamicModule =
             f "relative-include" commandAddRelativeInclude "adds a relative include, i.e. a C `include` with quotes. It also prepends the current directory." "(relative-include \"myheader.h\")",
             f "save-docs-internal" commandSaveDocsInternal "is the internal companion command to `save-docs`. `save-docs` should be called instead." "(save-docs-internal 'Module)",
             f "read-file" commandReadFile "reads a file into a string." "(read-file \"myfile.txt\")",
-            f "hash" commandHash "calculates the hash associated with a value." "(hash '('my 'value)) ; => 3175346968842793108"
+            f "hash" commandHash "calculates the hash associated with a value." "(hash '('my 'value)) ; => 3175346968842793108",
+            f "round" commandRound "rounds its numeric argument." "(round 2.4) ; => 2"
           ]
     binaries =
       let f = addBinaryCommand . spath

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -26,6 +26,7 @@ module Types
     getStructName,
     getPathFromStructName,
     getNameFromStructName,
+    promoteNumber,
   )
 where
 
@@ -350,3 +351,19 @@ getPathFromStructName structName =
 
 getNameFromStructName :: String -> String
 getNameFromStructName structName = last (map unpack (splitOn (pack ".") (pack structName)))
+
+-- N.B.: promoteNumber is only safe for numeric types!
+promoteNumber :: Ty -> Ty -> Ty
+promoteNumber a b | a == b = a
+promoteNumber ByteTy other = other
+promoteNumber other ByteTy = other
+promoteNumber IntTy other = other
+promoteNumber other IntTy = other
+promoteNumber LongTy other = other
+promoteNumber other LongTy = other
+promoteNumber FloatTy other = other
+promoteNumber other FloatTy = other
+promoteNumber DoubleTy _ = DoubleTy
+promoteNumber _ DoubleTy = DoubleTy
+promoteNumber a b =
+  error ("promoteNumber called with non-numbers: " ++ show a ++ ", " ++ show b)

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -142,6 +142,12 @@
 (defmacro test-walk-replace []
   (eval (walk-replace '((+ *)) '(+ 2 (+ 2 3)))))
 
+(defmacro test-cxr [ins l]
+  (eval (cxr ins l)))
+
+(defmacro test-neg [x]
+  (neg x))
+
 
 (deftest test
   (assert-true test
@@ -207,6 +213,12 @@
   (assert-false test
                 (test-< 2.0f 2.0f)
                 "< macro works as expected on floats II")
+  (assert-false test
+                (test-< 3.0 2.0f)
+                "< macro works as expected across types I")
+  (assert-true test
+               (test-< 1l 2.0f)
+               "< macro works as expected across types II")
   (assert-true test
                (test-> 2 1)
                "> macro works as expected on ints I")
@@ -231,6 +243,12 @@
   (assert-false test
                 (test-> 2.0f 2.0f)
                 "> macro works as expected on floats II")
+  (assert-true test
+               (test-> 2 1.0f)
+               "> macro works as expected across types I")
+  (assert-false test
+                (test-> 2.0 3l)
+                "> macro works as expected across types II")
 
   (assert-true test
                (test-= 2 2)
@@ -257,6 +275,12 @@
                 (test-= 2.0f 1.0f)
                 "= macro works as expected on floats II")
   (assert-true test
+               (test-= 2.0f 2)
+               "= macro works as expected across numeric types I")
+  (assert-false test
+                (test-= 2.0 1l)
+                "= macro works as expected across numeric types II")
+  (assert-true test
                (test-= "erik" "erik")
                "= macro works as expected on strings I")
   (assert-false test
@@ -268,6 +292,9 @@
   (assert-false test
                 (test-= veit heller)
                 "= macro works as expected on symbols II")
+  (assert-false test
+                (test-= veit "veit")
+                "= macro works as expected across types")
   (assert-false test
                 (and* true true false)
                 "and* macro works as expected I")
@@ -378,4 +405,16 @@
                 12
                 (test-walk-replace)
                 "walk-replace works as expected")
+  (assert-equal test
+                -1
+                (test-neg 1)
+                "Dynamic.neg works as expected")
+  (assert-equal test
+                4
+                (test-cxr (1 a 3 d) (1 2 3 4))
+                "Dynamic.cxr works as expected I")
+  (assert-equal test
+                1
+                (test-cxr (0 d 1 a) (1 2 3 4))
+                "Dynamic.cxr works as expected I")
 )

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -148,6 +148,9 @@
 (defmacro test-neg [x]
   (neg x))
 
+(defmacro test-round [n]
+  (round n))
+
 
 (deftest test
   (assert-true test
@@ -417,4 +420,12 @@
                 1
                 (test-cxr (0 d 1 a) (1 2 3 4))
                 "Dynamic.cxr works as expected I")
+  (assert-equal test
+                3
+                (test-round 3.4)
+                "Dynamic.round works as expected I")
+  (assert-equal test
+                3
+                (test-round 2.51)
+                "Dynamic.round works as expected II")
 )


### PR DESCRIPTION
The following things were changed and/or added:
- `Dynamic.neg` was added
- `Dynamic.mod` was changed to work on float values
- `Dynamic.cxr` was changed to work with `0` instructions
- `Dynamic.=` was changed to ignore the type of the number
- `Dynamic.round` was added
- dynamic arithmetic was changed to respect the numeric type tower
- the instances of `Eq` and `Ord` for `Number` are no longer derived, so that they work across numeric types
- the instance of `Num` for `Number` was changed to work across numeric types
- `promoteNumber` was added as a type function to implement the numeric tower.

The numeric tower is as follows:

```
Byte -> Int -> Long -> Float -> Double
```

Cheers