### PR TITLE
fix: deal with literals in match

### DIFF
--- a/test/output/test/test-for-errors/match-literals.carp.output.expected
+++ b/test/output/test/test-for-errors/match-literals.carp.output.expected
@@ -1,0 +1,1 @@
+match-literals.carp:5:18 I can’t use `0` in match, only lists and symbols are allowed

--- a/test/test-for-errors/match-literals.carp
+++ b/test/test-for-errors/match-literals.carp
@@ -1,0 +1,6 @@
+(Project.config "file-path-print-length" "short")
+
+(defn test [m]
+ (match m
+     (Maybe.Just 0) (println* "hi")
+     _ (println* "bye")))


### PR DESCRIPTION
This PR fixes #1113 by adding an analysis into `expand` that checks whether anything other than lists and symbols are used in the left hand side of a `match`. The code is quite inelegant; if anyone has any ideas on how to make it better, I’d love to hear it!

I also added a test case for the new error message.

Cheers