### PR TITLE
docs: don’t confuse liquid

### DIFF
--- a/docs/Format_Strings.md
+++ b/docs/Format_Strings.md
@@ -1,5 +1,7 @@
 # Format Strings
 
+{% raw %}
+
 Carp as to ways to format strings, `fmt` and `fstr`. In this document, we
 explore both functions in detail.
 
@@ -57,3 +59,5 @@ literal `{` need to be escaped as `{{`.
 
 While possible, it is discouraged to use complicated or even multiline
 expressions inside `fstr`.
+
+{% endraw %}


### PR DESCRIPTION
This PR fixes [the recent docs build failure](https://github.com/carp-lang/carp-docs/runs/1767071759) that was caused by an interplay of our escaping syntax and Jekyll’s templating language Liquid.

Reading up on Liquid, you can mark blocks as needing no templating by using `{% raw %}` blocks. Sadly, those also get rendered in Markdown.

Cheers