### PR TITLE
fix: release resources on break

### DIFF
--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Concretize where

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -595,8 +595,12 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
         XObj (Interface _ _) _ _ : _ ->
           pure ""
         -- Break
-        [XObj Break _ _] -> do
+        [XObj Break minfo _] -> do
+          case minfo of
+            Just i -> delete indent i
+            Nothing -> return ()
           appendToSrc (addIndent indent ++ "break;\n")
+          appendToSrc (addIndent indent ++ "// Unreachable:\n")
           pure ""
         -- Function application (functions with overridden names)
         func@(XObj (Sym _ (LookupGlobalOverride overriddenName)) _ _) : args ->


### PR DESCRIPTION
This PR fixes #1052 by fixing up `break` statements with the context of which resources need to be released.

This is achieved by descending from any `let` and `while` statement into an enclosed `break` and adding any variables that need to be freed in that scope to its deleters.

Cheers