### PR TITLE
fix: register should only take unqualified symbols

### DIFF
--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -533,8 +533,15 @@ registerInternal ctx name ty override =
        in (ctx {contextGlobalEnv = env'}, dynamicNil)
 
 primitiveRegister :: VariadicPrimitiveCallback
-primitiveRegister _ ctx [XObj (Sym (SymPath _ name) _) _ _, ty] =
+primitiveRegister _ ctx [XObj (Sym (SymPath [] name) _) _ _, ty] =
   registerInternal ctx name ty Nothing
+primitiveRegister _ ctx [invalid@(XObj (Sym _ _) _ _), _] =
+  pure
+    ( evalError
+        ctx
+        ("`register` expects an unqualified name as first argument, but got `" ++ pretty invalid ++ "`")
+        (xobjInfo invalid)
+    )
 primitiveRegister _ ctx [name, _] =
   pure
     ( evalError

--- a/test/output/test/test-for-errors/qualified-register.carp.output.expected
+++ b/test/output/test/test-for-errors/qualified-register.carp.output.expected
@@ -1,0 +1,1 @@
+qualified-register.carp:3:11 `register` expects an unqualified name as first argument, but got `X.x`

--- a/test/test-for-errors/qualified-register.carp
+++ b/test/test-for-errors/qualified-register.carp
@@ -1,0 +1,3 @@
+(Project.config "file-path-print-length" "short")
+
+(register X.x (Fn [] ()))


### PR DESCRIPTION
This PR fixes #1031 by enforcing that the symbol argument to `register` is unqualified.

Tests are included.

Cheers