### PR TITLE
docs: fix typo in make-deriver and add implementor note

### DIFF
--- a/core/Derive.carp
+++ b/core/Derive.carp
@@ -1,3 +1,8 @@
+; Implementors’ note: this code could be made more elegant by using quasiquotes
+; but quasiquoting is actually loaded after this module, so we can’t rely on
+; that functionality.
+
+
 (doc Derive "is a mechanism for deriving interfaces automatically.
 
 Please reference [the documentation](https://github.com/carp-lang/Carp/blob/master/docs/Derive.md)
@@ -15,7 +20,7 @@ Example:
 (make-deriver 'zero []
   (fn [t]
     (cons 'init
-      (map (fn [_] '(zero)) (members t)))))
+      (map (fn [_] '(zero)) (eval `(members %t)))))
 ```")
   (defndynamic make-deriver [f args body]
     (set! Derive.derivers


### PR DESCRIPTION
This PR fixes a typo in the example for `Derive.make-deriver` and adds a note for future maintainers at the top of the page to save them time.

Cheers