### PR TITLE
refactor: don’t print compilation info on implicit compile

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -643,13 +643,14 @@ executeCommand ctx@(Context env _ _ _ _ _ _ _) xobj =
             [ XObj Do (Just dummyInfo) Nothing,
               xobj',
               XObj
-                (Lst [XObj (Sym (SymPath [] "build") Symbol) (Just dummyInfo) Nothing])
+                (Lst [XObj (Sym (SymPath [] "build") Symbol) (Just dummyInfo) Nothing, trueXObj])
                 (Just dummyInfo)
                 Nothing,
               XObj
                 (Lst [XObj (Sym (SymPath [] "run") Symbol) (Just dummyInfo) Nothing])
                 (Just dummyInfo)
-                Nothing
+                Nothing,
+              (XObj (Lst []) (Just dummyInfo) (Just UnitTy))
             ]
         )
         (Just dummyInfo)

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -233,7 +233,6 @@ dynamicModule =
        in [ f "quit" commandQuit "quits the program." "(quit)",
             f "cat" commandCat "spits out the generated C code." "(cat)",
             f "run" commandRunExe "runs the built executable." "(run)",
-            f "build" (commandBuild False) "builds the current code to an executable." "(build)",
             f "reload" commandReload "reloads all currently loaded files that weren’t marked as only loading once (see `load` and `load-once`)." "(reload)",
             f "env" commandListBindings "lists all current bindings." "(env)",
             f "project" commandProject "prints the current project state." "(project)",
@@ -285,7 +284,8 @@ dynamicModule =
             f "str" commandStr "stringifies its arguments." "(str 1 \" \" 2 \" \" 3) ; => \"1 2 3\"",
             f "s-expr" commandSexpression "returns the s-expression associated with a binding. When the binding is a type, the deftype form is returned instead of the type's module by default. Pass an optional bool argument to explicitly request the module for a type instead of its definition form. If the bool is true, the module for the type will be returned. Returns an error when no definition is found for the binding." "(s-expr foo), (s-expr foo true)",
             f "load" commandLoad "loads a file into the current environment." "(load \"myfile.carp\")\n(load \"myrepo@version\" \"myfile\")",
-            f "load-once" commandLoadOnce "loads a file and prevents it from being reloaded (see `reload`)." "(load-once \"myfile.carp\")\n(load \"myrepo@version\" \"myfile\")"
+            f "load-once" commandLoadOnce "loads a file and prevents it from being reloaded (see `reload`)." "(load-once \"myfile.carp\")\n(load \"myrepo@version\" \"myfile\")",
+            f "build" commandBuild "builds the current code to an executable. Optionally takes a boolean that, when true, silences the output." "(build)"
           ]
     unaries' =
       let f = makeUnaryPrim . spath


### PR DESCRIPTION
This PR fixes #779 by hiding the compile information on an implicit compile (for instance, when typing `(Int.+ 1 2)` in the REPL) and letting it return `nil` instead of `0`, avoiding a print.

To this end, it also extends `build` by adding an optional boolean argument that specifies whether build information should be printed.

Cheers