### PR TITLE
refactor: Move evaluation errors into a separate module

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -26,6 +26,7 @@ library
                        Deftype,
                        Emit,
                        Env,
+                       EvalError,
                        Eval,
                        Expand,
                        GenerateConstraints,

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -14,6 +14,7 @@ import Data.Maybe (fromJust, fromMaybe, isJust)
 import Emit
 import Env
 import Expand
+import EvalError
 import Infer
 import Info
 import Lookup
@@ -81,7 +82,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
         checkStatic v = pure v
         unwrapLookup =
           fromMaybe
-            (evalError ctx ("Can't find symbol '" ++ show n ++ "'") info) -- all else failed, error.
+            (throwErr (SymbolNotFound spath) ctx info) -- all else failed, error.
         tryAllLookups =
           ( case preference of
               PreferDynamic -> tryDynamicLookup
@@ -118,7 +119,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
         checkPrivate meta found =
           pure $
             if metaIsTrue meta "private"
-              then evalError ctx ("The binding: " ++ show (getPath found) ++ " is private; it may only be used within the module that defines it.") info
+              then throwErr (PrivateBinding (getPath found)) ctx info
               else (ctx, Right (resolveDef found))
     Arr objs -> do
       (newCtx, evaled) <- foldlM successiveEval (ctx, Right []) objs
@@ -154,84 +155,28 @@ eval ctx xobj@(XObj o info ty) preference resolver =
               case xobjObj cond of
                 Bol b -> eval newCtx (if b then mtrue else mfalse) preference ResolveLocal
                 _ ->
-                  pure
-                    ( evalError
-                        ctx
-                        ( "This `if` condition contains the non-boolean value `"
-                            ++ pretty cond
-                            ++ "`"
-                        )
-                        (xobjInfo cond)
-                    )
+                  pure (throwErr (IfContainsNonBool cond) ctx (xobjInfo cond))
             Left e -> pure (newCtx, Left e)
         XObj If _ _ : _ ->
-          pure
-            ( evalError
-                ctx
-                ( "I didn’t understand this `if`.\n\n Got:\n```\n" ++ pretty xobj
-                    ++ "\n```\n\nExpected the form:\n```\n(if cond then else)\n```\n"
-                )
-                (xobjInfo xobj)
-            )
+          pure (throwErr (IfMalformed xobj) ctx (xobjInfo xobj))
         [XObj (Defn _) _ _, name, args@(XObj (Arr a) _ _), _] ->
           case xobjObj name of
             (Sym (SymPath [] _) _) ->
               if all isUnqualifiedSym a
                 then specialCommandDefine ctx xobj
                 else
-                  pure
-                    ( evalError
-                        ctx
-                        ( "`defn` requires all arguments to be unqualified symbols, but it got `"
-                            ++ pretty args
-                            ++ "`"
-                        )
-                        (xobjInfo xobj)
-                    )
+                  pure (throwErr (DefnContainsQualifiedArgs args) ctx (xobjInfo xobj))
             _ ->
-              pure
-                ( evalError
-                    ctx
-                    ( "`defn` identifiers must be unqualified symbols, but it got `"
-                        ++ pretty name
-                        ++ "`"
-                    )
-                    (xobjInfo xobj)
-                )
+              pure (throwErr (DefnIdentifierIsQualified name) ctx (xobjInfo xobj))
         [XObj (Defn _) _ _, _, invalidArgs, _] ->
-          pure
-            ( evalError
-                ctx
-                ( "`defn` requires an array of symbols as argument list, but it got `"
-                    ++ pretty invalidArgs
-                    ++ "`"
-                )
-                (xobjInfo xobj)
-            )
+          pure (throwErr (DefnContainsInvalidArgs invalidArgs) ctx (xobjInfo xobj))
         (defn@(XObj (Defn _) _ _) : _) ->
-          pure
-            ( evalError
-                ctx
-                ( "I didn’t understand the `defn` at " ++ prettyInfoFromXObj xobj
-                    ++ ":\n\n"
-                    ++ pretty xobj
-                    ++ "\n\nIs it valid? Every `defn` needs to follow the form `(defn name [arg] body)`."
-                )
-                (xobjInfo defn)
-            )
+          pure (throwErr (DefnMalformed xobj) ctx (xobjInfo defn))
         [XObj Def _ _, name, _] ->
           if isUnqualifiedSym name
             then specialCommandDefine ctx xobj
             else
-              pure
-                ( evalError
-                    ctx
-                    ( "`def` identifiers must be unqualified symbols, but it got `"
-                        ++ pretty name
-                        ++ "`"
-                    )
-                    (xobjInfo xobj)
-                )
+              pure (throwErr (DefIdentifierIsQualified name) ctx (xobjInfo xobj))
         [the@(XObj The _ _), t, value] ->
           do
             (newCtx, evaledValue) <- expandAll (evalDynamic ResolveLocal) ctx value -- TODO: Why expand all here?
@@ -242,34 +187,12 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                   Right (XObj (Lst [the, t, okValue]) info ty)
               )
         (XObj The _ _ : _) ->
-          pure
-            ( evalError
-                ctx
-                ( "I didn’t understand the `the` at " ++ prettyInfoFromXObj xobj
-                    ++ ":\n\n"
-                    ++ pretty xobj
-                    ++ "\n\nIs it valid? Every `the` needs to follow the form `(the type expression)`."
-                )
-                (xobjInfo xobj)
-            )
+          pure (throwErr (TheMalformed xobj) ctx (xobjInfo xobj))
         [XObj Let _ _, XObj (Arr bindings) _ _, body]
           | odd (length bindings) ->
-            pure
-              ( evalError
-                  ctx
-                  ("Uneven number of forms in `let`: " ++ pretty xobj)
-                  (xobjInfo xobj) -- Unreachable?
-              )
+              pure (throwErr (LetUnevenForms xobj) ctx (xobjInfo xobj))
           | not (all isSym (evenIndices bindings)) ->
-            pure
-              ( evalError
-                  ctx
-                  ( "`let` identifiers must be symbols, but it got `"
-                      ++ joinWithSpace (map pretty bindings)
-                      ++ "`"
-                  )
-                  (xobjInfo xobj)
-              )
+              pure (throwErr (LetMalformedIdentifiers bindings) ctx (xobjInfo xobj))
           | otherwise ->
             do
               let binds = unwrapVar (pairwise bindings) []
@@ -308,7 +231,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
               Right b ->
                 if all isUnqualifiedSym a
                   then (newCtx, Right (XObj (Closure (XObj (Lst [f, args, b]) info ty) (CCtx newCtx)) info ty))
-                  else evalError ctx ("`fn` requires all arguments to be unqualified symbols, but it got `" ++ pretty args ++ "`") (xobjInfo args)
+                  else (throwErr (FnContainsQualifiedArgs args) ctx (xobjInfo args))
               Left err -> (ctx, Left err)
         XObj (Closure (XObj (Lst [XObj (Fn _ _) _ _, XObj (Arr params) _ _, body]) _ _) (CCtx c)) _ _ : args ->
           case checkArity "<closure>" params args of
@@ -410,10 +333,10 @@ eval ctx xobj@(XObj o info ty) preference resolver =
         XObj With _ _ : xobj'@(XObj (Sym path _) _ _) : forms ->
           specialCommandWith ctx xobj' path forms
         XObj With _ _ : _ ->
-          pure (evalError ctx ("Invalid arguments to `with`: " ++ pretty xobj) (xobjInfo xobj))
+          pure (throwErr (WithContainsInvalidArgs xobj) ctx (xobjInfo xobj))
         XObj SetBang _ _ : args -> specialCommandSet ctx args
         [XObj Do _ _] ->
-          pure (evalError ctx "No forms in do" (xobjInfo xobj))
+          pure (throwErr DoMissingForms ctx (xobjInfo xobj))
         XObj Do _ _ : rest -> foldlM successiveEval' (ctx, dynamicNil) rest
           where
             successiveEval' (ctx', acc) x =
@@ -425,7 +348,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
         [XObj Address _ _, value] ->
           specialCommandAddress ctx value
         [] -> pure (ctx, dynamicNil)
-        _ -> pure (evalError ctx ("I did not understand the form `" ++ pretty xobj ++ "`") (xobjInfo xobj))
+        _ -> pure (throwErr (UnknownForm xobj) ctx (xobjInfo xobj))
     badArity name params args i = case checkArity name params args of
       Left err -> pure (evalError ctx err i)
       Right () -> error "badarity"
@@ -532,15 +455,7 @@ apply ctx@Context {contextInternalEnv = internal} body params args =
         [a, b] -> callWith env a b
         [a] -> callWith env a []
         _ ->
-          pure
-            ( evalError
-                ctx
-                ( "I didn’t understand this macro’s argument split, got `"
-                    ++ joinWith "," allParams
-                    ++ "`, but expected exactly one `:rest` separator."
-                )
-                Nothing
-            )
+          pure (throwErr (MacroBadArgumentSplit allParams) ctx Nothing)
   where
     callWith _ proper rest = do
       let n = length proper
@@ -716,7 +631,7 @@ specialCommandAddress ctx xobj =
           Right (annXObj, _) -> return (newCtx, Right annXObj)
           Left err ->
             return (ctx, Left err)
-    _ -> return (evalError ctx ("Can't get the address of non-symbol " ++ pretty xobj) (xobjInfo xobj))
+    _ -> pure (throwErr (AddressContainsNonSymbol xobj) ctx (xobjInfo xobj))
 
 specialCommandWhile :: Context -> XObj -> XObj -> IO (Context, Either EvalError XObj)
 specialCommandWhile ctx cond body = do
@@ -731,15 +646,7 @@ specialCommandWhile ctx cond body = do
               specialCommandWhile newCtx' cond body
             else pure (newCtx, dynamicNil)
         _ ->
-          pure
-            ( evalError
-                ctx
-                ( "This `while` condition contains the non-boolean value '"
-                    ++ pretty c
-                    ++ "`"
-                )
-                (xobjInfo c)
-            )
+          pure (throwErr (WhileContainsNonBool c) ctx (xobjInfo c))
     Left e -> pure (newCtx, Left e)
 
 getSigFromDefnOrDef :: Context -> Env -> FilePathPrintLength -> XObj -> Either EvalError (Maybe (Ty, XObj))
@@ -810,7 +717,7 @@ primitiveDefmodule xobj ctx@(Context env i _ pathStrings _ _ _ _) (XObj (Sym (Sy
     updateExistingModule (Binder meta (XObj (Lst [XObj MetaStub _ _, _]) _ _)) =
       defineNewModule meta
     updateExistingModule _ =
-      pure (evalError ctx ("Can't redefine '" ++ moduleName ++ "' as module") (xobjInfo xobj))
+      pure (throwErr (ModuleRedefinition moduleName) ctx (xobjInfo xobj))
     defineNewModule :: MetaData -> IO (Context, Either EvalError XObj)
     defineNewModule meta =
       pure (ctx', dynamicNil)
@@ -833,9 +740,9 @@ primitiveDefmodule xobj ctx@(Context env i _ pathStrings _ _ _ _) (XObj (Sym (Sy
           Left _ -> pure (ctx'', res)
           Right r -> evalDynamic ResolveLocal ctx'' r
 primitiveDefmodule _ ctx (x : _) =
-  pure (evalError ctx ("`defmodule` expects a symbol, got '" ++ pretty x ++ "' instead.") (xobjInfo x))
-primitiveDefmodule _ ctx [] =
-  pure (evalError ctx "`defmodule` requires at least a symbol, received none." (Just dummyInfo))
+  pure (throwErr (DefmoduleContainsNonSymbol x) ctx (xobjInfo x))
+primitiveDefmodule xobj ctx [] =
+  pure (throwErr DefmoduleNoArgs ctx (xobjInfo xobj))
 
 -- | "NORMAL" COMMANDS (just like the ones in Command.hs, but these need access to 'eval', etc.)
 
@@ -844,29 +751,25 @@ commandLoad :: VariadicCommandCallback
 commandLoad ctx [xobj@(XObj (Str path) i _), XObj (Str toLoad) _ _] =
   loadInternal ctx xobj path i (Just toLoad) DoesReload
 commandLoad ctx [XObj (Str _) _ _, x] =
-  pure $ evalError ctx ("Invalid args to `load`: " ++ pretty x) (xobjInfo x)
+  pure $ throwErr (LoadInvalidArgs [x]) ctx (xobjInfo x)
 commandLoad ctx [x, _] =
-  pure $ evalError ctx ("Invalid args to `load`: " ++ pretty x) (xobjInfo x)
+  pure $ throwErr (LoadInvalidArgs [x]) ctx (xobjInfo x)
 commandLoad ctx [xobj@(XObj (Str path) i _)] =
   loadInternal ctx xobj path i Nothing DoesReload
-commandLoad ctx [x] =
-  pure $ evalError ctx ("Invalid args to `load`: " ++ pretty x) (xobjInfo x)
-commandLoad ctx _ =
-  pure $ evalError ctx "Invalid args to `load`, expected (load str optional:fileFromRepo)" Nothing
+commandLoad ctx x =
+  pure $ throwErr (LoadInvalidArgs x) ctx Nothing
 
 commandLoadOnce :: VariadicCommandCallback
 commandLoadOnce ctx [xobj@(XObj (Str path) i _), XObj (Str toLoad) _ _] =
   loadInternal ctx xobj path i (Just toLoad) Frozen
 commandLoadOnce ctx [XObj (Str _) _ _, x] =
-  pure $ evalError ctx ("Invalid args to `load-once`: " ++ pretty x) (xobjInfo x)
+  pure $ throwErr (LoadOnceInvalidArgs [x]) ctx (xobjInfo x)
 commandLoadOnce ctx [x, _] =
-  pure $ evalError ctx ("Invalid args to `load-once`: " ++ pretty x) (xobjInfo x)
+  pure $ throwErr (LoadOnceInvalidArgs [x]) ctx (xobjInfo x)
 commandLoadOnce ctx [xobj@(XObj (Str path) i _)] =
   loadInternal ctx xobj path i Nothing Frozen
-commandLoadOnce ctx [x] =
-  pure $ evalError ctx ("Invalid args to `load-once`: " ++ pretty x) (xobjInfo x)
-commandLoadOnce ctx _ =
-  pure $ evalError ctx "Invalid args to `load-once`, expected `(load-once str optional:fileFromRepo)`" Nothing
+commandLoadOnce ctx x =
+  pure $ throwErr (LoadOnceInvalidArgs x) ctx Nothing
 
 loadInternal :: Context -> XObj -> String -> Maybe Info -> Maybe String -> ReloadMode -> IO (Context, Either EvalError XObj)
 loadInternal ctx xobj path i fileToLoad reloadMode = do
@@ -930,41 +833,16 @@ loadInternal ctx xobj path i fileToLoad reloadMode = do
         else map fst $ filter (isFrozen . snd) (projectFiles proj)
     isFrozen Frozen = True
     isFrozen _ = False
-    fppl ctx' =
-      projectFilePathPrintLength (contextProj ctx')
     invalidPath ctx' path' =
-      evalError
-        ctx'
-        ( ( case contextExecMode ctx' of
-              Check ->
-                machineReadableInfoFromXObj (fppl ctx') xobj ++ " I can't find a file named: '" ++ path' ++ "'"
-              _ -> "I can't find a file named: '" ++ path' ++ "'"
-          )
-            ++ "\n\nIf you tried loading an external package, try appending a version string (like `@master`)"
-        )
-        (xobjInfo xobj)
+      throwErr (LoadFileNotFound path') ctx' (xobjInfo xobj)
     invalidPathWith ctx' path' stderr cleanup cleanupPath = do
       _ <- liftIO $ when cleanup (removeDirectoryRecursive cleanupPath)
       pure $
-        evalError
-          ctx'
-          ( ( case contextExecMode ctx' of
-                Check ->
-                  machineReadableInfoFromXObj (fppl ctx') xobj ++ " I can't find a file named: '" ++ path' ++ "'"
-                _ -> "I can't find a file named: '" ++ path' ++ "'"
-            )
-              ++ "\n\nI tried interpreting the statement as a git import, but got: "
-              ++ stderr
-          )
-          (xobjInfo xobj)
+        throwErr (LoadGitFailure path' stderr) ctx' (xobjInfo xobj)
     replaceC _ _ [] = []
     replaceC c s (a : b) = if a == c then s ++ replaceC c s b else a : replaceC c s b
     cantLoadSelf ctx' path' =
-      case contextExecMode ctx' of
-        Check ->
-          evalError ctx' (machineReadableInfoFromXObj (fppl ctx') xobj ++ " A file can't load itself: '" ++ path' ++ "'") (xobjInfo xobj)
-        _ ->
-          evalError ctx' ("A file can't load itself: '" ++ path' ++ "'") (xobjInfo xobj)
+      throwErr (LoadRecursiveLoad path') ctx' (xobjInfo xobj)
     tryInstall path' =
       let split = splitOn "@" path'
        in tryInstallWithCheckout (joinWith "@" (init split)) (last split)
@@ -1145,7 +1023,7 @@ primitiveDefdynamic _ ctx (XObj (Sym (SymPath [] name) _) _ _) value = do
     Right evaledBody ->
       dynamicOrMacroWith newCtx (\path -> [XObj DefDynamic Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing, evaledBody]) DynamicTy name value
 primitiveDefdynamic _ ctx notName _ =
-  pure (evalError ctx ("`defndynamic` expected a name as first argument, but got " ++ pretty notName) (xobjInfo notName))
+  pure (throwErr (DefnDynamicInvalidName notName) ctx (xobjInfo notName))
 
 specialCommandSet :: Context -> [XObj] -> IO (Context, Either EvalError XObj)
 specialCommandSet ctx [orig@(XObj (Sym path@(SymPath _ n) _) _ _), val] =
@@ -1160,7 +1038,7 @@ specialCommandSet ctx [orig@(XObj (Sym path@(SymPath _ n) _) _ _), val] =
             lookupBinder path e
               >>= \binder -> pure (binder, setGlobal, e)
    in maybe
-        (pure $ evalError ctx ("I couldn't find the variable " ++ pretty orig ++ ", did you define it using `def` or `defdynamic`?") (xobjInfo orig))
+        (pure $ (throwErr (SetVarNotFound orig) ctx (xobjInfo orig)))
         (\(binder', setter', env') -> evalAndSet binder' setter' env')
         (lookupInternal <|> lookupGlobal)
   where
@@ -1188,9 +1066,9 @@ specialCommandSet ctx [orig@(XObj (Sym path@(SymPath _ n) _) _ _), val] =
       where
         success c xo = (c {contextInternalEnv = Just (setStaticOrDynamicVar (SymPath [] n) env binder xo)}, dynamicNil)
 specialCommandSet ctx [notName, _] =
-  pure (evalError ctx ("`set!` expected a name as first argument, but got " ++ pretty notName) (xobjInfo notName))
+  pure (throwErr (SetInvalidVarName notName) ctx (xobjInfo notName))
 specialCommandSet ctx args =
-  pure (evalError ctx ("`set!` takes a name and a value, but got `" ++ unwords (map pretty args)) (if null args then Nothing else xobjInfo (head args)))
+  pure (throwErr (SetInvalidArgs args) ctx (if null args then Nothing else xobjInfo (head args)))
 
 -- | Convenience method for signifying failure in a given context.
 failure :: Context -> XObj -> EvalError -> (Context, Either EvalError a)
@@ -1207,7 +1085,7 @@ typeCheckValueAgainstBinder ctx val binder = do
   where
     path = getPath (binderXObj binder)
     binderTy = xobjTy (binderXObj binder)
-    typeErr x = evalError ctx ("can't `set!` " ++ show path ++ " to a value of type " ++ show (fromJust (xobjTy x)) ++ ", " ++ show path ++ " has type " ++ show (fromJust binderTy)) (xobjInfo x)
+    typeErr x = throwErr (SetTypeMismatch path (fromJust (xobjTy x)) (fromJust binderTy)) ctx (xobjInfo x)
     go ctx'' (Just DynamicTy) x = (ctx'', Right x)
     go ctx'' t x@(XObj _ _ t') = if t == t' then (ctx'', Right x) else typeErr x
 
@@ -1240,7 +1118,7 @@ primitiveEval _ ctx val = do
         Right ok -> do
           (finalCtx, res) <- evalDynamic ResolveLocal newCtx' ok
           pure $ case res of
-            Left (HasStaticCall x i) -> evalError ctx ("Unexpected static call in " ++ pretty x) i
+            Left (HasStaticCall x i) -> throwErr (StaticCall x) ctx i
             _ -> (finalCtx, res)
 
 dynamicOrMacro :: Context -> Obj -> Ty -> String -> XObj -> XObj -> IO (Context, Either EvalError XObj)

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -13,8 +13,8 @@ import Data.List.Split (splitOn, splitWhen)
 import Data.Maybe (fromJust, fromMaybe, isJust)
 import Emit
 import Env
-import Expand
 import EvalError
+import Expand
 import Infer
 import Info
 import Lookup
@@ -164,8 +164,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
             (Sym (SymPath [] _) _) ->
               if all isUnqualifiedSym a
                 then specialCommandDefine ctx xobj
-                else
-                  pure (throwErr (DefnContainsQualifiedArgs args) ctx (xobjInfo xobj))
+                else pure (throwErr (DefnContainsQualifiedArgs args) ctx (xobjInfo xobj))
             _ ->
               pure (throwErr (DefnIdentifierIsQualified name) ctx (xobjInfo xobj))
         [XObj (Defn _) _ _, _, invalidArgs, _] ->
@@ -175,8 +174,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
         [XObj Def _ _, name, _] ->
           if isUnqualifiedSym name
             then specialCommandDefine ctx xobj
-            else
-              pure (throwErr (DefIdentifierIsQualified name) ctx (xobjInfo xobj))
+            else pure (throwErr (DefIdentifierIsQualified name) ctx (xobjInfo xobj))
         [the@(XObj The _ _), t, value] ->
           do
             (newCtx, evaledValue) <- expandAll (evalDynamic ResolveLocal) ctx value -- TODO: Why expand all here?
@@ -190,9 +188,9 @@ eval ctx xobj@(XObj o info ty) preference resolver =
           pure (throwErr (TheMalformed xobj) ctx (xobjInfo xobj))
         [XObj Let _ _, XObj (Arr bindings) _ _, body]
           | odd (length bindings) ->
-              pure (throwErr (LetUnevenForms xobj) ctx (xobjInfo xobj))
+            pure (throwErr (LetUnevenForms xobj) ctx (xobjInfo xobj))
           | not (all isSym (evenIndices bindings)) ->
-              pure (throwErr (LetMalformedIdentifiers bindings) ctx (xobjInfo xobj))
+            pure (throwErr (LetMalformedIdentifiers bindings) ctx (xobjInfo xobj))
           | otherwise ->
             do
               let binds = unwrapVar (pairwise bindings) []

--- a/src/EvalError.hs
+++ b/src/EvalError.hs
@@ -1,7 +1,12 @@
--- | Module EvalError defines errors that may occur during evaluation
+-- | Module EvalError defines errors that may occur during evaluation.
 module EvalError
   ( EvaluationError (..),
     throwErr,
+    defnInvalidArgs,
+    loadInvalidArgs,
+    loadOnceInvalidArgs,
+    withInvalidArgs,
+    setInvalidArgs,
   )
 where
 
@@ -12,7 +17,11 @@ import TypeError
 import Util
 import Types
 
+--------------------------------------------------------------------------------
+-- Data (Evaluation Errors)
+
 -- | Errors that occur when evaluating forms.
+-- Mostly called from the evaluator.
 data EvaluationError
   = SymbolNotFound SymPath
   | PrivateBinding SymPath
@@ -22,7 +31,6 @@ data EvaluationError
   | -- Defn
     DefnContainsQualifiedArgs XObj
   | DefnIdentifierIsQualified XObj
-  | DefnContainsInvalidArgs XObj
   | DefnMalformed XObj
   | -- Def
     DefIdentifierIsQualified XObj
@@ -33,8 +41,6 @@ data EvaluationError
   | LetMalformedIdentifiers [XObj]
   | -- Fn
     FnContainsQualifiedArgs XObj
-    -- With
-  |  WithContainsInvalidArgs XObj
   | -- Do
     DoMissingForms
   | -- Unknown Form
@@ -49,23 +55,21 @@ data EvaluationError
     ModuleRedefinition String
   | DefmoduleContainsNonSymbol XObj
   | DefmoduleNoArgs
-  | -- Load
-    LoadInvalidArgs [XObj]
   | LoadFileNotFound String
   | LoadGitFailure String String
   | LoadRecursiveLoad String
-  | -- Load-once
-    LoadOnceInvalidArgs [XObj]
   | -- Defndynamic
     DefnDynamicInvalidName XObj
   | -- Set!
     SetVarNotFound XObj
   | SetInvalidVarName XObj
-  | SetInvalidArgs [XObj]
   | SetTypeMismatch SymPath Ty Ty
   | -- Static Call
     StaticCall XObj
+  | -- Invalid Arguments
+    InvalidArgs String [XObj]
 
+-- Show instance for Evaluation Errors.
 instance Show EvaluationError where
   show (SymbolNotFound path) = "Can't find symbol '" ++ show path ++ "'"
   show (PrivateBinding path) =
@@ -84,10 +88,6 @@ instance Show EvaluationError where
   show (DefnIdentifierIsQualified name) =
     "`defn` identifiers must be unqualified symbols, but it got `"
       ++ pretty name
-      ++ "`"
-  show (DefnContainsInvalidArgs args) =
-    "`defn` requires an array of symbols as argument list, but it got `"
-      ++ pretty args
       ++ "`"
   show (DefnMalformed xobj) =
     "I didn’t understand the `defn` at " ++ prettyInfoFromXObj xobj
@@ -109,7 +109,6 @@ instance Show EvaluationError where
       ++ joinWithSpace (map pretty bindings)
       ++ "`"
   show (FnContainsQualifiedArgs args) = "`fn` requires all arguments to be unqualified symbols, but it got `" ++ pretty args ++ "`"
-  show (WithContainsInvalidArgs xobj) = "Invalid arguments to `with`: " ++ pretty xobj
   show DoMissingForms = "No forms in do"
   show (UnknownForm xobj) = "I did not understand the form `" ++ pretty xobj ++ "`"
   show (MacroBadArgumentSplit allParams) =
@@ -124,8 +123,6 @@ instance Show EvaluationError where
   show (ModuleRedefinition name) = "Can't redefine '" ++ name ++ "' as module"
   show (DefmoduleContainsNonSymbol x) = "`defmodule` expects a symbol, got '" ++ pretty x ++ "' instead."
   show DefmoduleNoArgs = "`defmodule` requires at least a symbol, received none."
-  show (LoadInvalidArgs xobj) = "Invalid args to `load`, expected (load str optional:fileFromRepo) but got: " ++ joinWithSpace (map pretty xobj)
-  show (LoadOnceInvalidArgs xobj) = "Invalid args to `load-once`, expected `(load-once str optional:fileFromRepo)` but got: " ++ joinWithSpace (map pretty xobj)
   show (LoadFileNotFound path) = " I can't find a file named: '" ++ path ++ "'" ++ "\n\nIf you tried loading an external package, try appending a version string (like `@master`)"
   show (LoadGitFailure path stderr) =
     "I can't find a file named: '" ++ path ++ "'"
@@ -135,12 +132,33 @@ instance Show EvaluationError where
   show (DefnDynamicInvalidName notName) = "`defndynamic` expected a name as first argument, but got " ++ pretty notName
   show (SetVarNotFound var) = "I couldn't find the variable " ++ pretty var ++ ", did you define it using `def` or `defdynamic`?"
   show (SetInvalidVarName var) = "`set!` expected a name as first argument, but got " ++ pretty var
-  show (SetInvalidArgs args) = "`set!` takes a name and a value, but got `" ++ unwords (map pretty args)
   show (SetTypeMismatch path oldTy newTy) = "can't `set!` " ++ show path ++ " to a value of type " ++ show oldTy ++ ", " ++ show path ++ " has type " ++ show newTy
   show (StaticCall x) = "Unexpected static call in " ++ pretty x
+  show (InvalidArgs expected actual) = expected ++ ", but got: " ++ joinWithComma (map pretty actual)
+
+--------------------------------------------------------------------------------
+-- Utilities
 
 -- | Given a Showable error, turn it into an EvalError
--- TODO: Unify this an toEvalError and remove one of these functions.
+-- TODO: Unify this and toEvalError and remove one of these functions.
 throwErr :: Show a => a -> Context -> Maybe Info -> (Context, Either EvalError XObj)
 throwErr err ctx info =
   evalError ctx (show err) info
+
+--------------------------------------------------------------------------------
+-- Invalid Argument Helpers
+
+defnInvalidArgs :: [XObj] -> EvaluationError
+defnInvalidArgs = InvalidArgs "Invalid args to `defn`, expected an array of symbols as an argument list"
+
+loadInvalidArgs :: [XObj] -> EvaluationError
+loadInvalidArgs = InvalidArgs  "Invalid args to `load`, expected (load str optional:fileFromRepo)"
+
+loadOnceInvalidArgs :: [XObj] -> EvaluationError
+loadOnceInvalidArgs = InvalidArgs "Invalid args to `load-once`, expected `(load-once str optional:fileFromRepo)`"
+
+withInvalidArgs :: [XObj] -> EvaluationError
+withInvalidArgs = InvalidArgs "Invalid arguments to `with`, expected a module name"
+
+setInvalidArgs :: [XObj] -> EvaluationError
+setInvalidArgs = InvalidArgs "Invalid arguments to `set!`, expected a symbol and a value"

--- a/src/EvalError.hs
+++ b/src/EvalError.hs
@@ -1,0 +1,146 @@
+-- | Module EvalError defines errors that may occur during evaluation
+module EvalError
+  ( EvaluationError (..),
+    throwErr,
+  )
+where
+
+import Info
+import Obj
+import SymPath
+import TypeError
+import Util
+import Types
+
+-- | Errors that occur when evaluating forms.
+data EvaluationError
+  = SymbolNotFound SymPath
+  | PrivateBinding SymPath
+  | -- If
+    IfContainsNonBool XObj
+  | IfMalformed XObj
+  | -- Defn
+    DefnContainsQualifiedArgs XObj
+  | DefnIdentifierIsQualified XObj
+  | DefnContainsInvalidArgs XObj
+  | DefnMalformed XObj
+  | -- Def
+    DefIdentifierIsQualified XObj
+  | -- The
+    TheMalformed XObj
+  | -- Let
+    LetUnevenForms XObj
+  | LetMalformedIdentifiers [XObj]
+  | -- Fn
+    FnContainsQualifiedArgs XObj
+    -- With
+  |  WithContainsInvalidArgs XObj
+  | -- Do
+    DoMissingForms
+  | -- Unknown Form
+    UnknownForm XObj
+  | -- Function/Macro Application
+    MacroBadArgumentSplit [String]
+  | -- Address
+    AddressContainsNonSymbol XObj
+  | -- While
+    WhileContainsNonBool XObj
+  | -- Defmodule
+    ModuleRedefinition String
+  | DefmoduleContainsNonSymbol XObj
+  | DefmoduleNoArgs
+  | -- Load
+    LoadInvalidArgs [XObj]
+  | LoadFileNotFound String
+  | LoadGitFailure String String
+  | LoadRecursiveLoad String
+  | -- Load-once
+    LoadOnceInvalidArgs [XObj]
+  | -- Defndynamic
+    DefnDynamicInvalidName XObj
+  | -- Set!
+    SetVarNotFound XObj
+  | SetInvalidVarName XObj
+  | SetInvalidArgs [XObj]
+  | SetTypeMismatch SymPath Ty Ty
+  | -- Static Call
+    StaticCall XObj
+
+instance Show EvaluationError where
+  show (SymbolNotFound path) = "Can't find symbol '" ++ show path ++ "'"
+  show (PrivateBinding path) =
+    "The binding: " ++ show path ++ " is private; it may only be used within the module that defines it."
+  show (IfContainsNonBool cond) =
+    "This `if` condition contains the non-boolean value `"
+      ++ pretty cond
+      ++ "`"
+  show (IfMalformed xobj) =
+    "I didn’t understand this `if`.\n\n Got:\n```\n" ++ pretty xobj
+      ++ "\n```\n\nExpected the form:\n```\n(if cond then else)\n```\n"
+  show (DefnContainsQualifiedArgs args) =
+    "`defn` requires all arguments to be unqualified symbols, but it got `"
+      ++ pretty args
+      ++ "`"
+  show (DefnIdentifierIsQualified name) =
+    "`defn` identifiers must be unqualified symbols, but it got `"
+      ++ pretty name
+      ++ "`"
+  show (DefnContainsInvalidArgs args) =
+    "`defn` requires an array of symbols as argument list, but it got `"
+      ++ pretty args
+      ++ "`"
+  show (DefnMalformed xobj) =
+    "I didn’t understand the `defn` at " ++ prettyInfoFromXObj xobj
+      ++ ":\n\n"
+      ++ pretty xobj
+      ++ "\n\nIs it valid? Every `defn` needs to follow the form `(defn name [arg] body)`."
+  show (DefIdentifierIsQualified name) =
+    "`def` identifiers must be unqualified symbols, but it got `"
+      ++ pretty name
+      ++ "`"
+  show (TheMalformed xobj) =
+    "I didn’t understand the `the` at " ++ prettyInfoFromXObj xobj
+      ++ ":\n\n"
+      ++ pretty xobj
+      ++ "\n\nIs it valid? Every `the` needs to follow the form `(the type expression)`."
+  show (LetUnevenForms xobj) = "Uneven number of forms in `let`: " ++ pretty xobj
+  show (LetMalformedIdentifiers bindings) =
+    "`let` identifiers must be symbols, but it got `"
+      ++ joinWithSpace (map pretty bindings)
+      ++ "`"
+  show (FnContainsQualifiedArgs args) = "`fn` requires all arguments to be unqualified symbols, but it got `" ++ pretty args ++ "`"
+  show (WithContainsInvalidArgs xobj) = "Invalid arguments to `with`: " ++ pretty xobj
+  show DoMissingForms = "No forms in do"
+  show (UnknownForm xobj) = "I did not understand the form `" ++ pretty xobj ++ "`"
+  show (MacroBadArgumentSplit allParams) =
+    "I didn’t understand this macro’s argument split, got `"
+      ++ joinWith "," allParams
+      ++ "`, but expected exactly one `:rest` separator."
+  show (AddressContainsNonSymbol xobj) = "Can't get the address of non-symbol " ++ pretty xobj
+  show (WhileContainsNonBool c) =
+    "This `while` condition contains the non-boolean value '"
+      ++ pretty c
+      ++ "`"
+  show (ModuleRedefinition name) = "Can't redefine '" ++ name ++ "' as module"
+  show (DefmoduleContainsNonSymbol x) = "`defmodule` expects a symbol, got '" ++ pretty x ++ "' instead."
+  show DefmoduleNoArgs = "`defmodule` requires at least a symbol, received none."
+  show (LoadInvalidArgs xobj) = "Invalid args to `load`, expected (load str optional:fileFromRepo) but got: " ++ joinWithSpace (map pretty xobj)
+  show (LoadOnceInvalidArgs xobj) = "Invalid args to `load-once`, expected `(load-once str optional:fileFromRepo)` but got: " ++ joinWithSpace (map pretty xobj)
+  show (LoadFileNotFound path) = " I can't find a file named: '" ++ path ++ "'" ++ "\n\nIf you tried loading an external package, try appending a version string (like `@master`)"
+  show (LoadGitFailure path stderr) =
+    "I can't find a file named: '" ++ path ++ "'"
+      ++ "\n\nI tried interpreting the statement as a git import, but got: "
+      ++ stderr
+  show (LoadRecursiveLoad path) = "A file can't load itself: '" ++ path ++ "'"
+  show (DefnDynamicInvalidName notName) = "`defndynamic` expected a name as first argument, but got " ++ pretty notName
+  show (SetVarNotFound var) = "I couldn't find the variable " ++ pretty var ++ ", did you define it using `def` or `defdynamic`?"
+  show (SetInvalidVarName var) = "`set!` expected a name as first argument, but got " ++ pretty var
+  show (SetInvalidArgs args) = "`set!` takes a name and a value, but got `" ++ unwords (map pretty args)
+  show (SetTypeMismatch path oldTy newTy) = "can't `set!` " ++ show path ++ " to a value of type " ++ show oldTy ++ ", " ++ show path ++ " has type " ++ show newTy
+  show (StaticCall x) = "Unexpected static call in " ++ pretty x
+
+-- | Given a Showable error, turn it into an EvalError
+-- TODO: Unify this an toEvalError and remove one of these functions.
+throwErr :: Show a => a -> Context -> Maybe Info -> (Context, Either EvalError XObj)
+throwErr err ctx info =
+  evalError ctx (show err) info


### PR DESCRIPTION
Following the same scheme as PrimitiveError and TypeError, this adds a
separate module for evaluation errors, removing a bunch of inline
strings in Eval.hs