### PR TITLE
fix: respect quotes in macro expand

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -487,6 +487,8 @@ macroExpand ctx xobj =
             ok <- expanded
             Right (XObj (StaticArr ok) i t)
         )
+    XObj (Lst [XObj (Sym (SymPath [] "quote") _) _ _, _]) _ _ ->
+      pure (ctx, Right xobj)
     XObj (Lst [XObj (Lst (XObj Macro _ _ : _)) _ _]) _ _ -> evalDynamic ResolveLocal ctx xobj
     XObj (Lst (x@(XObj (Sym _ _) _ _) : args)) i t -> do
       (next, f) <- evalDynamic ResolveLocal ctx x

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -40,6 +40,10 @@
       (StrangeThings.Piff x) false
       _ true)))
 
+; quoted macros do not get evaluated if not called
+(defmacro invalid []
+  '(cond x 1))
+
 (use-all Test Vector2 Foo)
 
 (defn test-unreachable []


### PR DESCRIPTION
This PR fixes an issue where quoted macros would be expanded still because the expander didn’t actually stop when it encountered a quote.

Cheers