### PR TITLE
feat: make reseeding of Random at startup configurable

### DIFF
--- a/core/Random.carp
+++ b/core/Random.carp
@@ -27,11 +27,29 @@
       (set! s (mod (+ (* s a) c) m))
       (/ s m)))
 
-  (private _)
   (hidden _)
   (doc _ "forces reseeding based on the current time at program start")
-  (def _ (do (seed) 0))
+  (def _ (do (seed) true))
+
+  (doc startup-reseed "enables reseeding the random number generator at startup.")
+  (defmacro startup-reseed []
+    (eval '(defmodule Random (def _ (do (seed) true)))))
+
+  (doc no-startup-reseed "disables reseeding the random number generator at startup.")
+  (defmacro no-startup-reseed []
+    (eval '(defmodule Random (def _ (do false)))))
+
+   (doc startup-reseed? "checks whether the random number generator was reseeded at startup.
+
+Use `Dynamic.Random.startup-reseed?` to check this in dynamic code.")
+  (defn startup-reseed? [] _)
 )
+
+(defmodule Dynamic
+  (defmodule Random
+    (doc startup-reseed? "checks whether the random number generator will be reseeded at startup.")
+    (defmacro startup-reseed? []
+      (last (last (s-expr Random._))))))
 
 (defmodule Int
   (defn random-between [lower upper]

--- a/core/Random.carp
+++ b/core/Random.carp
@@ -31,24 +31,22 @@
   (doc _ "forces reseeding based on the current time at program start")
   (def _ (do (seed) true))
 
-  (doc startup-reseed "enables reseeding the random number generator at startup.")
-  (defmacro startup-reseed []
-    (eval '(defmodule Random (def _ (do (seed) true)))))
+  (doc gen-seed-at-startup "toggles reseeding the random number generator at startup.")
+  (defmacro gen-seed-at-startup [toggle]
+    (if toggle
+      (eval '(defmodule Random (def _ (do (seed) true))))
+      (eval '(defmodule Random (def _ (do false))))))
 
-  (doc no-startup-reseed "disables reseeding the random number generator at startup.")
-  (defmacro no-startup-reseed []
-    (eval '(defmodule Random (def _ (do false)))))
+   (doc gen-seed-at-startup? "checks whether the random number generator was reseeded at startup.
 
-   (doc startup-reseed? "checks whether the random number generator was reseeded at startup.
-
-Use `Dynamic.Random.startup-reseed?` to check this in dynamic code.")
-  (defn startup-reseed? [] _)
+Use `Dynamic.Random.gen-seed-at-startup?` to check this in dynamic code.")
+  (defn gen-seed-at-startup? [] _)
 )
 
 (defmodule Dynamic
   (defmodule Random
-    (doc startup-reseed? "checks whether the random number generator will be reseeded at startup.")
-    (defmacro startup-reseed? []
+    (doc gen-seed-at-startup? "checks whether the random number generator will be reseeded at startup.")
+    (defmacro gen-seed-at-startup? []
       (last (last (s-expr Random._))))))
 
 (defmodule Int

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -487,6 +487,8 @@ macroExpand ctx xobj =
             ok <- expanded
             Right (XObj (StaticArr ok) i t)
         )
+    XObj (Lst [XObj (Sym (SymPath [] "quote") _) _ _, _]) _ _ ->
+      pure (ctx, Right xobj)
     XObj (Lst [XObj (Lst (XObj Macro _ _ : _)) _ _]) _ _ -> evalDynamic ResolveLocal ctx xobj
     XObj (Lst (x@(XObj (Sym _ _) _ _) : args)) i t -> do
       (next, f) <- evalDynamic ResolveLocal ctx x

--- a/test/random-seed.carp
+++ b/test/random-seed.carp
@@ -2,17 +2,17 @@
 
 (use-all Random Test)
 
-(def reseed-before? (Dynamic.Random.startup-reseed?))
+(def reseed-before? (Dynamic.Random.gen-seed-at-startup?))
 
-(Random.no-startup-reseed)
+(Random.gen-seed-at-startup false)
 
-(def reseed-after? (Dynamic.Random.startup-reseed?))
+(def reseed-after? (Dynamic.Random.gen-seed-at-startup?))
 
-(Random.startup-reseed)
+(Random.gen-seed-at-startup true)
 
-(def reseed-redo? (Dynamic.Random.startup-reseed?))
+(def reseed-redo? (Dynamic.Random.gen-seed-at-startup?))
 
-(Random.no-startup-reseed)
+(Random.gen-seed-at-startup false)
 
 (deftest test
   (assert-true test
@@ -30,6 +30,6 @@
              "deterministic randomization works as expected"
              Double.approx)
   (assert-false test
-                (Random.startup-reseed?)
+                (Random.gen-seed-at-startup?)
                 "reseed can be checked statically as well")
 )

--- a/test/random-seed.carp
+++ b/test/random-seed.carp
@@ -1,0 +1,35 @@
+(load "Test.carp")
+
+(use-all Random Test)
+
+(def reseed-before? (Dynamic.Random.startup-reseed?))
+
+(Random.no-startup-reseed)
+
+(def reseed-after? (Dynamic.Random.startup-reseed?))
+
+(Random.startup-reseed)
+
+(def reseed-redo? (Dynamic.Random.startup-reseed?))
+
+(Random.no-startup-reseed)
+
+(deftest test
+  (assert-true test
+               reseed-before?
+               "reseeding is on by default")
+  (assert-false test
+                reseed-after?
+                "reseeding can be disabled")
+  (assert-true test
+                reseed-redo?
+                "reseeding can be re-enabled")
+  (assert-op test
+             0.658908 ; will always be the initial if not reseeded
+             (Random.random)
+             "deterministic randomization works as expected"
+             Double.approx)
+  (assert-false test
+                (Random.startup-reseed?)
+                "reseed can be checked statically as well")
+)

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -40,6 +40,10 @@
       (StrangeThings.Piff x) false
       _ true)))
 
+; quoted macros do not get evaluated if not called
+(defmacro invalid []
+  '(cond x 1))
+
 (use-all Test Vector2 Foo)
 
 (defn test-unreachable []


### PR DESCRIPTION
**Note**: *this PR depends on #1160.*

This PR makes reseeding the random number generator in `Random` at startup configurable.

It adds the following functions:
- `Random.startup-reseed` will enable reseeding at startup. **This is the default**.
- `Random.no-startup-reseed` will disable reseeding at startup.
- `Random.startup-reseed?` can be called to check whether `Random` was reseeded at startup.
- `Dynamic.Random.startup-reseed?` can be called to check whether `Random` will be reseeded at startup.

Test cases are included.

An open question remains whether we need two functions to enable and disable reseeding to make the intent clear, or whether one function with a boolean argument—e.g. `(Random.startup-reseed true)`—would be enough.

Cheers