### PR TITLE
fix: #968

### DIFF
--- a/src/Env.hs
+++ b/src/Env.hs
@@ -85,6 +85,16 @@ envBindingNames = concatMap select . envBindings
     select (Binder _ (XObj (Mod m) _ _)) = envBindingNames m
     select (Binder _ obj) = [getName obj]
 
+envPublicBindingNames :: Env -> [String]
+envPublicBindingNames = concatMap select . envBindings
+  where
+    select :: Binder -> [String]
+    select (Binder _ (XObj (Mod m) _ _)) = envPublicBindingNames m
+    select (Binder meta obj) =
+      if metaIsTrue meta "private" || metaIsTrue meta "hidden"
+        then []
+        else [getName obj]
+
 -- | Recursively look through all environments for (def ...) forms.
 findAllGlobalVariables :: Env -> [Binder]
 findAllGlobalVariables env =

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -27,7 +27,7 @@ import System.Exit (exitSuccess)
 
 completeKeywordsAnd :: Context -> String -> [Completion]
 completeKeywordsAnd context word =
-  findKeywords word (envBindingNames (contextGlobalEnv context) ++ keywords) []
+  findKeywords word (envPublicBindingNames (contextGlobalEnv context) ++ keywords) []
   where
     findKeywords _ [] res = res
     findKeywords match (x : xs) res =
@@ -35,15 +35,7 @@ completeKeywordsAnd context word =
         then findKeywords match xs (res ++ [simpleCompletion x])
         else findKeywords match xs res
     keywords =
-      [ "Int", -- we should probably have a list of those somewhere
-        "Float",
-        "Double",
-        "Bool",
-        "String",
-        "Char",
-        "Array",
-        "Fn",
-        "def",
+      [ "def",
         "defn",
         "let",
         "do",


### PR DESCRIPTION
This PR fixes #968 by not autocompleting private or hidden bindings in the REPL (sadly even if you are inside the module, since we don’t have a parser for partial trees that could help us there).

Cheers