### PR TITLE
refactor: Context and Qualify

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -85,7 +85,7 @@
                                             (Dynamic.String.concat [x newline])))
                                 strings
                                 ())]
-    (eval (list 'meta-set! name "doc" (Dynamic.String.concat (list-to-array-internal separated []))))))
+    (list 'meta-set! name "doc" (Dynamic.String.concat (list-to-array-internal separated [])))))
 
 (doc print-doc "Print the documentation for a binding.")
 (defmacro print-doc [name]

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -43,14 +43,6 @@ instance Exception CarpException
 dynamicNil :: Either a XObj
 dynamicNil = Right (XObj (Lst []) (Just dummyInfo) (Just UnitTy)) -- TODO: Remove/unwrap (Right ...) to a XObj
 
--- | Dynamic 'true'.
-trueXObj :: XObj
-trueXObj = XObj (Bol True) Nothing Nothing
-
--- | Dynamic 'false'.
-falseXObj :: XObj
-falseXObj = XObj (Bol False) Nothing Nothing
-
 boolToXObj :: Bool -> XObj
 boolToXObj b = if b then trueXObj else falseXObj
 

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -9,7 +9,9 @@ module Context
     replaceTypeEnv',
     replaceHistory',
     insertInGlobalEnv,
+    insertInGlobalEnv',
     insertInTypeEnv,
+    insertInTypeEnv',
     insertIntoInternalEnv,
     innermostModuleEnv,
     bindLetDeclaration,
@@ -90,6 +92,14 @@ insertIntoInternalEnv ctx path binder =
   ctx {contextInternalEnv = fmap insert (contextInternalEnv ctx)}
   where insert :: Env -> Env
         insert e = envInsertAt e path binder
+
+-- | insertInGlobalEnv with arguments flipped.
+insertInGlobalEnv' :: SymPath -> Binder -> Context -> Context
+insertInGlobalEnv' path binder ctx = insertInGlobalEnv ctx path binder
+
+-- | insertInTypeEnv with arguments flipped.
+insertInTypeEnv' :: SymPath -> Binder -> Context -> Context
+insertInTypeEnv' path binder ctx = insertInTypeEnv ctx path binder
 
 -- Specialized binding insertion functions
 

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -4,6 +4,7 @@ module Context
     replaceTypeEnv,
     replaceHistory,
     replaceProject,
+    replacePath,
     replaceGlobalEnv',
     replaceInternalEnv',
     replaceTypeEnv',
@@ -12,48 +13,89 @@ module Context
     insertInGlobalEnv',
     insertInTypeEnv,
     insertInTypeEnv',
-    insertIntoInternalEnv,
+    insertInInternalEnv,
     innermostModuleEnv,
     bindLetDeclaration,
+    lookupInterface,
+    lookupBinderInGlobalEnv,
+    lookupBinderInTypeEnv,
+    lookupBinderInContextEnv,
+    contextualize,
   )
 where
 
 import Env
+import Lookup
 import Obj
-import SymPath
 import Project
+import Qualify (QualifiedPath, qualifyPath, unqualify)
+import SymPath
 
--- Environment replacement functions
+--------------------------------------------------------------------------------
+-- Contextual Class
+
+-- | Class of symbol paths (identifiers) that can be made relative to a
+-- context.
+--
+-- This class factors heavily in performing lookups in a given context
+-- flexibly; certain portions of the codebase deliver fully qualified symbols
+-- for lookup while others deliver an unqualified symbol that must be
+-- contextualized before lookups are performed.
+class Contextual a where
+  contextualize :: a -> Context -> SymPath
+
+-- | Unqualified paths are contextualized according to the current context.
+instance Contextual SymPath where
+  contextualize spath ctx = unqualify (qualifyPath ctx spath)
+
+-- | Fully qualified paths require no further contextualization.
+instance Contextual QualifiedPath where
+  contextualize qpath _ = unqualify qpath
+
+--------------------------------------------------------------------------------
+-- Environment Replacement Functions
 
 -- | Replace a context's internal environment with a new environment.
+--
 -- The previous environment is completely replaced and will not be recoverable.
 replaceInternalEnv :: Context -> Env -> Context
 replaceInternalEnv ctx env =
   ctx {contextInternalEnv = Just env}
 
 -- | Replace a context's global environment with a new environment.
+--
 -- The previous environment is completely replaced and will not be recoverable.
 replaceGlobalEnv :: Context -> Env -> Context
 replaceGlobalEnv ctx env =
   ctx {contextGlobalEnv = env}
 
 -- | Replace a context's type environment with a new environment.
+--
 -- The previous environment is completely replaced and will not be recoverable.
 replaceTypeEnv :: Context -> TypeEnv -> Context
 replaceTypeEnv ctx env =
   ctx {contextTypeEnv = env}
 
 -- | Replace a context's history with a new history.
+--
 -- The previous history is completely replaced and will not be recoverable.
 replaceHistory :: Context -> [XObj] -> Context
 replaceHistory ctx hist =
   ctx {contextHistory = hist}
 
 -- | Replace a context's project with a new project.
+--
 -- The previous project is completely replaced and will not be recoverable.
 replaceProject :: Context -> Project -> Context
 replaceProject ctx proj =
   ctx {contextProj = proj}
+
+-- | Replace a context's path with a new path.
+--
+-- The previous path is completely replaced and will not be recoverable.
+replacePath :: Context -> [String] -> Context
+replacePath ctx paths =
+  ctx {contextPath = paths}
 
 -- | replaceInternalEnv with arguments flipped.
 replaceInternalEnv' :: Env -> Context -> Context
@@ -71,51 +113,110 @@ replaceTypeEnv' = flip replaceTypeEnv
 replaceHistory' :: [XObj] -> Context -> Context
 replaceHistory' = flip replaceHistory
 
--- Binding insertion functions
+--------------------------------------------------------------------------------
+-- Binding Insertion Functions
 
--- | Adds a binder to a context's global environment at the specified path.
-insertInGlobalEnv :: Context -> SymPath -> Binder -> Context
-insertInGlobalEnv ctx path binder =
+-- | Adds a binder to a context's global environment at a qualified path.
+--
+-- In most cases the qualified path will have been qualified under the same
+-- context, but this constraint is *not* enforced by the definition of this
+-- function.
+insertInGlobalEnv :: Context -> QualifiedPath -> Binder -> Context
+insertInGlobalEnv ctx qpath binder =
   let globalEnv = contextGlobalEnv ctx
-   in ctx {contextGlobalEnv = envInsertAt globalEnv path binder}
+   in ctx {contextGlobalEnv = envInsertAt globalEnv (unqualify qpath) binder}
 
--- | Adds a binder to a context's type environment at the specified path.
-insertInTypeEnv :: Context -> SymPath -> Binder -> Context
-insertInTypeEnv ctx path binder =
+-- | Adds a binder to a context's type environment at a qualified path.
+--
+-- In most cases the qualified path will have been qualified under the same
+-- context, but this constraint is *not* enforced by the definition of this
+-- function.
+insertInTypeEnv :: Context -> QualifiedPath -> Binder -> Context
+insertInTypeEnv ctx qpath binder =
   let typeEnv = getTypeEnv (contextTypeEnv ctx)
-   in ctx {contextTypeEnv = TypeEnv (envInsertAt typeEnv path binder)}
+   in ctx {contextTypeEnv = TypeEnv (envInsertAt typeEnv (unqualify qpath) binder)}
 
--- | Adds a binder to a context's internal environment at the specified path.
+-- | Adds a binder to a context's internal environment at an unqualified path.
+--
 -- If the context does not have an internal environment, this function does nothing.
-insertIntoInternalEnv :: Context -> SymPath -> Binder -> Context
-insertIntoInternalEnv ctx path binder =
+insertInInternalEnv :: Context -> SymPath -> Binder -> Context
+insertInInternalEnv ctx path@(SymPath [] _) binder =
   ctx {contextInternalEnv = fmap insert (contextInternalEnv ctx)}
-  where insert :: Env -> Env
-        insert e = envInsertAt e path binder
+  where
+    insert :: Env -> Env
+    insert e = envInsertAt e path binder
+insertInInternalEnv _ _ _ =
+  error "attempted to insert a qualified symbol into an internal environment"
 
 -- | insertInGlobalEnv with arguments flipped.
-insertInGlobalEnv' :: SymPath -> Binder -> Context -> Context
+insertInGlobalEnv' :: QualifiedPath -> Binder -> Context -> Context
 insertInGlobalEnv' path binder ctx = insertInGlobalEnv ctx path binder
 
 -- | insertInTypeEnv with arguments flipped.
-insertInTypeEnv' :: SymPath -> Binder -> Context -> Context
+insertInTypeEnv' :: QualifiedPath -> Binder -> Context -> Context
 insertInTypeEnv' path binder ctx = insertInTypeEnv ctx path binder
-
--- Specialized binding insertion functions
 
 -- | Inserts a let binding into the appropriate environment in a context.
 bindLetDeclaration :: Context -> String -> XObj -> Context
 bindLetDeclaration ctx name xobj =
   let binder = Binder emptyMeta (toLocalDef name xobj)
-   in insertIntoInternalEnv ctx (SymPath [] name) binder
+   in insertInInternalEnv ctx (SymPath [] name) binder
 
--- Specialized environment retrieval functions
+--------------------------------------------------------------------------------
+-- Environment Retrieval Functions
 
 -- | Retrieves the innermost (deepest) module environment in a context
 -- according to the context's contextPath.
+--
 -- Returns Nothing if the Context path is empty.
 innermostModuleEnv :: Context -> Maybe Env
 innermostModuleEnv ctx = go (contextPath ctx)
-  where go :: [String] -> Maybe Env
-        go [] = Nothing
-        go xs = Just $ getEnv (contextGlobalEnv ctx) xs
+  where
+    go :: [String] -> Maybe Env
+    go [] = Nothing
+    go xs = Just $ getEnv (contextGlobalEnv ctx) xs
+
+--------------------------------------------------------------------------------
+-- Binder Lookup Functions
+
+-- | Lookup a binder with a fully determined location in a context.
+decontextualizedLookup :: (Context -> SymPath -> Maybe Binder) -> Context -> SymPath -> Maybe Binder
+decontextualizedLookup f ctx path =
+  f (replacePath ctx []) path
+
+lookupInterface :: Context -> SymPath -> Maybe Binder
+lookupInterface ctx path =
+  decontextualizedLookup lookupBinderInTypeEnv ctx path
+
+-- | Lookup a binder in a context's type environment.
+--
+-- Depending on the type of path passed to this function, further
+-- contextualization of the path may be performed before the lookup is
+-- performed.
+lookupBinderInTypeEnv :: Contextual a => Context -> a -> Maybe Binder
+lookupBinderInTypeEnv ctx path =
+  let typeEnv = getTypeEnv (contextTypeEnv ctx)
+      fullPath = contextualize path ctx
+   in lookupBinder fullPath typeEnv
+
+-- | Lookup a binder in a context's global environment.
+--
+-- Depending on the type of path passed to this function, further
+-- contextualization of the path may be performed before the lookup is
+-- performed.
+lookupBinderInGlobalEnv :: Contextual a => Context -> a -> Maybe Binder
+lookupBinderInGlobalEnv ctx path =
+  let global = contextGlobalEnv ctx
+      fullPath = contextualize path ctx
+   in lookupBinder fullPath global
+
+-- | Lookup a binder in a context's context environment.
+--
+-- Depending on the type of path passed to this function, further
+-- contextualization of the path may be performed before the lookup is
+-- performed.
+lookupBinderInContextEnv :: Context -> SymPath -> Maybe Binder
+lookupBinderInContextEnv ctx path =
+  let ctxEnv = contextEnv ctx
+      fullPath = contextualize path ctx
+   in lookupBinder fullPath ctxEnv

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -1,19 +1,111 @@
 module Context
-  ( insertInGlobalEnv,
+  ( replaceGlobalEnv,
+    replaceInternalEnv,
+    replaceTypeEnv,
+    replaceHistory,
+    replaceProject,
+    replaceGlobalEnv',
+    replaceInternalEnv',
+    replaceTypeEnv',
+    replaceHistory',
+    insertInGlobalEnv,
     insertInTypeEnv,
+    insertIntoInternalEnv,
+    innermostModuleEnv,
+    bindLetDeclaration,
   )
 where
 
 import Env
 import Obj
 import SymPath
+import Project
 
+-- Environment replacement functions
+
+-- | Replace a context's internal environment with a new environment.
+-- The previous environment is completely replaced and will not be recoverable.
+replaceInternalEnv :: Context -> Env -> Context
+replaceInternalEnv ctx env =
+  ctx {contextInternalEnv = Just env}
+
+-- | Replace a context's global environment with a new environment.
+-- The previous environment is completely replaced and will not be recoverable.
+replaceGlobalEnv :: Context -> Env -> Context
+replaceGlobalEnv ctx env =
+  ctx {contextGlobalEnv = env}
+
+-- | Replace a context's type environment with a new environment.
+-- The previous environment is completely replaced and will not be recoverable.
+replaceTypeEnv :: Context -> TypeEnv -> Context
+replaceTypeEnv ctx env =
+  ctx {contextTypeEnv = env}
+
+-- | Replace a context's history with a new history.
+-- The previous history is completely replaced and will not be recoverable.
+replaceHistory :: Context -> [XObj] -> Context
+replaceHistory ctx hist =
+  ctx {contextHistory = hist}
+
+-- | Replace a context's project with a new project.
+-- The previous project is completely replaced and will not be recoverable.
+replaceProject :: Context -> Project -> Context
+replaceProject ctx proj =
+  ctx {contextProj = proj}
+
+-- | replaceInternalEnv with arguments flipped.
+replaceInternalEnv' :: Env -> Context -> Context
+replaceInternalEnv' = flip replaceInternalEnv
+
+-- | replaceGlobalEnv with arguments flipped.
+replaceGlobalEnv' :: Env -> Context -> Context
+replaceGlobalEnv' = flip replaceGlobalEnv
+
+-- | replaceTypeEnv with arguments flipped.
+replaceTypeEnv' :: TypeEnv -> Context -> Context
+replaceTypeEnv' = flip replaceTypeEnv
+
+-- | replaceHistory with arguments flipped.
+replaceHistory' :: [XObj] -> Context -> Context
+replaceHistory' = flip replaceHistory
+
+-- Binding insertion functions
+
+-- | Adds a binder to a context's global environment at the specified path.
 insertInGlobalEnv :: Context -> SymPath -> Binder -> Context
 insertInGlobalEnv ctx path binder =
   let globalEnv = contextGlobalEnv ctx
    in ctx {contextGlobalEnv = envInsertAt globalEnv path binder}
 
+-- | Adds a binder to a context's type environment at the specified path.
 insertInTypeEnv :: Context -> SymPath -> Binder -> Context
 insertInTypeEnv ctx path binder =
   let typeEnv = getTypeEnv (contextTypeEnv ctx)
    in ctx {contextTypeEnv = TypeEnv (envInsertAt typeEnv path binder)}
+
+-- | Adds a binder to a context's internal environment at the specified path.
+-- If the context does not have an internal environment, this function does nothing.
+insertIntoInternalEnv :: Context -> SymPath -> Binder -> Context
+insertIntoInternalEnv ctx path binder =
+  ctx {contextInternalEnv = fmap insert (contextInternalEnv ctx)}
+  where insert :: Env -> Env
+        insert e = envInsertAt e path binder
+
+-- Specialized binding insertion functions
+
+-- | Inserts a let binding into the appropriate environment in a context.
+bindLetDeclaration :: Context -> String -> XObj -> Context
+bindLetDeclaration ctx name xobj =
+  let binder = Binder emptyMeta (toLocalDef name xobj)
+   in insertIntoInternalEnv ctx (SymPath [] name) binder
+
+-- Specialized environment retrieval functions
+
+-- | Retrieves the innermost (deepest) module environment in a context
+-- according to the context's contextPath.
+-- Returns Nothing if the Context path is empty.
+innermostModuleEnv :: Context -> Maybe Env
+innermostModuleEnv ctx = go (contextPath ctx)
+  where go :: [String] -> Maybe Env
+        go [] = Nothing
+        go xs = Just $ getEnv (contextGlobalEnv ctx) xs

--- a/src/Infer.hs
+++ b/src/Infer.hs
@@ -15,6 +15,7 @@ import Constraints
 import GenerateConstraints
 import InitialTypes
 import Obj
+import Qualify
 import TypeError
 import Types
 
@@ -22,10 +23,10 @@ import Types
 -- | Returns a list of all the bindings that need to be added for the new form to work.
 -- | The concretization of MultiSym:s (= ambiguous use of symbols, resolved by type usage)
 -- | makes it possible to solve more types so let's do it several times.
-annotate :: TypeEnv -> Env -> XObj -> Maybe (Ty, XObj) -> Either TypeError (XObj, [XObj])
-annotate typeEnv globalEnv xobj rootSig =
+annotate :: TypeEnv -> Env -> Qualified -> Maybe (Ty, XObj) -> Either TypeError (XObj, [XObj])
+annotate typeEnv globalEnv qualifiedXObj rootSig =
   do
-    initiated <- initialTypes typeEnv globalEnv xobj
+    initiated <- initialTypes typeEnv globalEnv (runQualified qualifiedXObj)
     (annotated, dependencies) <- annotateUntilDone typeEnv globalEnv initiated rootSig [] 100
     (final, deleteDeps) <- manageMemory typeEnv globalEnv annotated
     finalWithNiceTypes <- beautifyTypeVariables final

--- a/src/Infer.hs
+++ b/src/Infer.hs
@@ -26,7 +26,7 @@ import Types
 annotate :: TypeEnv -> Env -> Qualified -> Maybe (Ty, XObj) -> Either TypeError (XObj, [XObj])
 annotate typeEnv globalEnv qualifiedXObj rootSig =
   do
-    initiated <- initialTypes typeEnv globalEnv (runQualified qualifiedXObj)
+    initiated <- initialTypes typeEnv globalEnv (unQualified qualifiedXObj)
     (annotated, dependencies) <- annotateUntilDone typeEnv globalEnv initiated rootSig [] 100
     (final, deleteDeps) <- manageMemory typeEnv globalEnv annotated
     finalWithNiceTypes <- beautifyTypeVariables final

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -30,24 +30,6 @@ lookupInEnv path@(SymPath (p : ps) name) env =
         Just parent -> lookupInEnv path parent
         Nothing -> Nothing
 
--- | Lookup a binder in a context's typeEnv.
-lookupBinderInTypeEnv :: Context -> SymPath -> Maybe Binder
-lookupBinderInTypeEnv ctx path =
-  let typeEnv = getTypeEnv (contextTypeEnv ctx)
-   in lookupBinder path typeEnv
-
--- | Lookup a binder in a context's globalEnv.
-lookupBinderInGlobalEnv :: Context -> SymPath -> Maybe Binder
-lookupBinderInGlobalEnv ctx path =
-  let global = contextGlobalEnv ctx
-   in lookupBinder path global
-
--- | Lookup a binder in a context's contextEnv.
-lookupBinderInContextEnv :: Context -> SymPath -> Maybe Binder
-lookupBinderInContextEnv ctx path =
-  let ctxEnv = contextEnv ctx
-   in lookupBinder path ctxEnv
-
 -- | Performs a multiLookupEverywhere but drops envs from the result and wraps
 -- the results in a Maybe.
 multiLookupBinderEverywhere :: Context -> SymPath -> Maybe [Binder]

--- a/src/Meta.hs
+++ b/src/Meta.hs
@@ -7,6 +7,7 @@ module Meta
     updateBinderMeta,
     Meta.member,
     binderMember,
+    hide,
   )
 where
 
@@ -56,3 +57,7 @@ member key meta = Map.member key $ getMeta meta
 
 binderMember :: String -> Binder -> Bool
 binderMember key binder = Meta.member key $ fromBinder binder
+
+hide :: Binder -> Binder
+hide binder =
+  updateBinderMeta binder "hidden" trueXObj

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -1102,3 +1102,11 @@ toLocalDef var value =
 -- | Create a fresh binder for an XObj (a binder with empty Metadata).
 toBinder :: XObj -> Binder
 toBinder xobj = Binder emptyMeta xobj
+
+-- | Dynamic 'true'.
+trueXObj :: XObj
+trueXObj = XObj (Bol True) Nothing Nothing
+
+-- | Dynamic 'false'.
+falseXObj :: XObj
+falseXObj = XObj (Bol False) Nothing Nothing

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -1098,3 +1098,7 @@ instance Semigroup Context where
 toLocalDef :: String -> XObj -> XObj
 toLocalDef var value =
   (XObj (Lst [XObj LocalDef Nothing Nothing, XObj (Sym (SymPath [] var) Symbol) Nothing Nothing, value]) (xobjInfo value) (xobjTy value))
+
+-- | Create a fresh binder for an XObj (a binder with empty Metadata).
+toBinder :: XObj -> Binder
+toBinder xobj = Binder emptyMeta xobj

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -174,7 +174,7 @@ define hidden ctx qualifiedXObj =
         then defineInTypeEnv newBinder
         else defineInGlobalEnv newBinder
   where
-    annXObj = runQualified qualifiedXObj
+    annXObj = unQualified qualifiedXObj
     freshBinder = toBinder annXObj
     qpath = getQualifiedPath qualifiedXObj
     defineInTypeEnv :: Binder -> IO Context

--- a/src/Qualify.hs
+++ b/src/Qualify.hs
@@ -15,7 +15,7 @@ module Qualify
   )
 where
 
-import Control.Monad (foldM)
+import Control.Monad (foldM, liftM)
 import Data.List (foldl')
 import Debug.Trace
 import Env
@@ -169,6 +169,11 @@ setFullyQualifiedSymbols t g e xobj =
 -- | The type of functions that qualify XObjs (forms/s-expressions).
 type Qualifier = TypeEnv -> Env -> Env -> XObj -> Either QualificationError Qualified
 
+-- Note to maintainers: liftM unQualified is used extensively throughout to
+-- turn a Qualified XObj back into an XObj for further nesting. Recall that:
+--
+--     foo <- liftM unQualified x === foo <- pure . unQualified =<< x
+
 -- | Qualify the symbols in a Defn form's body.
 qualifyFunctionDefinition :: Qualifier
 qualifyFunctionDefinition typeEnv globalEnv env (XObj (Lst [defn@(XObj (Defn _) _ _), sym@(XObj (Sym (SymPath _ functionName) _) _ _), args@(XObj (Arr argsArr) _ _), body]) i t) =
@@ -176,40 +181,36 @@ qualifyFunctionDefinition typeEnv globalEnv env (XObj (Lst [defn@(XObj (Defn _) 
   -- It is marked as RecursionEnv basically is the same thing as external to not mess up lookup.
   -- Inside the recursion env is the function env that contains bindings for the arguments of the function.
   -- Note: These inner envs is ephemeral since they are not stored in a module or global scope.
-  let recursionEnv = Env Map.empty (Just env) (Just (functionName ++ "-recurse-env")) Set.empty RecursionEnv 0
-      envWithSelf = extendEnv recursionEnv functionName sym
-      functionEnv = Env Map.empty (Just envWithSelf) Nothing Set.empty InternalEnv 0
-      envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
-   in setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body
-        >>= pure . unQualified
-        >>= \qualifiedBody -> pure $ Qualified $ XObj (Lst [defn, sym, args, qualifiedBody]) i t
+  do let recursionEnv = Env Map.empty (Just env) (Just (functionName ++ "-recurse-env")) Set.empty RecursionEnv 0
+         envWithSelf = extendEnv recursionEnv functionName sym
+         functionEnv = Env Map.empty (Just envWithSelf) Nothing Set.empty InternalEnv 0
+         envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
+     qualifiedBody <- liftM unQualified (setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body)
+     pure (Qualified (XObj (Lst [defn, sym, args, qualifiedBody]) i t))
 qualifyFunctionDefinition _ _ _ xobj = Left $ FailedToQualifyDeclarationName xobj
 
 -- | Qualify the symbols in a lambda body.
 qualifyLambda :: Qualifier
 qualifyLambda typeEnv globalEnv env (XObj (Lst [fn@(XObj (Fn _ _) _ _), args@(XObj (Arr argsArr) _ _), body]) i t) =
-  let lvl = envFunctionNestingLevel env
-      functionEnv = Env Map.empty (Just env) Nothing Set.empty InternalEnv (lvl + 1)
-      envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
-   in setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body
-        >>= pure . unQualified
-        >>= \qualifiedBody -> pure $ Qualified $ XObj (Lst [fn, args, qualifiedBody]) i t
+  do let lvl = envFunctionNestingLevel env
+         functionEnv = Env Map.empty (Just env) Nothing Set.empty InternalEnv (lvl + 1)
+         envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
+     qualifiedBody <- liftM unQualified (setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body)
+     pure (Qualified (XObj (Lst [fn, args, qualifiedBody]) i t))
 qualifyLambda _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 
 -- | Qualify the symbols in a The form's body.
 qualifyThe :: Qualifier
 qualifyThe typeEnv globalEnv env (XObj (Lst [the@(XObj The _ _), typeX, value]) i t) =
-  setFullyQualifiedSymbols typeEnv globalEnv env value
-    >>= pure . unQualified
-    >>= \qualifiedValue -> pure $ Qualified $ XObj (Lst [the, typeX, qualifiedValue]) i t
+  do qualifiedValue <- liftM unQualified (setFullyQualifiedSymbols typeEnv globalEnv env value)
+     pure (Qualified (XObj (Lst [the, typeX, qualifiedValue]) i t))
 qualifyThe _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 
 -- | Qualify the symbols in a Def form's body.
 qualifyDef :: Qualifier
 qualifyDef typeEnv globalEnv env (XObj (Lst [def@(XObj Def _ _), sym, expr]) i t) =
-  setFullyQualifiedSymbols typeEnv globalEnv env expr
-    >>= pure . unQualified
-    >>= \qualifiedExpr -> pure $ Qualified $ XObj (Lst [def, sym, qualifiedExpr]) i t
+  do qualifiedExpr <- liftM unQualified (setFullyQualifiedSymbols typeEnv globalEnv env expr)
+     pure (Qualified (XObj (Lst [def, sym, qualifiedExpr]) i t))
 qualifyDef _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 
 -- | Qualify the symbols in a Let form's bindings and body.
@@ -218,20 +219,17 @@ qualifyLet typeEnv globalEnv env (XObj (Lst [letExpr@(XObj Let _ _), bind@(XObj 
   | odd (length bindings) = Right $ Qualified $ XObj (Lst [letExpr, bind, body]) i t -- Leave it untouched for the compiler to find the error.
   | not (all isSym (evenIndices bindings)) = Right $ Qualified $ XObj (Lst [letExpr, bind, body]) i t -- Leave it untouched for the compiler to find the error.
   | otherwise =
-    let Just ii = i
-        lvl = envFunctionNestingLevel env
-        innerEnv = Env Map.empty (Just env) (Just ("let-env-" ++ show (infoIdentifier ii))) Set.empty InternalEnv lvl
-     in foldM qualifyBinding (innerEnv, []) (pairwise bindings)
-          >>= \(innerEnv', qualifiedBindings) ->
-            setFullyQualifiedSymbols typeEnv globalEnv innerEnv' body
-              >>= pure . unQualified
-              >>= \qualifiedBody -> pure $ Qualified $ XObj (Lst [letExpr, XObj (Arr qualifiedBindings) bindi bindt, qualifiedBody]) i t
+    do let Just ii = i
+           lvl = envFunctionNestingLevel env
+           innerEnv = Env Map.empty (Just env) (Just ("let-env-" ++ show (infoIdentifier ii))) Set.empty InternalEnv lvl
+       (innerEnv', qualifiedBindings) <- foldM qualifyBinding (innerEnv, []) (pairwise bindings)
+       qualifiedBody <- liftM unQualified (setFullyQualifiedSymbols typeEnv globalEnv innerEnv' body)
+       pure (Qualified (XObj (Lst [letExpr, XObj (Arr qualifiedBindings) bindi bindt, qualifiedBody]) i t))
   where
     qualifyBinding :: (Env, [XObj]) -> (XObj, XObj) -> Either QualificationError (Env, [XObj])
     qualifyBinding (e, bs) (s@(XObj (Sym (SymPath _ binderName) _) _ _), o) =
-      setFullyQualifiedSymbols typeEnv globalEnv e o
-        >>= pure . unQualified
-        >>= \qualified -> pure $ (extendEnv e binderName s, bs ++ [s, qualified])
+      do qualified <- liftM unQualified (setFullyQualifiedSymbols typeEnv globalEnv e o)
+         (pure (extendEnv e binderName s, bs ++ [s, qualified]))
     qualifyBinding _ _ = error "bad let binding"
 qualifyLet _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 
@@ -240,12 +238,9 @@ qualifyMatch :: Qualifier
 qualifyMatch typeEnv globalEnv env (XObj (Lst (matchExpr@(XObj (Match _) _ _) : expr : casesXObjs)) i t)
   | odd (length casesXObjs) = pure $ Qualified $ XObj (Lst (matchExpr : expr : casesXObjs)) i t -- Leave it untouched for the compiler to find the error.
   | otherwise =
-    setFullyQualifiedSymbols typeEnv globalEnv env expr
-      >>= pure . unQualified
-      >>= \qualifiedExpr ->
-        mapM qualifyCases (pairwise casesXObjs)
-          >>= pure . map (map unQualified)
-          >>= \qualifiedCases -> pure $ Qualified $ XObj (Lst (matchExpr : qualifiedExpr : concat qualifiedCases)) i t
+      do qualifiedExpr <- pure . unQualified =<< setFullyQualifiedSymbols typeEnv globalEnv env expr
+         qualifiedCases <- pure . map (map unQualified) =<< mapM qualifyCases (pairwise casesXObjs)
+         pure (Qualified (XObj (Lst (matchExpr : qualifiedExpr : concat qualifiedCases)) i t))
   where
     Just ii = i
     lvl = envFunctionNestingLevel env
@@ -281,9 +276,8 @@ qualifyWith _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 qualifyLst :: Qualifier
 qualifyLst typeEnv globalEnv env (XObj (Lst xobjs) i t) =
   -- TODO: Perhaps this general case can be sufficient? No need with all the cases above..?
-  mapM (setFullyQualifiedSymbols typeEnv globalEnv env) xobjs
-    >>= pure . map unQualified
-    >>= \xobjs' -> pure $ Qualified $ XObj (Lst xobjs') i t
+  do qualifiedXObjs <- liftM (map unQualified) (mapM (setFullyQualifiedSymbols typeEnv globalEnv env) xobjs)
+     pure (Qualified (XObj (Lst qualifiedXObjs) i t))
 qualifyLst _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 
 -- | Qualify a single symbol.
@@ -388,15 +382,13 @@ qualifySym _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 -- | Qualify an Arr form.
 qualifyArr :: Qualifier
 qualifyArr typeEnv globalEnv env (XObj (Arr array) i t) =
-  mapM (setFullyQualifiedSymbols typeEnv globalEnv env) array
-    >>= pure . map unQualified
-    >>= \array' -> pure $ Qualified $ XObj (Arr array') i t
+  do qualifiedArr <- liftM (map unQualified) (mapM (setFullyQualifiedSymbols typeEnv globalEnv env) array)
+     pure (Qualified (XObj (Arr qualifiedArr) i t))
 qualifyArr _ _ _ xobj = Left $ FailedToQualifySymbols xobj
 
 -- | Qualify a StaticArr form.
 qualifyStaticArr :: Qualifier
 qualifyStaticArr typeEnv globalEnv env (XObj (StaticArr array) i t) =
-  mapM (setFullyQualifiedSymbols typeEnv globalEnv env) array
-    >>= pure . map unQualified
-    >>= \array' -> pure $ Qualified $ XObj (StaticArr array') i t
+  do qualifiedArr <- liftM (map unQualified) (mapM (setFullyQualifiedSymbols typeEnv globalEnv env) array)
+     pure (Qualified (XObj (StaticArr qualifiedArr) i t))
 qualifyStaticArr _ _ _ xobj = Left $ FailedToQualifySymbols xobj

--- a/src/Qualify.hs
+++ b/src/Qualify.hs
@@ -1,5 +1,21 @@
-module Qualify where
+--------------------------------------------------------------------------------
 
+-- | Defines data, errors, and functions for qualifying symbols in a given
+-- context.
+module Qualify
+  ( QualificationError,
+    QualifiedPath,
+    Qualified (..),
+    qualify,
+    qualifyPath,
+    unqualify,
+    markQualified,
+    qualifyNull,
+    getQualifiedPath,
+  )
+where
+
+import Control.Monad (foldM)
 import Data.List (foldl')
 import Debug.Trace
 import Env
@@ -11,147 +27,293 @@ import qualified Set
 import Types
 import Util
 
--- | Changes the symbol part of a defn (the name) to a new symbol path
--- | Example: (defn foo () 123) => (defn GreatModule.foo () 123)
-setFullyQualifiedDefn :: XObj -> SymPath -> XObj
-setFullyQualifiedDefn (XObj (Lst [defn, XObj _ symi symt, args, body]) i t) newPath =
-  XObj (Lst [defn, XObj (Sym newPath Symbol) symi symt, args, body]) i t
-setFullyQualifiedDefn (XObj (Lst [def, XObj _ symi symt, expr]) i t) newPath =
-  XObj (Lst [def, XObj (Sym newPath Symbol) symi symt, expr]) i t
-setFullyQualifiedDefn xobj _ = error ("Can't set new path on " ++ show xobj)
+--------------------------------------------------------------------------------
+-- Errors
+
+-- | Error qualifying a symbol.
+data QualificationError
+  = FailedToQualifyDeclarationName XObj
+  | FailedToQualifySymbols XObj
+  | FailedToQualifyPath SymPath
+
+instance Show QualificationError where
+  show (FailedToQualifyDeclarationName xobj) =
+    "Couldn't fully qualify the definition: " ++ pretty xobj
+  show (FailedToQualifySymbols xobj) =
+    "Couldn't fully qualify the symbols in the form: " ++ pretty xobj
+  show (FailedToQualifyPath spath) =
+    "Couldn't fully qualify the symbol: " ++ show spath
+      ++ "in the given context."
+
+--------------------------------------------------------------------------------
+-- Data
+
+-- | Denotes an XObj containing only symbols that *have been fully qualified*.
+--
+-- A fully qualified xobj **must not** be qualified further (e.g. using context
+-- paths).
+newtype Qualified = Qualified {runQualified :: XObj}
+
+-- | Denotes a symbol that has been fully qualified.
+newtype QualifiedPath = QualifiedPath SymPath
+  deriving (Ord, Eq)
+
+instance Show QualifiedPath where
+  show (QualifiedPath spath) = show spath
+
+--------------------------------------------------------------------------------
+-- Path Qualification Functions
+
+-- | Qualifies a symbol in a given Context.
+qualifyPath :: Context -> SymPath -> QualifiedPath
+qualifyPath ctx spath =
+  let qpath = consPath (contextPath ctx) spath
+   in (QualifiedPath qpath)
+
+-- | Transforms a qualified path into an equivalent SymPath.
+--
+-- Used to cross the qualified/unqualified symbol boundary.
+-- This is predominantly used for compatibility with other parts of the
+-- codebase once qualification checks have been performed.
+unqualify :: QualifiedPath -> SymPath
+unqualify (QualifiedPath spath) = spath
+
+-- | Marks a path as fully qualified without performing any transformations.
+--
+-- Used to indicate a "naked", unprocessed path should be treated qualified as
+-- given. For example, `inc` in `(implements inc Module.inc)` should be
+-- interpreted as fully qualified as typed and should not be qualified using
+-- the overarching context.
+markQualified :: SymPath -> QualifiedPath
+markQualified = QualifiedPath
+
+-- | Qualify a symbol contextually if it is not qualified, otherwise, mark it
+-- qualified.
+--
+-- This should be used whenever a path entered with *any* initial
+-- qualifications should be treated as an absolute reference while symbols
+-- without qualifications should be treated as a relative reference.
+--
+-- For example, `Foo.inc` in `(implements inc Foo.inc)` will be treated as an
+-- absolute reference to `Foo.inc`, even in the context of `Foo` and will not
+-- be qualified further. Contrarily, the second `inc` in `(implements inc inc)`
+-- in the context of `Foo` would be further qualified to `Foo.inc`.
+qualifyNull :: Context -> SymPath -> QualifiedPath
+qualifyNull ctx spath@(SymPath [] _) = qualifyPath ctx spath
+qualifyNull _ spath = markQualified spath
+
+--------------------------------------------------------------------------------
+-- XObj Qualification Functions
+
+-- | Gets the qualified path of a fully qualified XObj.
+getQualifiedPath :: Qualified -> QualifiedPath
+getQualifiedPath = QualifiedPath . getPath . runQualified
+
+-- | Qualifies all symbols in an XObj in the given context.
+qualify :: Context -> XObj -> Either QualificationError Qualified
+qualify ctx xobj@(XObj obj info ty) =
+  -- TODO: Merge this with setFullyQualifiedSymbols
+  case obj of
+    Lst [defn, (XObj (Sym (SymPath _ name) mode) symi symt), args, body] ->
+      setFullyQualifiedSymbols t g i (XObj (Lst [defn, (XObj (Sym (SymPath pathStrings name) mode) symi symt), args, body]) info ty)
+    Lst [def, XObj (Sym (SymPath _ name) mode) symi symt, expr] ->
+      setFullyQualifiedSymbols t g i (XObj (Lst [def, (XObj (Sym (SymPath pathStrings name) mode) symi symt), expr]) info ty)
+    _ -> setFullyQualifiedSymbols t g i xobj
+  where
+    pathStrings :: [String]
+    pathStrings = contextPath ctx
+    t :: TypeEnv
+    t = contextTypeEnv ctx
+    g :: Env
+    g = contextGlobalEnv ctx
+    i :: Env
+    i = getEnv g pathStrings
 
 -- | Changes all symbols EXCEPT bound vars (defn names, variable names, etc) to their fully qualified paths.
 -- | This must run after the 'setFullyQualifiedDefn' function has fixed the paths of all bindings in the environment.
 -- | This function does NOT go into function-body scope environments and the like.
-setFullyQualifiedSymbols :: TypeEnv -> Env -> Env -> XObj -> XObj
-setFullyQualifiedSymbols
-  typeEnv
-  globalEnv
-  env
-  ( XObj
-      ( Lst
-          [ defn@(XObj (Defn _) _ _),
-            sym@(XObj (Sym (SymPath _ functionName) _) _ _),
-            args@(XObj (Arr argsArr) _ _),
-            body
-            ]
-        )
-      i
-      t
-    ) =
-    -- For self-recursion, there must be a binding to the function in the inner env.
-    -- It is marked as RecursionEnv basically is the same thing as external to not mess up lookup.
-    -- Inside the recursion env is the function env that contains bindings for the arguments of the function.
-    -- Note: These inner envs is ephemeral since they are not stored in a module or global scope.
-    let recursionEnv = Env Map.empty (Just env) (Just (functionName ++ "-recurse-env")) Set.empty RecursionEnv 0
-        envWithSelf = extendEnv recursionEnv functionName sym
-        functionEnv = Env Map.empty (Just envWithSelf) Nothing Set.empty InternalEnv 0
-        envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
-     in XObj (Lst [defn, sym, args, setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body]) i t
-setFullyQualifiedSymbols
-  typeEnv
-  globalEnv
-  env
-  ( XObj
-      ( Lst
-          [ fn@(XObj (Fn _ _) _ _),
-            args@(XObj (Arr argsArr) _ _),
-            body
-            ]
-        )
-      i
-      t
-    ) =
-    let lvl = envFunctionNestingLevel env
-        functionEnv = Env Map.empty (Just env) Nothing Set.empty InternalEnv (lvl + 1)
-        envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
-     in XObj (Lst [fn, args, setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body]) i t
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst [the@(XObj The _ _), typeXObj, value]) i t) =
-  let value' = setFullyQualifiedSymbols typeEnv globalEnv env value
-   in XObj (Lst [the, typeXObj, value']) i t
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst [def@(XObj Def _ _), sym, expr]) i t) =
-  let expr' = setFullyQualifiedSymbols typeEnv globalEnv env expr
-   in XObj (Lst [def, sym, expr']) i t
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst [letExpr@(XObj Let _ _), bind@(XObj (Arr bindings) bindi bindt), body]) i t)
-  | odd (length bindings) = XObj (Lst [letExpr, bind, body]) i t -- Leave it untouched for the compiler to find the error.
-  | not (all isSym (evenIndices bindings)) = XObj (Lst [letExpr, bind, body]) i t -- Leave it untouched for the compiler to find the error.
+setFullyQualifiedSymbols :: TypeEnv -> Env -> Env -> XObj -> Either QualificationError Qualified
+setFullyQualifiedSymbols t g e xobj =
+  case qualified of
+    Right qualifiedXObj -> Right $ Qualified $ qualifiedXObj
+    err -> fmap Qualified err
+  where
+    qualified :: Either QualificationError XObj
+    qualified =
+      fmap runQualified $
+        case xobjObj xobj of
+          Lst ((XObj (Defn _) _ _) : _) ->
+            qualifyFunctionDefinition t g e xobj
+          Lst ((XObj (Fn _ _) _ _) : _) ->
+            qualifyLambda t g e xobj
+          Lst ((XObj The _ _) : _) ->
+            qualifyThe t g e xobj
+          Lst ((XObj Def _ _) : _) ->
+            qualifyDef t g e xobj
+          Lst ((XObj Let _ _) : _) ->
+            qualifyLet t g e xobj
+          Lst ((XObj (Match _) _ _) : _) ->
+            qualifyMatch t g e xobj
+          Lst ((XObj With _ _) : _) ->
+            qualifyWith t g e xobj
+          Lst _ ->
+            qualifyLst t g e xobj
+          Sym _ _ ->
+            qualifySym t g e xobj
+          Arr _ ->
+            qualifyArr t g e xobj
+          StaticArr _ ->
+            qualifyStaticArr t g e xobj
+          _ -> Right $ Qualified $ xobj
+
+-- | The type of functions that qualify XObjs (forms/s-expressions).
+type Qualifier = TypeEnv -> Env -> Env -> XObj -> Either QualificationError Qualified
+
+-- | Qualify the symbols in a Defn form's body.
+qualifyFunctionDefinition :: Qualifier
+qualifyFunctionDefinition typeEnv globalEnv env (XObj (Lst [defn@(XObj (Defn _) _ _), sym@(XObj (Sym (SymPath _ functionName) _) _ _), args@(XObj (Arr argsArr) _ _), body]) i t) =
+  -- For self-recursion, there must be a binding to the function in the inner env.
+  -- It is marked as RecursionEnv basically is the same thing as external to not mess up lookup.
+  -- Inside the recursion env is the function env that contains bindings for the arguments of the function.
+  -- Note: These inner envs is ephemeral since they are not stored in a module or global scope.
+  let recursionEnv = Env Map.empty (Just env) (Just (functionName ++ "-recurse-env")) Set.empty RecursionEnv 0
+      envWithSelf = extendEnv recursionEnv functionName sym
+      functionEnv = Env Map.empty (Just envWithSelf) Nothing Set.empty InternalEnv 0
+      envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
+   in setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body
+        >>= pure . runQualified
+        >>= \qualifiedBody -> pure $ Qualified $ XObj (Lst [defn, sym, args, qualifiedBody]) i t
+qualifyFunctionDefinition _ _ _ xobj = Left $ FailedToQualifyDeclarationName xobj
+
+-- | Qualify the symbols in a lambda body.
+qualifyLambda :: Qualifier
+qualifyLambda typeEnv globalEnv env (XObj (Lst [fn@(XObj (Fn _ _) _ _), args@(XObj (Arr argsArr) _ _), body]) i t) =
+  let lvl = envFunctionNestingLevel env
+      functionEnv = Env Map.empty (Just env) Nothing Set.empty InternalEnv (lvl + 1)
+      envWithArgs = foldl' (\e arg@(XObj (Sym (SymPath _ argSymName) _) _ _) -> extendEnv e argSymName arg) functionEnv argsArr
+   in setFullyQualifiedSymbols typeEnv globalEnv envWithArgs body
+        >>= pure . runQualified
+        >>= \qualifiedBody -> pure $ Qualified $ XObj (Lst [fn, args, qualifiedBody]) i t
+qualifyLambda _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify the symbols in a The form's body.
+qualifyThe :: Qualifier
+qualifyThe typeEnv globalEnv env (XObj (Lst [the@(XObj The _ _), typeX, value]) i t) =
+  setFullyQualifiedSymbols typeEnv globalEnv env value
+    >>= pure . runQualified
+    >>= \qualifiedValue -> pure $ Qualified $ XObj (Lst [the, typeX, qualifiedValue]) i t
+qualifyThe _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify the symbols in a Def form's body.
+qualifyDef :: Qualifier
+qualifyDef typeEnv globalEnv env (XObj (Lst [def@(XObj Def _ _), sym, expr]) i t) =
+  setFullyQualifiedSymbols typeEnv globalEnv env expr
+    >>= pure . runQualified
+    >>= \qualifiedExpr -> pure $ Qualified $ XObj (Lst [def, sym, qualifiedExpr]) i t
+qualifyDef _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify the symbols in a Let form's bindings and body.
+qualifyLet :: Qualifier
+qualifyLet typeEnv globalEnv env (XObj (Lst [letExpr@(XObj Let _ _), bind@(XObj (Arr bindings) bindi bindt), body]) i t)
+  | odd (length bindings) = Right $ Qualified $ XObj (Lst [letExpr, bind, body]) i t -- Leave it untouched for the compiler to find the error.
+  | not (all isSym (evenIndices bindings)) = Right $ Qualified $ XObj (Lst [letExpr, bind, body]) i t -- Leave it untouched for the compiler to find the error.
   | otherwise =
     let Just ii = i
         lvl = envFunctionNestingLevel env
         innerEnv = Env Map.empty (Just env) (Just ("let-env-" ++ show (infoIdentifier ii))) Set.empty InternalEnv lvl
-        (innerEnv', bindings') =
-          foldl'
-            ( \(e, bs) (s@(XObj (Sym (SymPath _ binderName) _) _ _), o) ->
-                let qualified = setFullyQualifiedSymbols typeEnv globalEnv e o
-                 in (extendEnv e binderName s, bs ++ [s, qualified])
-            )
-            (innerEnv, [])
-            (pairwise bindings)
-        newBody = setFullyQualifiedSymbols typeEnv globalEnv innerEnv' body
-     in XObj (Lst [letExpr, XObj (Arr bindings') bindi bindt, newBody]) i t
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst (matchExpr@(XObj (Match _) _ _) : expr : casesXObjs)) i t) =
-  if even (length casesXObjs)
-    then
-      let newExpr = setFullyQualifiedSymbols typeEnv globalEnv env expr
-          Just ii = i
-          lvl = envFunctionNestingLevel env
-          innerEnv = Env Map.empty (Just env) (Just ("case-env-" ++ show (infoIdentifier ii))) Set.empty InternalEnv lvl
-          newCasesXObjs =
-            map
-              ( \(l, r) ->
-                  case l of
-                    XObj (Lst (_ : xs)) _ _ ->
-                      let l' = setFullyQualifiedSymbols typeEnv globalEnv env l
-                          innerEnv' = foldl' folder innerEnv xs
-                            where
-                              folder e v = case v of
-                                XObj (Sym (SymPath _ binderName) _) _ _ ->
-                                  extendEnv e binderName v
-                                -- Nested sumtypes
-                                -- fold recursively -- is there a more efficient way?
-                                XObj (Lst (_ : ys)) _ _ ->
-                                  foldl' folder innerEnv ys
-                                x ->
-                                  error ("Can't match variable with " ++ show x)
-                          r' = setFullyQualifiedSymbols typeEnv globalEnv innerEnv' r
-                       in [l', r']
-                    XObj {} ->
-                      let l' = setFullyQualifiedSymbols typeEnv globalEnv env l
-                          r' = setFullyQualifiedSymbols typeEnv globalEnv env r
-                       in [l', r']
-              )
-              (pairwise casesXObjs)
-       in XObj (Lst (matchExpr : newExpr : concat newCasesXObjs)) i t
-    else XObj (Lst (matchExpr : expr : casesXObjs)) i t -- Leave it untouched for the compiler to find the error.
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst [XObj With _ _, XObj (Sym path _) _ _, expression]) _ _) =
+     in foldM qualifyBinding (innerEnv, []) (pairwise bindings)
+          >>= \(innerEnv', qualifiedBindings) ->
+            setFullyQualifiedSymbols typeEnv globalEnv innerEnv' body
+              >>= pure . runQualified
+              >>= \qualifiedBody -> pure $ Qualified $ XObj (Lst [letExpr, XObj (Arr qualifiedBindings) bindi bindt, qualifiedBody]) i t
+  where
+    qualifyBinding :: (Env, [XObj]) -> (XObj, XObj) -> Either QualificationError (Env, [XObj])
+    qualifyBinding (e, bs) (s@(XObj (Sym (SymPath _ binderName) _) _ _), o) =
+      setFullyQualifiedSymbols typeEnv globalEnv e o
+        >>= pure . runQualified
+        >>= \qualified -> pure $ (extendEnv e binderName s, bs ++ [s, qualified])
+    qualifyBinding _ _ = error "bad let binding"
+qualifyLet _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify symbols in a Match form.
+qualifyMatch :: Qualifier
+qualifyMatch typeEnv globalEnv env (XObj (Lst (matchExpr@(XObj (Match _) _ _) : expr : casesXObjs)) i t)
+  | odd (length casesXObjs) = pure $ Qualified $ XObj (Lst (matchExpr : expr : casesXObjs)) i t -- Leave it untouched for the compiler to find the error.
+  | otherwise =
+    setFullyQualifiedSymbols typeEnv globalEnv env expr
+      >>= pure . runQualified
+      >>= \qualifiedExpr ->
+        mapM qualifyCases (pairwise casesXObjs)
+          >>= pure . map (map runQualified)
+          >>= \qualifiedCases -> pure $ Qualified $ XObj (Lst (matchExpr : qualifiedExpr : concat qualifiedCases)) i t
+  where
+    Just ii = i
+    lvl = envFunctionNestingLevel env
+    innerEnv :: Env
+    innerEnv = Env Map.empty (Just env) (Just ("case-env-" ++ show (infoIdentifier ii))) Set.empty InternalEnv lvl
+    qualifyCases :: (XObj, XObj) -> Either QualificationError [Qualified]
+    qualifyCases (l@(XObj (Lst (_ : xs)) _ _), r) =
+      let innerEnv' = foldl' foldVars innerEnv xs
+       in setFullyQualifiedSymbols typeEnv globalEnv env l
+            >>= \l' ->
+              setFullyQualifiedSymbols typeEnv globalEnv innerEnv' r
+                >>= \r' -> Right $ [l', r']
+    qualifyCases (l, r) =
+      setFullyQualifiedSymbols typeEnv globalEnv env l
+        >>= \l' ->
+          setFullyQualifiedSymbols typeEnv globalEnv env r
+            >>= \r' -> Right $ [l', r']
+    foldVars :: Env -> XObj -> Env
+    foldVars env' v@(XObj (Sym (SymPath _ binderName) _) _ _) = extendEnv env' binderName v
+    -- Nested sumtypes
+    -- fold recursively -- is there a more efficient way?
+    foldVars _ (XObj (Lst (_ : ys)) _ _) = foldl' foldVars innerEnv ys
+    foldVars _ v = error ("Can't match variable with " ++ show v)
+qualifyMatch _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify symbols in a With form.
+qualifyWith :: Qualifier
+qualifyWith typeEnv globalEnv env (XObj (Lst [XObj With _ _, XObj (Sym path _) _ _, expression]) _ _) =
   let useThese = envUseModules env
       env' = env {envUseModules = Set.insert path useThese}
    in setFullyQualifiedSymbols typeEnv globalEnv env' expression
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Lst xobjs) i t) =
+qualifyWith _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify symbols in a generic Lst form.
+qualifyLst :: Qualifier
+qualifyLst typeEnv globalEnv env (XObj (Lst xobjs) i t) =
   -- TODO: Perhaps this general case can be sufficient? No need with all the cases above..?
-  let xobjs' = map (setFullyQualifiedSymbols typeEnv globalEnv env) xobjs
-   in XObj (Lst xobjs') i t
-setFullyQualifiedSymbols typeEnv globalEnv localEnv xobj@(XObj (Sym path _) i t) =
-  case path of
-    -- Unqualified:
-    SymPath [] name ->
-      case lookupBinder path (getTypeEnv typeEnv) of
-        Just (Binder _ (XObj (Lst (XObj (Interface _ _) _ _ : _)) _ _)) ->
-          -- Found an interface with the same path!
-          -- Have to ensure it's not a local variable with the same name as the interface
-          case lookupInEnv path localEnv of
-            Just (foundEnv, _) ->
-              if envIsExternal foundEnv
-                then createInterfaceSym name
-                else doesNotBelongToAnInterface False localEnv
-            Nothing ->
-              --trace ("Will turn '" ++ show path ++ "' " ++ prettyInfoFromXObj xobj ++ " into an interface symbol.")
-              createInterfaceSym name
+  mapM (setFullyQualifiedSymbols typeEnv globalEnv env) xobjs
+    >>= pure . map runQualified
+    >>= \xobjs' -> pure $ Qualified $ XObj (Lst xobjs') i t
+qualifyLst _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify a single symbol.
+-- TODO: Clean this up
+qualifySym :: Qualifier
+qualifySym typeEnv globalEnv localEnv xobj@(XObj (Sym path _) i t) =
+  Right $
+    Qualified $
+      case path of
+        -- Unqualified:
+        SymPath [] name ->
+          case lookupBinder path (getTypeEnv typeEnv) of
+            Just (Binder _ (XObj (Lst (XObj (Interface _ _) _ _ : _)) _ _)) ->
+              -- Found an interface with the same path!
+              -- Have to ensure it's not a local variable with the same name as the interface
+              case lookupInEnv path localEnv of
+                Just (foundEnv, _) ->
+                  if envIsExternal foundEnv
+                    then createInterfaceSym name
+                    else doesNotBelongToAnInterface False localEnv
+                Nothing ->
+                  --trace ("Will turn '" ++ show path ++ "' " ++ prettyInfoFromXObj xobj ++ " into an interface symbol.")
+                  createInterfaceSym name
+            _ ->
+              doesNotBelongToAnInterface False localEnv
+        -- Qualified:
         _ ->
           doesNotBelongToAnInterface False localEnv
-    -- Qualified:
-    _ ->
-      doesNotBelongToAnInterface False localEnv
   where
     createInterfaceSym name =
       XObj (InterfaceSym name) i t
@@ -223,10 +385,20 @@ setFullyQualifiedSymbols typeEnv globalEnv localEnv xobj@(XObj (Sym path _) i t)
             )
             res
             bs
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (Arr array) i t) =
-  let array' = map (setFullyQualifiedSymbols typeEnv globalEnv env) array
-   in XObj (Arr array') i t
-setFullyQualifiedSymbols typeEnv globalEnv env (XObj (StaticArr array) i t) =
-  let array' = map (setFullyQualifiedSymbols typeEnv globalEnv env) array
-   in XObj (StaticArr array') i t
-setFullyQualifiedSymbols _ _ _ xobj = xobj
+qualifySym _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify an Arr form.
+qualifyArr :: Qualifier
+qualifyArr typeEnv globalEnv env (XObj (Arr array) i t) =
+  mapM (setFullyQualifiedSymbols typeEnv globalEnv env) array
+    >>= pure . map runQualified
+    >>= \array' -> pure $ Qualified $ XObj (Arr array') i t
+qualifyArr _ _ _ xobj = Left $ FailedToQualifySymbols xobj
+
+-- | Qualify a StaticArr form.
+qualifyStaticArr :: Qualifier
+qualifyStaticArr typeEnv globalEnv env (XObj (StaticArr array) i t) =
+  mapM (setFullyQualifiedSymbols typeEnv globalEnv env) array
+    >>= pure . map runQualified
+    >>= \array' -> pure $ Qualified $ XObj (StaticArr array') i t
+qualifyStaticArr _ _ _ xobj = Left $ FailedToQualifySymbols xobj

--- a/src/Qualify.hs
+++ b/src/Qualify.hs
@@ -253,16 +253,14 @@ qualifyMatch typeEnv globalEnv env (XObj (Lst (matchExpr@(XObj (Match _) _ _) : 
     innerEnv = Env Map.empty (Just env) (Just ("case-env-" ++ show (infoIdentifier ii))) Set.empty InternalEnv lvl
     qualifyCases :: (XObj, XObj) -> Either QualificationError [Qualified]
     qualifyCases (l@(XObj (Lst (_ : xs)) _ _), r) =
-      let innerEnv' = foldl' foldVars innerEnv xs
-       in setFullyQualifiedSymbols typeEnv globalEnv env l
-            >>= \l' ->
-              setFullyQualifiedSymbols typeEnv globalEnv innerEnv' r
-                >>= \r' -> Right $ [l', r']
+      do let innerEnv' = foldl' foldVars innerEnv xs
+         qualifiedLHS <- setFullyQualifiedSymbols typeEnv globalEnv env l
+         qualifiedRHS <- setFullyQualifiedSymbols typeEnv globalEnv innerEnv' r
+         Right [qualifiedLHS, qualifiedRHS]
     qualifyCases (l, r) =
-      setFullyQualifiedSymbols typeEnv globalEnv env l
-        >>= \l' ->
-          setFullyQualifiedSymbols typeEnv globalEnv env r
-            >>= \r' -> Right $ [l', r']
+      do qualifiedLHS <- setFullyQualifiedSymbols typeEnv globalEnv env l
+         qualifiedRHS <- setFullyQualifiedSymbols typeEnv globalEnv env r
+         Right [qualifiedLHS, qualifiedRHS]
     foldVars :: Env -> XObj -> Env
     foldVars env' v@(XObj (Sym (SymPath _ binderName) _) _ _) = extendEnv env' binderName v
     -- Nested sumtypes


### PR DESCRIPTION
This PR is on the bigger side and does a few things:

1. Augments `Context.hs` with several utility functions for managing environments and other properties of a context--this enables us to use a more abstract/opaque API and move all context updating into a single place, making it harder to get things wrong.
2. Refactors the `Qualify` module to include types for representing *fully qualified xobjs and sympaths*. While I was working through the code base I realized that we were qualifying symbols across module boundaries (for example, the xobjs passed to `define` in `Primitives.hs` are fully qualified by `annotateWithinContext` in `Eval.hs`, which is also called in a few other contexts, meanwhile, several other primitives qualified symbols themselves, using contextPaths.) The old situation made code hard to grok and made it easy to mistakenly re-qualify a symbol that was already qualified or forget to qualify a symbol that still needed qualification. Using a type to represent the difference is a more defensive strategy which should make communication across modules more apparent and make it harder to do the wrong thing.
3. A couple of other miscellaneous refactors are included.