### PR TITLE
fix: don't qualify paths of registered types

### DIFF
--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -237,7 +237,8 @@ primitiveRegisterTypeWithoutFields :: Context -> String -> Maybe String -> IO (C
 primitiveRegisterTypeWithoutFields ctx t override = do
   let path = SymPath [] t
       typeDefinition = XObj (Lst [XObj (ExternalType override) Nothing Nothing, XObj (Sym path Symbol) Nothing Nothing]) Nothing (Just TypeTy)
-  pure (insertInTypeEnv ctx (qualifyPath ctx path) (toBinder typeDefinition), dynamicNil)
+  -- TODO: Support registering types in modules
+  pure (insertInTypeEnv ctx (markQualified path) (toBinder typeDefinition), dynamicNil)
 
 primitiveRegisterTypeWithFields :: Context -> XObj -> String -> Maybe String -> XObj -> IO (Context, Either EvalError XObj)
 primitiveRegisterTypeWithFields ctx x t override members =


### PR DESCRIPTION
The previous commit added qualification to paths of registered types.
However, while types defined in Carp support qualification (definition
within a module) thanks to special logic, this logic is not yet
implemented for registered types, leading to errors if their paths are
qualified in the type environment. This commit fixes the behavior and
adds a TODO to support this for registered types.