### PR TITLE
fix: don't `eval` meta-set! macros

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -95,7 +95,7 @@
 
 (doc sig "Annotate a binding with the desired signature.")
 (defmacro sig [name signature]
-  (eval (list 'meta-set! name "sig" signature)))
+  (list 'meta-set! name "sig" signature))
 
 (doc print-sig "Print the annotated signature for a binding.")
 (defmacro print-sig [name]
@@ -103,11 +103,11 @@
 
 (doc hide "Mark a binding as hidden, this will make it not print with the 'info' command.")
 (defmacro hidden [name]
-  (eval (list 'meta-set! name "hidden" true)))
+  (list 'meta-set! name "hidden" true))
 
 (doc private "Mark a binding as private, this will make it inaccessible from other modules.")
 (defmacro private [name]
-  (eval (list 'meta-set! name "private" true)))
+  (list 'meta-set! name "private" true))
 
 (doc todo "sets the todo property for a binding.")
 (defmacro todo [name value]
@@ -126,12 +126,12 @@
 
 (doc annotate "Add an annotation to this binding.")
 (defmacro annotate [name annotation]
-  (eval (list 'meta-set! name "annotations" (eval (annotate-helper name annotation)))))
+  (list 'meta-set! name "annotations" (eval (annotate-helper name annotation))))
 
 (doc deprecated "Declares that a binding is deprecated, using an optional explanation.")
 (defmacro deprecated [name :rest explanation]
   (let [v (if (= (length explanation) 0) true (car explanation))]
-    (eval (list 'meta-set! name "deprecated" v))))
+    (list 'meta-set! name "deprecated" v)))
 
 (defmodule Dynamic
 


### PR DESCRIPTION
Previously, we called eval on meta-set! macros like doc and sig. The
effect of this is to make such calls in the repl have immediate effect,
rather than print their macro expansions. Unfortunately, this behavior
has a dark and unintended consequence when evaluating files. Because
these macro calls force evaluation of their bodies, the meta-set! call
is executed immediately on macro expansion, *often in the wrong
context*, resulting in "stub" meta forms for undefined bindings to be
added to the wrong module scope. Consider the following (assuming the
old definitions of these functions using eval hold):

```
(defmodule Foo
  (defmodule Bar
    (doc baz "foo")
  )
)
```

One would expect this code to result in one binding/definition being
created, `Foo.Bar.baz`. However, this code will actually produce two
bindings `Foo.baz` and the expected `Foo.Bar.baz`. This is due to the
way we evaluate macros. Macro expansion will happen in two passes, once
for all forms in `defmodule Foo`, and a second time for all forms in
`defmodule Bar`. When `doc` contains an `eval` call, the meta-set is
forced during macro expansion cycle 1, in `defmodule Foo`, resulting
in an additional, unanticipated binding being added to Foo.
Contrarily, if we remove the call to `eval`, the first expansion
during evaluation of `defmodule Foo` simply expands the call into
meta-set, which is then evaluated normally during evaluation of
`defmodule Bar`.

The primary trade-off entailed by this change is that calls like `doc
foo` will no longer be immediately evaluated in the repl. The utility of
these macros seems more aligned to their use in files, so I don't think
it's a change many will gripe about. Users can also wrap such calls in
eval themselves to evaluate the macro expansion in the repl when needed
(or even in files, too).