### PR TITLE
feat: add dynamic types

### DIFF
--- a/core/Dynamic.carp
+++ b/core/Dynamic.carp
@@ -81,31 +81,40 @@ Example:
 ; => \"(Point 1 4)\"
 ```")
   (defmacro deftype-dynamic [name slots]
-    (eval `(defmodule %name
-       (defndynamic init %(collect-into slots array)
-          [%(String.concat [dynamic-type-tag (Symbol.str name)]) %@slots])
+    (let [slots-arr (collect-into slots array)
+          slots-ls (collect-into slots list)]
+      (eval `(defmodule %name
+         (defndynamic init %slots-arr
+            [%(String.concat [dynamic-type-tag (Symbol.str name)]) %@slots-ls])
 
-       (defndynamic %(Symbol.concat [name '?]) [o]
-         (and (array? o) (= (car o) '%(String.concat [dynamic-type-tag (Symbol.str name)]))))
+         (defndynamic %(Symbol.concat [name '?]) [o]
+           (and (array? o)
+                (= (car o)
+                   '%(String.concat [dynamic-type-tag (Symbol.str name)]))))
 
-       %@(map
-           (fn [slot]
-             `(defndynamic %slot [o]
-                 (List.nth o %(inc (List.index-of slots slot)))))
-           slots)
+         %@(map
+             (fn [slot]
+               `(defndynamic %slot [o]
+                   (List.nth o %(inc (List.index-of slots-ls slot)))))
+             slots-ls)
 
-       %@(map
-           (fn [slot]
-             `(defndynamic %(Symbol.concat ['set- slot]) [o n]
-                 (List.set-nth o %(inc (List.index-of slots slot)) n)))
-           slots)
+         %@(map
+             (fn [slot]
+               `(defndynamic %(Symbol.concat ['set- slot]) [o n]
+                   (List.set-nth o %(inc (List.index-of slots-ls slot)) n)))
+             slots-ls)
 
-      (defndynamic str [o]
-        (String.concat
-          ["(" %(Symbol.str name)
-               %@(map (fn [slot] `(String.concat [" " (str (%(Symbol.prefix name slot) o))])) slots)
-           ")"]))
-    ))
+        (defndynamic str [o]
+          (String.concat
+            ["(" %(Symbol.str name)
+                 %@(map (fn [slot]
+                          `(String.concat [" "
+                                           (str (%(Symbol.prefix name slot) o))
+                                          ]))
+                        slots-ls)
+             ")"]))
+      ))
+    )
   )
 
   ; this is sadly too slow :(

--- a/core/Dynamic.carp
+++ b/core/Dynamic.carp
@@ -88,9 +88,10 @@ Example:
             [%(String.concat [dynamic-type-tag (Symbol.str name)]) %@slots-ls])
 
          (defndynamic %(Symbol.concat [name '?]) [o]
-           (and (array? o)
-                (= (car o)
-                   '%(String.concat [dynamic-type-tag (Symbol.str name)]))))
+           (and* (array? o)
+                 (= (length o) %(inc (length slots)))
+                 (= (car o)
+                    '%(String.concat [dynamic-type-tag (Symbol.str name)]))))
 
          %@(map
              (fn [slot]
@@ -141,8 +142,12 @@ Example:
             cs (prim-str dynamic-type-tag)]
         (if (and (string? tag?) (String.starts-with? tag? cs))
           (let [md (String.suffix tag? (String.length cs))
-                f (Symbol.prefix (Symbol.from md) 'str)]
-            ((eval f) a))
+                mds (Symbol.from md)
+                f (Symbol.prefix mds 'str)
+                pred (Symbol.prefix mds (Symbol.concat [mds '?]))]
+            (if (pred a)
+              ((eval f) a)
+              (prim-str a)))
           (prim-str a)))
       (prim-str a)))
 )

--- a/core/Dynamic.carp
+++ b/core/Dynamic.carp
@@ -52,12 +52,90 @@
     (defndynamic suffix [s from]
       (String.slice s from (String.length s)))
 
+    (defndynamic starts-with? [s prfx]
+      (= (String.prefix s (String.length prfx)) prfx))
+
+    (defndynamic ends-with? [s prfx]
+      (= (String.suffix s (String.length prfx)) prfx))
+
     (defndynamic head [s]
       (String.prefix s 1))
 
     (defndynamic tail [s]
       (String.suffix s 1))
   )
+
+  (hidden dynamic-type-tag)
+  (defdynamic dynamic-type-tag "carp-dynamic-type-tag-")
+
+  (doc deftype-dynamic "creates a dynamic type with the members `slots` under
+the name `name`.
+
+Getters, setters, and initializers will be created.
+
+Example:
+```
+(deftype-dynamic Point (x y))
+
+(Point.str (Point.set-y (Point.init 1 2) 4))
+; => \"(Point 1 4)\"
+```")
+  (defmacro deftype-dynamic [name slots]
+    (eval `(defmodule %name
+       (defndynamic init %(collect-into slots array)
+          [%(String.concat [dynamic-type-tag (Symbol.str name)]) %@slots])
+
+       (defndynamic %(Symbol.concat [name '?]) [o]
+         (and (array? o) (= (car o) '%(String.concat [dynamic-type-tag (Symbol.str name)]))))
+
+       %@(map
+           (fn [slot]
+             `(defndynamic %slot [o]
+                 (List.nth o %(inc (List.index-of slots slot)))))
+           slots)
+
+       %@(map
+           (fn [slot]
+             `(defndynamic %(Symbol.concat ['set- slot]) [o n]
+                 (List.set-nth o %(inc (List.index-of slots slot)) n)))
+           slots)
+
+      (defndynamic str [o]
+        (String.concat
+          ["(" %(Symbol.str name)
+               %@(map (fn [slot] `(String.concat [" " (str (%(Symbol.prefix name slot) o))])) slots)
+           ")"]))
+    ))
+  )
+
+  ; this is sadly too slow :(
+  ;(defdynamic prim-= =)
+
+  ;(defndynamic = [a b]
+  ;  (if (and (array? a) (not (empty? a)))
+  ;    (let [tag? (car a)
+  ;          s (str tag?)
+  ;          cs (str dynamic-type-tag)]
+  ;      (if (and (symbol? tag?) (String.starts-with? s cs))
+  ;        (let [md (String.suffix s (length cs))
+  ;              f (Symbol.prefix (Symbol.from md) '=)]
+  ;          ((eval f) a b))
+  ;        (prim-= a b)))
+  ;    (prim-= a b)))
+
+  (hidden prim-str)
+  (defdynamic prim-str str)
+
+  (defndynamic str [a]
+    (if (and (array? a) (not (empty? a)))
+      (let [tag? (car a)
+            cs (prim-str dynamic-type-tag)]
+        (if (and (string? tag?) (String.starts-with? tag? cs))
+          (let [md (String.suffix tag? (String.length cs))
+                f (Symbol.prefix (Symbol.from md) 'str)]
+            ((eval f) a))
+          (prim-str a)))
+      (prim-str a)))
 )
 
 

--- a/core/Dynamic.carp
+++ b/core/Dynamic.carp
@@ -118,21 +118,6 @@ Example:
     )
   )
 
-  ; this is sadly too slow :(
-  ;(defdynamic prim-= =)
-
-  ;(defndynamic = [a b]
-  ;  (if (and (array? a) (not (empty? a)))
-  ;    (let [tag? (car a)
-  ;          s (str tag?)
-  ;          cs (str dynamic-type-tag)]
-  ;      (if (and (symbol? tag?) (String.starts-with? s cs))
-  ;        (let [md (String.suffix s (length cs))
-  ;              f (Symbol.prefix (Symbol.from md) '=)]
-  ;          ((eval f) a b))
-  ;        (prim-= a b)))
-  ;    (prim-= a b)))
-
   (hidden prim-str)
   (defdynamic prim-str str)
 

--- a/core/Dynamic.carp
+++ b/core/Dynamic.carp
@@ -150,6 +150,23 @@ Example:
               (prim-str a)))
           (prim-str a)))
       (prim-str a)))
+
+  ; this was already defined, but before hidden was, so we call it here
+  (hidden prim-dynamic-type)
+
+  (defndynamic dynamic-type [a]
+    (if (and (array? a) (not (empty? a)))
+      (let [tag? (car a)
+            cs (prim-str dynamic-type-tag)]
+        (if (and (string? tag?) (String.starts-with? tag? cs))
+          (let [md (String.suffix tag? (String.length cs))
+                mds (Symbol.from md)
+                pred (Symbol.prefix mds (Symbol.concat [mds '?]))]
+            (if (pred a)
+              mds
+              (prim-dynamic-type a)))
+          (prim-dynamic-type a)))
+      (prim-dynamic-type a)))
 )
 
 

--- a/core/List.carp
+++ b/core/List.carp
@@ -337,5 +337,18 @@ elements is uneven, the trailing element will be discarded.")
         (empty? l) '()
         (pred (car l)) (car l)
         (List.find (cdr l) pred)))
+
+    (doc index-of "finds the index of the first occurence of `elem` in the list
+`l`.
+
+If it isn’t found, `-1` is returned.")
+    (defndynamic index-of [l elem]
+      (cond
+        (empty? l) -1
+        (= elem (car l)) 0
+        (let [idx (List.index-of (cdr l) elem)]
+          (if (= -1 idx)
+            idx
+            (inc idx)))))
   )
 )

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -197,7 +197,7 @@
 
 (defmacro load-and-use [name]
   (do
-    (eval (list 'load (str name ".carp")))
+    (eval (list 'load (prim-str name ".carp")))
     (eval (list 'use name))))
 
 (defmacro comment [:rest forms]

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -61,20 +61,22 @@
           true
           (List.in? elem (cdr l))))))
 
+  (defdynamic prim-dynamic-type dynamic-type)
+
   (defndynamic string? [s]
-    (= (dynamic-type s) 'string))
+    (= (prim-dynamic-type s) 'string))
 
   (defndynamic symbol? [s]
-    (= (dynamic-type s) 'symbol))
+    (= (prim-dynamic-type s) 'symbol))
 
   (defndynamic list? [s]
-    (= (dynamic-type s) 'list))
+    (= (prim-dynamic-type s) 'list))
 
   (defndynamic array? [s]
-    (= (dynamic-type s) 'array))
+    (= (prim-dynamic-type s) 'array))
 
   (defndynamic number? [s]
-    (List.in? (dynamic-type s) '(int long double float byte))))
+    (List.in? (prim-dynamic-type s) '(int long double float byte))))
 
 (meta-set! doc "doc" "Set documentation for a binding.")
 (defmacro doc [name :rest strings]

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -632,7 +632,7 @@
     (doc init "creates a dynamic pair, i.e. a list with two elements.")
     (defndynamic init [k v] (list k v)))
 
-  (deftype-dynamic Map (l))
+  (deftype-dynamic Map [buckets])
 
   (defmodule Map
     (hidden dflt-len)
@@ -662,39 +662,39 @@
     (doc resize "resizes a dynamic map to size `s`.")
     (defndynamic resize [m s]
       (let-do [n (n-times s list)]
-        (Map.init (Map.resize- n (Map.l m)))))
+        (Map.init (Map.resize- n (Map.buckets m)))))
 
     (doc grow "grows a dynamic map.")
-    (defndynamic grow [m] (Map.resize m (* (length (Map.l m)) 2)))
+    (defndynamic grow [m] (Map.resize m (* (length (Map.buckets m)) 2)))
     (doc shrink "shrinks dynamic map.")
     (defndynamic shrink [m]
-      (let [new-size (/ (length (Map.l m)) 2)]
+      (let [new-size (/ (length (Map.buckets m)) 2)]
         (if (< new-size dflt-len)
           m
           (Map.resize m new-size))))
 
     (doc contains? "checks whether the dynamic map `m` contains the key `k`.")
     (defndynamic contains? [m k]
-      (let [l (Map.l m)
+      (let [l (Map.buckets m)
             idx (Dynamic.imod (hash k) (length l))]
         (List.in? k (map car (List.nth l idx)))))
 
     (doc put "adds a value `v` under the key `k` into the map. If `k` already
 exists in the map, it is updated.")
     (defndynamic put [m k v]
-      (if (> (/ (* (Map.len m) 100) (length (Map.l m))) Map.min-load)
+      (if (> (/ (* (Map.len m) 100) (length (Map.buckets m))) Map.min-load)
         (Map.put (Map.grow m) k v)
         (if (Map.contains? m k)
           (Map.update m k (fn [_] v))
-          (let [idx (Dynamic.imod (hash k) (length (Map.l m)))]
-            (Map.init (List.update-nth (Map.l m) idx (fn [l] (cons (list k v) l))))))))
+          (let [idx (Dynamic.imod (hash k) (length (Map.buckets m)))]
+            (Map.init (List.update-nth (Map.buckets m) idx (fn [l] (cons (list k v) l))))))))
 
     (doc get-with-default "gets the value under the key `k`. If `k` doesn’t
 exist in the map, the default value is returned.")
     (defndynamic get-with-default [m k default-value]
       (if (Map.contains? m k)
-        (let [idx (Dynamic.imod (hash k) (length (Map.l m)))
-              l (List.nth (Map.l m) idx)]
+        (let [idx (Dynamic.imod (hash k) (length (Map.buckets m)))
+              l (List.nth (Map.buckets m) idx)]
           (cadr (List.find l (fn [pair] (= (car pair) k)))))
           default-value))
 
@@ -707,8 +707,8 @@ map, `nil` is returned.")
 `k` doesn’t exist in the map, it is returned unchanged.")
     (defndynamic update [m k f]
       (if (Map.contains? m k)
-        (let [idx (Dynamic.imod (hash k) (length (Map.l m)))]
-          (Map.init (List.update-nth (Map.l m) idx
+        (let [idx (Dynamic.imod (hash k) (length (Map.buckets m)))]
+          (Map.init (List.update-nth (Map.buckets m) idx
             (curry
                 map
                 (fn [pair] (if (= (car pair) k) (list k (f (cadr pair))) pair))))))
@@ -718,8 +718,8 @@ map, `nil` is returned.")
 function `f`. If `k` doesn’t exist in the map, it is set to `(f v)`.")
     (defndynamic update-with-default [m k f v]
       (if (Map.contains? m k)
-        (let [idx (Dynamic.imod (hash k) (length (Map.l m)))]
-          (Map.init (List.update-nth (Map.l m) idx
+        (let [idx (Dynamic.imod (hash k) (length (Map.buckets m)))]
+          (Map.init (List.update-nth (Map.buckets m) idx
             (curry
                 map
                 (fn [pair] (if (= (car pair) k) (list k (f (cadr pair))) pair))))))
@@ -727,7 +727,7 @@ function `f`. If `k` doesn’t exist in the map, it is set to `(f v)`.")
 
     (doc len "returns the length of the map `m`.")
     (defndynamic len [m]
-      (reduce (fn [acc l] (+ acc (length l))) 0 (Map.l m)))
+      (reduce (fn [acc l] (+ acc (length l))) 0 (Map.buckets m)))
 
     (doc empty? "checks whether the map `m` is empty.")
     (defndynamic empty? [m]
@@ -735,17 +735,17 @@ function `f`. If `k` doesn’t exist in the map, it is set to `(f v)`.")
 
     (doc keys "returns the key in the map `m`.")
     (defndynamic keys [m]
-      (reduce (fn [acc l] (append acc (map car l))) '() (Map.l m)))
+      (reduce (fn [acc l] (append acc (map car l))) '() (Map.buckets m)))
 
     (doc vals "returns the values in the map `m`.")
     (defndynamic vals [m]
-      (reduce (fn [acc l] (append acc (map cadr l))) '() (Map.l m)))
+      (reduce (fn [acc l] (append acc (map cadr l))) '() (Map.buckets m)))
 
     (doc reverse "reverses the key-value pairs in the map `m`.")
     (defndynamic reverse [m]
       (reduce
         (fn [acc l] (reduce (fn [n p] (Map.put n (cadr p) (car p))) acc l))
-        (Map.create) (Map.l m)))
+        (Map.create) (Map.buckets m)))
 
     (defndynamic str [m]
       (String.concat [
@@ -759,17 +759,17 @@ function `f`. If `k` doesn’t exist in the map, it is set to `(f v)`.")
     (doc remove "removes the pair under the key `k` from the map `m`. If it
 doesn’t exist, the map is returned unchanged.")
     (defndynamic remove [m k]
-      (if (> (/ (* (Map.len m) 100) (length (Map.l m))) Map.min-load)
+      (if (> (/ (* (Map.len m) 100) (length (Map.buckets m))) Map.min-load)
         (Map.remove (Map.shrink m) k)
-        (let [idx (imod (hash k) (length (Map.l m)))]
-          (reduce (fn [acc l] (cons (filter (fn [pair] (/= (car pair) k)) l) acc)) '() (Map.l m)))))
+        (let [idx (imod (hash k) (length (Map.buckets m)))]
+          (reduce (fn [acc l] (cons (filter (fn [pair] (/= (car pair) k)) l) acc)) '() (Map.buckets m)))))
 
     (doc all? "checks whether all key value pairs in `m` satisfy the predicate
 `pred`. `pred` takes the pair `(k v)` as its sole argument.")
     (defndynamic all? [pred m]
       ; TODO: using (curry all? pred) doesn’t work here, i suppose it’s an env
       ; problem
-      (all? (fn [l] (all? pred l)) (Map.l m)))
+      (all? (fn [l] (all? pred l)) (Map.buckets m)))
 
     (doc = "checks whether two maps `m1` and `m2` are equal.")
     (defndynamic = [m1 m2]
@@ -780,13 +780,13 @@ doesn’t exist, the map is returned unchanged.")
 the pair `(k v)` as its sole argument and is expected to return a new value
 under `v`.")
     (defndynamic map [f m]
-      (Map.init (map (fn [l] (map (fn [pair] (list (car pair) (f pair))) l)) (Map.l m))))
+      (Map.init (map (fn [l] (map (fn [pair] (list (car pair) (f pair))) l)) (Map.buckets m))))
 
     (doc kv-reduce "reduces the map `m` using the function `f` and the initial
 value `init`. `f` takes the accumulator and the pair `(k v)` as its arguments
 and is expected to return a new accumulator.")
     (defndynamic kv-reduce [f init m]
-      (reduce (fn [acc l] (reduce f acc l)) init (Map.l m)))
+      (reduce (fn [acc l] (reduce f acc l)) init (Map.buckets m)))
 
     (doc merge "merges to maps `m1` and `m2`. Values in `m1` are preferred on
 collision.")
@@ -798,6 +798,6 @@ collision.")
       (reduce (fn [m pair] (Map.put m (car pair) (cadr pair))) (Map.create) a))
 
     (doc to-array "creates an array of key-value pairs from the map `m`.")
-    (defndynamic to-array [m] (collect-into (reduce append '() (Map.l m)) array))
+    (defndynamic to-array [m] (collect-into (reduce append '() (Map.buckets m)) array))
   )
 )

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -632,6 +632,8 @@
     (doc init "creates a dynamic pair, i.e. a list with two elements.")
     (defndynamic init [k v] (list k v)))
 
+  (deftype-dynamic Map (l))
+
   (defmodule Map
     (hidden dflt-len)
     (defdynamic dflt-len 16)
@@ -643,7 +645,7 @@
 
     (doc create "makes a dynamic map.")
     (defndynamic create []
-      (n-times Map.dflt-len list))
+      (Map.init (n-times Map.dflt-len list)))
 
     (hidden resize-bucket)
     (defndynamic resize-bucket [n m]
@@ -655,44 +657,44 @@
     (defndynamic resize- [n m]
       (if (empty? m)
         n
-        (do
-          (Map.resize- (Map.resize-bucket n (car m)) (cdr m)))))
+        (Map.resize- (Map.resize-bucket n (car m)) (cdr m))))
 
     (doc resize "resizes a dynamic map to size `s`.")
     (defndynamic resize [m s]
       (let-do [n (n-times s list)]
-        (Map.resize- n m )))
+        (Map.init (Map.resize- n (Map.l m)))))
 
     (doc grow "grows a dynamic map.")
-    (defndynamic grow [m] (Map.resize m (* (length m) 2)))
+    (defndynamic grow [m] (Map.resize m (* (length (Map.l m)) 2)))
     (doc shrink "shrinks dynamic map.")
     (defndynamic shrink [m]
-      (let [new-size (/ (length m) 2)]
+      (let [new-size (/ (length (Map.l m)) 2)]
         (if (< new-size dflt-len)
           m
           (Map.resize m new-size))))
 
     (doc contains? "checks whether the dynamic map `m` contains the key `k`.")
     (defndynamic contains? [m k]
-      (let [idx (Dynamic.imod (hash k) (length m))]
-        (List.in? k (map car (List.nth m idx)))))
+      (let [l (Map.l m)
+            idx (Dynamic.imod (hash k) (length l))]
+        (List.in? k (map car (List.nth l idx)))))
 
     (doc put "adds a value `v` under the key `k` into the map. If `k` already
 exists in the map, it is updated.")
     (defndynamic put [m k v]
-      (if (> (/ (* (Map.len m) 100) (length m)) Map.min-load)
+      (if (> (/ (* (Map.len m) 100) (length (Map.l m))) Map.min-load)
         (Map.put (Map.grow m) k v)
         (if (Map.contains? m k)
           (Map.update m k (fn [_] v))
-          (let [idx (Dynamic.imod (hash k) (length m))]
-            (List.update-nth m idx (fn [l] (cons (list k v) l)))))))
+          (let [idx (Dynamic.imod (hash k) (length (Map.l m)))]
+            (Map.init (List.update-nth (Map.l m) idx (fn [l] (cons (list k v) l))))))))
 
     (doc get-with-default "gets the value under the key `k`. If `k` doesn’t
 exist in the map, the default value is returned.")
     (defndynamic get-with-default [m k default-value]
       (if (Map.contains? m k)
-        (let [idx (Dynamic.imod (hash k) (length m))
-              l (List.nth m idx)]
+        (let [idx (Dynamic.imod (hash k) (length (Map.l m)))
+              l (List.nth (Map.l m) idx)]
           (cadr (List.find l (fn [pair] (= (car pair) k)))))
           default-value))
 
@@ -705,27 +707,27 @@ map, `nil` is returned.")
 `k` doesn’t exist in the map, it is returned unchanged.")
     (defndynamic update [m k f]
       (if (Map.contains? m k)
-        (let [idx (Dynamic.imod (hash k) (length m))]
-          (List.update-nth m idx
+        (let [idx (Dynamic.imod (hash k) (length (Map.l m)))]
+          (Map.init (List.update-nth (Map.l m) idx
             (curry
                 map
-                (fn [pair] (if (= (car pair) k) (list k (f (cadr pair))) pair)))))
+                (fn [pair] (if (= (car pair) k) (list k (f (cadr pair))) pair))))))
         m))
 
     (doc update-with-default "updates the value under the key `k` using the
 function `f`. If `k` doesn’t exist in the map, it is set to `(f v)`.")
     (defndynamic update-with-default [m k f v]
       (if (Map.contains? m k)
-        (let [idx (Dynamic.imod (hash k) (length m))]
-          (List.update-nth m idx
+        (let [idx (Dynamic.imod (hash k) (length (Map.l m)))]
+          (Map.init (List.update-nth (Map.l m) idx
             (curry
                 map
-                (fn [pair] (if (= (car pair) k) (list k (f (cadr pair))) pair)))))
+                (fn [pair] (if (= (car pair) k) (list k (f (cadr pair))) pair))))))
         (Map.put m k (f v))))
 
     (doc len "returns the length of the map `m`.")
     (defndynamic len [m]
-      (reduce (fn [acc l] (+ acc (length l))) 0 m))
+      (reduce (fn [acc l] (+ acc (length l))) 0 (Map.l m)))
 
     (doc empty? "checks whether the map `m` is empty.")
     (defndynamic empty? [m]
@@ -733,30 +735,23 @@ function `f`. If `k` doesn’t exist in the map, it is set to `(f v)`.")
 
     (doc keys "returns the key in the map `m`.")
     (defndynamic keys [m]
-      (reduce (fn [acc l] (append acc (map car l))) '() m))
+      (reduce (fn [acc l] (append acc (map car l))) '() (Map.l m)))
 
     (doc vals "returns the values in the map `m`.")
     (defndynamic vals [m]
-      (reduce (fn [acc l] (append acc (map cadr l))) '() m))
+      (reduce (fn [acc l] (append acc (map cadr l))) '() (Map.l m)))
 
     (doc reverse "reverses the key-value pairs in the map `m`.")
     (defndynamic reverse [m]
       (reduce
         (fn [acc l] (reduce (fn [n p] (Map.put n (cadr p) (car p))) acc l))
-        (Map.create) m))
+        (Map.create) (Map.l m)))
 
     (defndynamic str [m]
       (String.concat [
         "{ "
-        (reduce
-          (fn [acc l]
-            (String.concat [
-              acc
-              (reduce
-                (fn [a pair] (String.concat [a (str (car pair)) " " (str (cadr pair)) " "]))
-                ""
-                l)
-              ]))
+        (Map.kv-reduce
+          (fn [a pair] (String.concat [a (str (car pair)) " " (str (cadr pair)) " "]))
           ""
           m)
         "}"]))
@@ -764,17 +759,17 @@ function `f`. If `k` doesn’t exist in the map, it is set to `(f v)`.")
     (doc remove "removes the pair under the key `k` from the map `m`. If it
 doesn’t exist, the map is returned unchanged.")
     (defndynamic remove [m k]
-      (if (> (/ (* (Map.len m) 100) (length m)) Map.min-load)
+      (if (> (/ (* (Map.len m) 100) (length (Map.l m))) Map.min-load)
         (Map.remove (Map.shrink m) k)
-        (let [idx (imod (hash k) (length m))]
-          (reduce (fn [acc l] (cons (filter (fn [pair] (/= (car pair) k)) l) acc)) '() m))))
+        (let [idx (imod (hash k) (length (Map.l m)))]
+          (reduce (fn [acc l] (cons (filter (fn [pair] (/= (car pair) k)) l) acc)) '() (Map.l m)))))
 
     (doc all? "checks whether all key value pairs in `m` satisfy the predicate
 `pred`. `pred` takes the pair `(k v)` as its sole argument.")
     (defndynamic all? [pred m]
       ; TODO: using (curry all? pred) doesn’t work here, i suppose it’s an env
       ; problem
-      (all? (fn [l] (all? pred l)) m))
+      (all? (fn [l] (all? pred l)) (Map.l m)))
 
     (doc = "checks whether two maps `m1` and `m2` are equal.")
     (defndynamic = [m1 m2]
@@ -785,13 +780,13 @@ doesn’t exist, the map is returned unchanged.")
 the pair `(k v)` as its sole argument and is expected to return a new value
 under `v`.")
     (defndynamic map [f m]
-      (map (fn [l] (map (fn [pair] (list (car pair) (f pair))) l)) m))
+      (Map.init (map (fn [l] (map (fn [pair] (list (car pair) (f pair))) l)) (Map.l m))))
 
     (doc kv-reduce "reduces the map `m` using the function `f` and the initial
 value `init`. `f` takes the accumulator and the pair `(k v)` as its arguments
 and is expected to return a new accumulator.")
     (defndynamic kv-reduce [f init m]
-      (reduce (fn [acc l] (reduce f acc l)) init m))
+      (reduce (fn [acc l] (reduce f acc l)) init (Map.l m)))
 
     (doc merge "merges to maps `m1` and `m2`. Values in `m1` are preferred on
 collision.")
@@ -803,6 +798,6 @@ collision.")
       (reduce (fn [m pair] (Map.put m (car pair) (cadr pair))) (Map.create) a))
 
     (doc to-array "creates an array of key-value pairs from the map `m`.")
-    (defndynamic to-array [m] (collect-into (reduce append '() m) array))
+    (defndynamic to-array [m] (collect-into (reduce append '() (Map.l m)) array))
   )
 )

--- a/core/Map.carp
+++ b/core/Map.carp
@@ -643,9 +643,12 @@
     (hidden max-load)
     (defdynamic max-load 80)
 
-    (doc create "makes a dynamic map.")
+    (hidden create-sized)
+    (defndynamic create-sized [s]
+      (Map.init (n-times s list)))
+
     (defndynamic create []
-      (Map.init (n-times Map.dflt-len list)))
+      (Map.create-sized Map.dflt-len))
 
     (hidden resize-bucket)
     (defndynamic resize-bucket [n m]
@@ -661,8 +664,8 @@
 
     (doc resize "resizes a dynamic map to size `s`.")
     (defndynamic resize [m s]
-      (let-do [n (n-times s list)]
-        (Map.init (Map.resize- n (Map.buckets m)))))
+      (let-do [n (Map.create-sized s)]
+        (Map.resize- n (Map.buckets m))))
 
     (doc grow "grows a dynamic map.")
     (defndynamic grow [m] (Map.resize m (* (length (Map.buckets m)) 2)))

--- a/core/Quasiquote.carp
+++ b/core/Quasiquote.carp
@@ -59,8 +59,10 @@ Example:
     (cond
       (and (list? form) (> (length form) 0))
         (quasiquote-list form)
+      (and (array? form) (empty? form))
+        []
       (array? form)
-        (collect-into (map quasiquote- form) array)
+        (list 'collect-into (quasiquote-list (collect-into form list)) 'array)
       (list 'quote form)))
 
   (doc quasiquote "is a quotation that may have expressions inside it in the

--- a/docs/Dynamic_Types.md
+++ b/docs/Dynamic_Types.md
@@ -1,0 +1,39 @@
+# Dynamic Types
+
+While the primitive types that dynamic Carp has to offer—lists, arrays,
+numbers, symbols, and strings—are often enough for writing simple macros,
+sometimes more abstract types are needed.
+
+Maps in dynamic Carp are one such example, but you can define your own type
+just as easily. Let’s assume that you need a type `Pair` with a `fst` and
+`snd` property:
+
+```clojure
+; this will define the type `Pair`
+(deftype-dynamic Pair [fst snd])
+
+; we can now construct that type
+(defdynamic p (Pair.init 1 2)) ; => (Pair 1 2)
+
+; we can get and set properties
+(Pair.x p) ; => 1
+(Pair.set-x p 4) ; => (Pair 4 2)
+
+; we can check whether something is a `Pair`
+(Pair.Pair? p) ; => true
+(Pair.Pair? "not a pair") ; => false
+
+; we can stringify it, compare it, and check the type
+(str p) ; => "(Pair 1 2)"
+(= p (Pair.init 2 3)) ; => false
+(dynamic-type p) ; => Pair
+```
+
+As you might see from the example, many of the features of dynamic types
+emulate those of types in static Carp.
+
+Something to look out for is that while if you choose to overwrite the `str`
+function on your generated type this will work as expected, `=` does not work
+like this due to performance constraints (the cost of looking up the right
+function proved to be too slow for the time being). Patches for this are very
+welcome!

--- a/docs/Macros.md
+++ b/docs/Macros.md
@@ -1,5 +1,9 @@
 # Macros
 
+### Related pages
+
+* [Dynamic Types](Dynamic_Types.md) - A way to define your own types in dynamic Carp.
+
 Macros are among the most divisive features about any Lisp. There are many
 different design decisions to be made, and all of them have proponents and
 detractors.

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -639,6 +639,10 @@ commandMinus :: BinaryCommandCallback
 commandMinus = commandArith (-) "-"
 
 commandDiv :: BinaryCommandCallback
+commandDiv ctx _ x@(XObj (Num _ (Integral 0)) _ _) =
+  pure $ evalError ctx "Attempted to divide by zero." (xobjInfo x)
+commandDiv ctx _ x@(XObj (Num _ (Floating 0)) _ _) =
+  pure $ evalError ctx "Attempted to divide by zero." (xobjInfo x)
 commandDiv ctx p@(XObj (Num _ (Integral _)) _ _) q@(XObj (Num _ (Integral _)) _ _) = commandArith div "/" ctx p q
 commandDiv ctx p q = commandArith (/) "/" ctx p q
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -625,6 +625,8 @@ executeCommand ctx@(Context env _ _ _ _ _ _ _) xobj =
         executeCommand newCtx (withBuildAndRun (XObj (Lst []) (Just dummyInfo) Nothing))
       Left (HasStaticCall _ _) ->
         callFromRepl newCtx xobj
+      Right a@(XObj (Arr _) _ _) ->
+        executeCommand newCtx (XObj (Lst [XObj (Sym (SymPath [] "str") Symbol) (Just dummyInfo) Nothing, XObj (Lst [XObj (Sym (SymPath [] "quote") Symbol) (Just dummyInfo) Nothing, a]) (Just dummyInfo) Nothing]) (Just dummyInfo) Nothing)
       Right res -> pure (res, newCtx)
   where
     callFromRepl newCtx xobj' = do


### PR DESCRIPTION
This PR adds dynamic types to Carp. Yes, it’s a big feature.

The most important part here is `deftype-dynamic`, which takes a name and a list of slots, or members. Calling it will generate an `init` function, getters and setters, and `str`, similar to what would happen if it were a static type. It also generates a predicate to check whether a value is actually such a tagged type under `<type>.<type>?`.

Under the hood, we are using a tagged array, similar to approaches like [SRFI-9](https://srfi.schemers.org/srfi-9/srfi-9.html).

This PR also makes three other changes:
- it changes dynamic map to be a `deftype-dynamic`.
- it changes `str` to call `<Type>.str` if we’re handling a tagged type and `prim-str` (which is the compiler one) if we’re given anything else.
- it changes the top-level command evaluator to call `str` on any array that is being returned. This means that we get a nice string if we return a tagged type at the top-level REPL.

Code documentation is included, but I will add a section to the docs; I wanted to hold off on that until we’ve decided that this is a good idea.

Cheers