### PR TITLE
feat: Add support for emitting literal C

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -71,7 +71,8 @@ defaultProject =
       projectForceReload = False,
       projectPkgConfigFlags = [],
       projectCModules = [],
-      projectLoadStack = []
+      projectLoadStack = [],
+      projectPreproc = []
     }
 
 -- | Starting point of the application.

--- a/core/core.h
+++ b/core/core.h
@@ -15,6 +15,7 @@ typedef char *Pattern;
 typedef int64_t Long;
 typedef uint32_t Char;
 typedef char CChar;
+typedef void *c_code;
 
 #if defined NDEBUG
 #define CHK_INDEX(i, n)

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -172,6 +172,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             (Match _) -> dontVisit
             With -> dontVisit
             MetaStub -> dontVisit
+            C c -> pure c
     visitStr' indent str i shouldEscape =
       -- This will allocate a new string every time the code runs:
       -- do let var = freshVar i

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -3,6 +3,7 @@ module Emit
     envToC,
     globalsToC,
     projectIncludesToC,
+    projectPreprocToC,
     envToDeclarations,
     checkForUnresolvedSymbols,
     ToCMode (..),
@@ -946,6 +947,11 @@ projectIncludesToC proj = intercalate "\n" (map includerToC includes) ++ "\n\n"
     includerToC (SystemInclude file) = "#include <" ++ file ++ ">"
     includerToC (RelativeInclude file) = "#include \"" ++ file ++ "\""
     includes = projectIncludes proj
+
+projectPreprocToC :: Project -> String
+projectPreprocToC proj = intercalate "\n" preprocs ++ "\n\n"
+  where
+    preprocs = projectPreproc proj
 
 binderToC :: ToCMode -> Binder -> Either ToCError String
 binderToC toCMode binder =

--- a/src/InitialTypes.hs
+++ b/src/InitialTypes.hs
@@ -74,6 +74,7 @@ initialTypes typeEnv rootEnv root = evalState (visit rootEnv root) 0
     visit env xobj = case xobjObj xobj of
       (Num t _) -> pure (Right (xobj {xobjTy = Just t}))
       (Bol _) -> pure (Right (xobj {xobjTy = Just BoolTy}))
+      (C _) -> pure (Right xobj {xobjTy = Just CTy})
       (Str _) -> do
         lt <- genVarTy
         pure (Right (xobj {xobjTy = Just (RefTy StringTy lt)}))

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -170,6 +170,7 @@ data Obj
   | Ref
   | Deref
   | Interface Ty [SymPath]
+  | C String -- C literal
   deriving (Show, Eq, Generic)
 
 instance Hashable Obj
@@ -411,6 +412,7 @@ pretty = visit 0
     visit :: Int -> XObj -> String
     visit indent xobj =
       case xobjObj xobj of
+        C c -> show c
         Lst lst -> "(" ++ joinWithSpace (map (visit indent) lst) ++ ")"
         Arr arr -> "[" ++ joinWithSpace (map (visit indent) arr) ++ "]"
         StaticArr arr -> "$[" ++ joinWithSpace (map (visit indent) arr) ++ "]"
@@ -488,6 +490,7 @@ prettyUpTo lim xobj =
         Num DoubleTy _ -> ""
         Num _ _ -> error "Invalid number type."
         Str _ -> ""
+        C _ -> ""
         Pattern _ -> ""
         Chr _ -> ""
         Sym _ _ -> ""
@@ -778,6 +781,7 @@ incrementEnvNestLevel env =
 
 -- | Converts an S-expression to one of the Carp types.
 xobjToTy :: XObj -> Maybe Ty
+xobjToTy (XObj (Sym (SymPath _ "C") _) _ _) = Just CTy
 xobjToTy (XObj (Sym (SymPath _ "Unit") _) _ _) = Just UnitTy
 xobjToTy (XObj (Sym (SymPath _ "Int") _) _ _) = Just IntTy
 xobjToTy (XObj (Sym (SymPath _ "Float") _) _ _) = Just FloatTy

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -18,6 +18,7 @@ instance Show Target where
 data Project = Project
   { projectTitle :: String,
     projectIncludes :: [Includer],
+    projectPreproc  :: [String],
     projectCFlags :: [String],
     projectLibFlags :: [String],
     projectPkgConfigFlags :: [String],
@@ -59,6 +60,7 @@ instance Show Project where
         "Compiler: " ++ projectCompiler,
         "Target: " ++ show projectTarget,
         "Includes:\n    " ++ joinIndented (map show projectIncludes),
+        "Preprocessor directives:\n    " ++ joinIndented (map show projectPreproc),
         "Cflags:\n    " ++ joinIndented projectCFlags,
         "Library flags:\n    " ++ joinIndented projectLibFlags,
         "Flags for pkg-config:\n    " ++ joinIndented projectPkgConfigFlags,

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -365,6 +365,25 @@ dynamicStringModule =
       let f = addTernaryCommand . spath
        in [f "slice" commandSubstring "creates a substring from a beginning index to an end index." "(String.slice \"hello\" 1 3) ; => \"ell\""]
 
+unsafeModule :: Env
+unsafeModule =
+  Env {
+    envBindings = bindings,
+    envParent = Nothing,
+    envModuleName = Just "Unsafe",
+    envUseModules = Set.empty,
+    envMode = ExternalEnv,
+    envFunctionNestingLevel = 0
+  }
+  where
+    spath = SymPath ["Unsafe"]
+    bindings = Map.fromList unaries
+    unaries =
+      let f = addUnaryCommand . spath
+       in [ f "emit-c" commandEmitC "emits literal C inline" "(Unsafe.emit-c \"#if 0\")",
+            f "preproc" commandPreproc "adds preprocessing C code to emitted output" "(Unsafe.preproc (Unsafe.emit-c \"#define FOO 0\"))"
+          ]
+
 -- | A submodule of the Dynamic module. Contains functions for working with symbols in the repl or during compilation.
 dynamicSymModule :: Env
 dynamicSymModule =
@@ -457,6 +476,7 @@ startingGlobalEnv noArray =
           ++ [("Pointer", Binder emptyMeta (XObj (Mod pointerModule) Nothing Nothing))]
           ++ [("Dynamic", Binder emptyMeta (XObj (Mod dynamicModule) Nothing Nothing))]
           ++ [("Function", Binder emptyMeta (XObj (Mod functionModule) Nothing Nothing))]
+          ++ [("Unsafe", Binder emptyMeta (XObj (Mod unsafeModule) Nothing Nothing))]
 
 -- | The type environment (containing deftypes and interfaces) before any code is run.
 startingTypeEnv :: Env

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -65,6 +65,7 @@ data Ty
   | MacroTy
   | DynamicTy -- the type of dynamic functions (used in REPL and macros)
   | InterfaceTy
+  | CTy -- C literals
   | Universe -- the type of types of types (the type of TypeTy)
   deriving (Eq, Ord, Generic)
 
@@ -192,6 +193,7 @@ instance Show Ty where
   show MacroTy = "Macro"
   show DynamicTy = "Dynamic"
   show Universe = "Universe"
+  show CTy = "C"
 
 showMaybeTy :: Maybe Ty -> String
 showMaybeTy (Just t) = show t

--- a/src/TypesToC.hs
+++ b/src/TypesToC.hs
@@ -54,4 +54,5 @@ tyToCManglePtr _ ty = f ty
     f Universe = err "universe"
     f (PointerTy _) = err "pointers"
     f (RefTy _ _) = err "references"
+    f CTy = "c_code" -- Literal C; we shouldn't emit anything.
     err s = error ("Can't emit the type of " ++ s ++ ".")


### PR DESCRIPTION
This PR introduces two new features that allow users to add arbitrary C code to the compiler's output:

## `Unsafe.emit-c : (Fn [String] C)`

Emits literal C code inline. One can use this for certain interop scenarios in which some C code *must* take e.g. a string literal as an argument. For example, the c11 `static_assert` macro *only* accepts a C string literal in the second argument position. A call to `(static-assert 0 (Unsafe.emit-c "\"foo\""))` emits the proper code `static_assert(0, "foo")`.

### Why do we need it?
Two existing solutions, just using a Carp string literal and using a deftemplate (or `inline-c`, which uses deftemplate) don't work for different reasons:

1. Carp's strings are managed, so they tend to be assigned to a generated variable name, such as `_8` for this purpose. Unfortunately, that means calls to `(static-assert 0 "foo")` in Carp are emitted as `static_assert(0, _8)` which C treats as invalid since the macro only accepts a string literal according to the standard.
2. Deftemplates aren't flexible enough to emit a literal inline on demand. Furthermore, they always generate both a declaration and definition. They are also replaced with the symbols they are bound to. Thus `(deftemplate foo "" "\"foo\"")` and `(static-assert foo)` is emitted as `static_assert(0, foo)`; invalid for the same reason as 1.

## `Unsafe.preproc` : (Fn [C] Unit)

Adds some literal C code (a value of `C` type in Carp) to a set of "preprocessor" strings to be appended to the compiler's output after `include` directives but *before* any other emitted code. This function allows users to add arbitrary C code to the code emitted by the compiler and ensure whatever code they add is available before any Carp code is called. It's best illustrated with an example:

```clojure
(Unsafe.preproc (Unsafe.emit-c "#define FOO 0"))                                                                                                                                                                                                                                
(Unsafe.preproc (Unsafe.emit-c "void foo() { printf(\"%d\\n\", 1); }"))                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                
(register FOO Int)                                                                                                                                                                                                                                                              
(register foo (Fn [] ()))                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                
(defn main []                                                                                                                                                                                                                                                                   
  (do (foo)                                                                                                                                                                                                                                                                     
      (IO.println &(fmt "%d" FOO))))
```

When run, this code will first print `1` and then print `0`. The code that's emitted for this carp looks as follows:

```c
#include <assert.h>                                                                                                                                                                                                                                                             
#include <stddef.h>                                                                                                                                                                                                                                                             
#include <stdlib.h>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
// .. a bunch of other includes                                                                                                                                                                                                                              
#include <signal.h>                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                
#define FOO 0                                                                                                                                                                                                                                                                   
void foo() { printf("%d\n", 1); }                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                
//Types:                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
// Depth 3                                                                                                                                                                                                                                                                      
typedef struct {                                                                                                                                                                                                                                                                
    union {                                                                                                                                                                                                                                                                     
    struct {                                                                                                                                                                                                                                                                    
        Long member0;                                                                                                                                                                                                                                                           
    } Just;                                                                                                                                                                                                                                                                     
    // Nothing                                                                                                                                                                                                                                                                  
    char __dummy;                                                                                                                                                                                                                                                               
    } u;                                                                                                                                                                                                                                                                        
    char _tag;                                                                                                                                                                                                                                                                  
} Maybe__Long;                                                                                                                                                                                                                                                                  
#define Maybe__Long_Just_tag 0                                                                                                                                                                                                                                                  
#define Maybe__Long_Nothing_tag 1
```

### Why do we need it?

I was trying to find a nice way of adding compiler pragmas from Carp. Currently there's no great way to do this primarily because of the deftemplate limitations described above. If this PR is merged, this gives us a straightforward way to do this. It also would enable us to replace many h helper files with `preproc` calls. e.g. once could just call `(Unsafe.preproc (Unsafe.emit-c "typedef char *String"))` in `core.carp`.

Since preproc only accepts a `C` value as an argument, the only way to use it is in with combination with `Unsafe.emit-c` which should make it clear to users that it's a risk call and give one pause before using it too heavily.