### PR TITLE
fix: allow dynamic closures to mutate the global env

### DIFF
--- a/test/dynamic-closures.carp
+++ b/test/dynamic-closures.carp
@@ -2,6 +2,7 @@
 (use Test)
 
 (defdynamic x 400)
+(defdynamic z 0)
 
 ;; close over a global variable
 (defdynamic closure-one
@@ -23,6 +24,10 @@
 (defdynamic closure-five
   (fn [] (let [x 5] (fn [] x))))
 
+;; closures can update the global environment (issue #1181)
+(defdynamic closure-six
+  (fn [] (set! z (inc z))))
+
 (defdynamic y 500)
 
 (defmacro test-closure-one [] (closure-one))
@@ -30,6 +35,11 @@
 (defmacro test-closure-three [] (closure-three))
 (defmacro test-closure-four [] (closure-four))
 (defmacro test-closure-five [] ((closure-five)))
+(defmacro test-closure-six []
+  (do (closure-six)
+      (closure-six)
+      (closure-six)
+      z))
 
 ;; Change the global value of x (closed over in closure-one)
 (set! x 1000)
@@ -55,4 +65,8 @@
     5
     (test-closure-five)
     "nested closures prefer closed-over bindings")
+  (assert-equal test
+    3
+    (test-closure-six)
+    "closures can update the global environment")
 )


### PR DESCRIPTION
Previously, closures could not change the global environment. As such,
calls to commands like `set!` within a closure did not update global
variables as one might expect.

This commit fixes the issue by doing two things:

- Preserve any updates to the global environment that occur when
  evaluating a closure.
- Handle contexts correctly when evaluating commands.

The latter point requires a bit more explanation. At some point, we
stopped threading through the context produced after evaluating a
command's arguments, which had the unfortunate result that some commands
did not get access to the latest environment values.

Both of these fixes together fix issue 1181.

## Example 

```
(defdynamic foo 0)                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                
(def z 0)                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                
(defndynamic inc-counter [x]                                                                                                                                                                                                                                                    
  (do (set! foo (inc foo))                                                                                                                                                                                                                                                      
      (macro-log (str "x: " x " counter: " foo))))                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                
(defndynamic return-fn []                                                                                                                                                                                                                                                       
 (fn [x] (inc-counter x)))                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                
(defmacro my-macro []                                                                                                                                                                                                                                                           
  (do                                                                                                                                                                                                                                                                           
    (inc-counter 0)                                                                                                                                                                                                                                                             
    (map (return-fn) '(1 2 3))))                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
(my-macro)
```
**Old Behavior**
```
carp -b example.carp
=> x: 0 counter: 1
   x: 1 counter: 2
   x: 2 counter: 2
   x: 3 counter: 2
```

**New Behavior**

```
carp -b example.carp
=> x: 0 counter: 1
   x: 1 counter: 2
   x: 2 counter: 3
   x: 3 counter: 4
```

fixes #1181