### PR TITLE
feat: treat keywords as symbols

### DIFF
--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -199,6 +199,11 @@ isSym :: XObj -> Bool
 isSym (XObj (Sym (SymPath _ _) _) _ _) = True
 isSym _ = False
 
+isSpecialSym :: XObj -> Bool
+isSpecialSym (XObj (Sym (SymPath [] s) _) _ _) =
+  elem s ["defn", "def", "do", "while", "fn", "let", "break", "if", "match", "match-ref", "address", "set!", "the", "ref", "deref", "with"]
+isSpecialSym _ = False
+
 isArray :: XObj -> Bool
 isArray (XObj (Arr _) _ _) = True
 isArray _ = False

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -412,25 +412,8 @@ symbol = do
             Nothing
         )
     else pure $ case last segments of
-      "defn" -> XObj (Defn Nothing) i Nothing
-      "def" -> XObj Def i Nothing
-      -- TODO: What about the other def- forms?
-      "do" -> XObj Do i Nothing
-      "while" -> XObj While i Nothing
-      "fn" -> XObj (Fn Nothing Set.empty) i Nothing
-      "let" -> XObj Let i Nothing
-      "break" -> XObj Break i Nothing
-      "if" -> XObj If i Nothing
-      "match" -> XObj (Match MatchValue) i Nothing
-      "match-ref" -> XObj (Match MatchRef) i Nothing
       "true" -> XObj (Bol True) i Nothing
       "false" -> XObj (Bol False) i Nothing
-      "address" -> XObj Address i Nothing
-      "set!" -> XObj SetBang i Nothing
-      "the" -> XObj The i Nothing
-      "ref" -> XObj Ref i Nothing
-      "deref" -> XObj Deref i Nothing
-      "with" -> XObj With i Nothing
       name -> XObj (Sym (SymPath (init segments) name) Symbol) i Nothing
 
 atom :: Parsec.Parsec String ParseState XObj

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -5,6 +5,7 @@ import Commands
 import Eval
 import Info
 import qualified Map
+import qualified Meta
 import Obj
 import Primitives
 import qualified Set
@@ -367,14 +368,14 @@ dynamicStringModule =
 
 unsafeModule :: Env
 unsafeModule =
-  Env {
-    envBindings = bindings,
-    envParent = Nothing,
-    envModuleName = Just "Unsafe",
-    envUseModules = Set.empty,
-    envMode = ExternalEnv,
-    envFunctionNestingLevel = 0
-  }
+  Env
+    { envBindings = bindings,
+      envParent = Nothing,
+      envModuleName = Just "Unsafe",
+      envUseModules = Set.empty,
+      envMode = ExternalEnv,
+      envFunctionNestingLevel = 0
+    }
   where
     spath = SymPath ["Unsafe"]
     bindings = Map.fromList unaries
@@ -467,9 +468,31 @@ startingGlobalEnv noArray =
       envFunctionNestingLevel = 0
     }
   where
+    makeSymbol s doc example o =
+      (s, Binder (Meta.set "doc" (makeDoc doc example) emptyMeta) (XObj o Nothing Nothing))
+    makeDoc doc example =
+      (XObj (Str (doc ++ "\n\nExample:\n```\n" ++ example ++ "\n```")) Nothing Nothing)
     bindings =
+      -- NOTE: special symbols that should be treated like keywords also need to
+      -- be added to isSpecialSym in obj (to avoid emitting them as c etc.)
       Map.fromList $
-        [ register "NULL" (PointerTy (VarTy "a"))
+        [ register "NULL" (PointerTy (VarTy "a")),
+          makeSymbol "defn" "is used to define a function." "(defn name [arg] body)" (Defn Nothing),
+          makeSymbol "def" "is used to bind a variable." "(def variable \"value\")" Def,
+          makeSymbol "do" "is used to group statements." "(do (println* \"hi\") 1) ; => 1" Do,
+          makeSymbol "while" "is used for loops." "(while true\n  (loop-forever))" While,
+          makeSymbol "fn" "is used to define anonymous functions." "(fn [arg] body)" (Fn Nothing Set.empty),
+          makeSymbol "let" "" "" Let,
+          makeSymbol "break" "" "" Break,
+          makeSymbol "if" "" "" If,
+          makeSymbol "match" "" "" (Match MatchValue),
+          makeSymbol "match-ref" "" "" (Match MatchRef),
+          makeSymbol "address" "" "" Address,
+          makeSymbol "set!" "" "" SetBang,
+          makeSymbol "the" "" "" The,
+          makeSymbol "ref" "" "" Ref,
+          makeSymbol "deref" "" "" Deref,
+          makeSymbol "with" "" "" With
         ]
           ++ [("Array", Binder emptyMeta (XObj (Mod arrayModule) Nothing Nothing)) | not noArray]
           ++ [("StaticArray", Binder emptyMeta (XObj (Mod staticArrayModule) Nothing Nothing))]

--- a/test/output/test/test-for-errors/return_ref_in_do.carp.output.expected
+++ b/test/output/test/test-for-errors/return_ref_in_do.carp.output.expected
@@ -1,1 +1,1 @@
-return_ref_in_do.carp:3:1 The reference '(defn f [] (do () () () () (ref [1 2 3])))' isn't alive.
+return_ref_in_do.carp:3:2 The reference '(defn f [] (do () () () () (ref [1 2 3])))' isn't alive.

--- a/test/output/test/test-for-errors/return_ref_to_array_literal.carp.output.expected
+++ b/test/output/test/test-for-errors/return_ref_to_array_literal.carp.output.expected
@@ -1,1 +1,1 @@
-return_ref_to_array_literal.carp:3:1 The reference '(defn f [] (ref [1 2 3]))' isn't alive.
+return_ref_to_array_literal.carp:3:2 The reference '(defn f [] (ref [1 2 3]))' isn't alive.

--- a/test/output/test/test-for-errors/return_ref_to_function_result.carp.output.expected
+++ b/test/output/test/test-for-errors/return_ref_to_function_result.carp.output.expected
@@ -1,1 +1,1 @@
-return_ref_to_function_result.carp:6:1 The reference '(defn f [] (ref (make-data)))' isn't alive.
+return_ref_to_function_result.carp:6:2 The reference '(defn f [] (ref (make-data)))' isn't alive.

--- a/test/output/test/test-for-errors/wrong_sig_for_def.carp.output.expected
+++ b/test/output/test/test-for-errors/wrong_sig_for_def.carp.output.expected
@@ -1,2 +1,2 @@
  Inferred Macro, can't unify with Bool.
-wrong_sig_for_def.carp:4:1 Inferred Bool, can't unify with Int.
+wrong_sig_for_def.carp:4:2 Inferred Bool, can't unify with Int.

--- a/test/output/test/test-for-errors/wrong_sig_for_defn.carp.output.expected
+++ b/test/output/test/test-for-errors/wrong_sig_for_defn.carp.output.expected
@@ -1,2 +1,2 @@
  Inferred Macro, can't unify with (Fn [] Bool).
-wrong_sig_for_defn.carp:4:1 Inferred (Fn [] Bool), can't unify with (Fn [Int] Float).
+wrong_sig_for_defn.carp:4:2 Inferred (Fn [] Bool), can't unify with (Fn [Int] Float).


### PR DESCRIPTION
This PR fixes #1189 by adding symbols for all the keywords that resolve to their special AST types. This means that we can actually treat them as symbols in metaprogramming, and as an added bonus when you use `info` on them you get regular documentation.

It also means that we need to do a bit of a dance in `expand` and `commandBuild` to make sure we don’t emit them and always resolve them. This seems brittle, and if we could get the benefits mentioned above without those drawbacks, I’d be happier. Let me know if you have any ideas!

We also had to touch a bunch of different files, but not really much has changed in the grand scheme of things.

Cheers