### PR TITLE
feat: add setf

### DIFF
--- a/core/Core.carp
+++ b/core/Core.carp
@@ -59,6 +59,7 @@
 (load-once "Control.carp")
 (load-once "Opaque.carp")
 (load-once "Unit.carp")
+(load-once "Setf.carp")
 
 (posix-only
  (system-include "sys/wait.h")

--- a/core/Setf.carp
+++ b/core/Setf.carp
@@ -1,0 +1,68 @@
+(doc Setf "is a module that emulates a simple version of
+[`setf`](http://www.lispworks.com/documentation/HyperSpec/Body/m_setf_.htm#setf)
+that allows you to register your own places using
+[`register-place`](#register-place).")
+(defmodule Setf
+  (hidden places)
+  (defdynamic places {})
+
+  (doc register-place "registers a place of name `name` using the expression
+builder `builder`.
+
+Example:
+```
+(register-place 'nth (fn [args] `(Array.aset %@args)))
+```")
+  (defndynamic register-place [name builder]
+    (set! Setf.places (Map.put Setf.places name builder)))
+
+  (doc register-simple-place "registers a place of name `name` that uses the
+setter `setter`.
+
+Example:
+```
+(register-simple-place 'nth 'Array.aset)
+```")
+  (defndynamic register-simple-place [name setter]
+    (Setf.register-place name (fn [args] (cons setter args))))
+
+  (hidden get-place)
+  (defndynamic get-place [n]
+    (Map.get Setf.places n))
+
+  (doc setf "sets the value under the place `place` to the value `val`.
+
+Example:
+```
+(def x 1)
+(setf x 10)
+x ; => 10
+
+(def x [1 2 3]
+(setf (nth x 1) 10)
+x ; => [1 10 3]
+```")
+  (defmacro setf [place val]
+    (let [place (if (symbol? place) `(sym %place) place)
+          key (if (and (list? place) (not (empty? place)))
+                 (car place)
+                 'place-malformed)
+          setter? (Setf.get-place key)]
+      (cond
+        (= key 'place-malformed)
+          (macro-error (list "The `setf` place " place " is malformed. A list or symbol was expected"))
+        (= nil setter?)
+          (macro-error (list "I didn’t find a `setf` place for " key ". Is it defined?"))
+        (setter? (cons-last val (cdr place))))))
+)
+
+(use Setf)
+
+(register-simple-place 'sym 'set!)
+(register-simple-place 'nth 'Array.aset!)
+(register-simple-place 'char-at 'String.string-set!)
+; something is fishy with these
+;(register-place 'car
+;  (fn [args] `(set! %(car args) (cons %(cadr args) (cdr %(car args))))))
+;(register-place 'cdr
+;  (fn [args] `(set! %(car args) (cons (car %(car args)) %(cadr args)))))

--- a/core/Setf.carp
+++ b/core/Setf.carp
@@ -38,8 +38,8 @@ Example:
 (setf x 10)
 x ; => 10
 
-(def x [1 2 3]
-(setf (nth x 1) 10)
+(def x [1 2 3])
+(setf (nth &x 1) 10)
 x ; => [1 10 3]
 ```")
   (defmacro setf [place val]

--- a/core/Setf.carp
+++ b/core/Setf.carp
@@ -26,6 +26,17 @@ Example:
   (defndynamic register-simple-place [name setter]
     (Setf.register-place name (fn [args] (cons setter args))))
 
+  (doc register-struct-places "registers all members of a struct-like type as
+places.
+
+Example:
+```
+(register-struct-places 'Vector2)
+
+(let-do [x (Vector2.init 1 2)]
+  (setf (Vector2.x &x) 10)
+  x) ; => (Vector2 10  2)
+```")
   (defndynamic register-struct-places [t]
     (map
       (fn [member]

--- a/core/Setf.carp
+++ b/core/Setf.carp
@@ -26,6 +26,15 @@ Example:
   (defndynamic register-simple-place [name setter]
     (Setf.register-place name (fn [args] (cons setter args))))
 
+  (defndynamic register-struct-places [t]
+    (map
+      (fn [member]
+        (let [name (car member)
+              getter (Symbol.prefix t name)
+              setter (Symbol.prefix t (Symbol.concat ['set- name '!]))]
+          (Setf.register-simple-place getter setter)))
+      (eval `(members %t))))
+
   (hidden get-place)
   (defndynamic get-place [n]
     (Map.get Setf.places n))

--- a/docs/core/generate_core_docs.carp
+++ b/docs/core/generate_core_docs.carp
@@ -26,6 +26,7 @@
            Function
            Geometry
            Quasiquote
+           Setf
            Int
            Introspect
            Unit

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -598,8 +598,8 @@ commandSymConcat ctx a =
     _ -> evalError ctx ("Can't call concat with " ++ pretty a) (xobjInfo a)
 
 commandSymPrefix :: BinaryCommandCallback
-commandSymPrefix ctx (XObj (Sym (SymPath [] prefix) _) _ _) (XObj (Sym (SymPath [] suffix) _) i t) =
-  pure (ctx, Right (XObj (Sym (SymPath [prefix] suffix) (LookupGlobal CarpLand AVariable)) i t))
+commandSymPrefix ctx (XObj (Sym (SymPath [] prefix) _) _ _) (XObj (Sym (SymPath [] suffix) st) i t) =
+  pure (ctx, Right (XObj (Sym (SymPath [prefix] suffix) st) i t))
 commandSymPrefix ctx x (XObj (Sym (SymPath [] _) _) _ _) =
   pure $ evalError ctx ("Can’t call `prefix` with " ++ pretty x) (xobjInfo x)
 commandSymPrefix ctx _ x =

--- a/test/setf.carp
+++ b/test/setf.carp
@@ -1,0 +1,54 @@
+(deftype T [x Int y Int z Int])
+(derive T =)
+(derive T str)
+
+(register-simple-place 'T.x 'T.set-x!)
+
+(load "Test.carp")
+(use Test)
+
+(deftest test
+  ; as of yet unimplemented
+  ;(assert-dynamic-equal test
+  ;                      '(1 2 3)
+  ;                      (let-do [x '(2 2 3)]
+  ;                        (setf (car x) 1)
+  ;                        x)
+  ;                      "setf works for car"
+  ;)
+  ;(assert-dynamic-equal test
+  ;                      '(1 2)
+  ;                      (let-do [x '(1 2 3)]
+  ;                        (setf (cdr x) '(2))
+  ;                        x)
+  ;                      "setf works for cdr"
+  ;)
+  (assert-equal test
+                &[1 2 3]
+                &(let-do [x [1 3 3]]
+                  (setf (nth &x 1) 2)
+                  x)
+                "setf works for nth"
+  )
+  (assert-equal test
+                "hey"
+                &(let-do [x @"hoy"]
+                  (setf (char-at &x 1) \e)
+                  x)
+                "setf works for char-at"
+  )
+  (assert-equal test
+                10
+                (let-do [x 1]
+                  (setf x 10)
+                  x)
+                "setf works on symbols"
+  )
+  (assert-equal test
+                &(T.init 1 1 1)
+                &(let-do [x (T.init 0 1 1)]
+                  (setf (T.x &x) 1)
+                  x)
+                "setf works on custom types"
+  )
+)


### PR DESCRIPTION
This PR adds `setf`, or generalized variable setting. It allows for things such as:

```clojure
(def x 1)
(setf x 10)
x ; => 10

(def x [1 2 3])
(setf (nth &x 1) 10)
x ; => [1 10 3]
```

and is extensible using `register-simple-place`, which registers a “place”, i.e. something that can be set. For example:

```clojure
(deftype T [x Int y Int z Int])

(register-simple-place 'T.x 'T.set-x!)

(let-do [x (T.init 0 1 1)]
  (setf (T.x &x) 1)
  x) ; => (T 1 1 1)
```

More complicated setters that emit arbitrary expressions can be registered using `register-place`.

If this PR looks like something we’d like, I’ll write some docs for it.

Cheers