### PR TITLE
feat: use ascii type variables in prettify

### DIFF
--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -495,10 +495,11 @@ beautifyTy mappings = f
     bmappings = beautification mappings
     beautification :: TypeMappings -> Map.Map String String
     beautification m =
-      Map.fromList $ zip (map (\(VarTy name) -> name) tys) ((: []) <$> ['a' ..])
+      Map.fromList $ zip (map (\(VarTy name) -> name) tys) beautList
       where
         tys = nub $ concat $ typeVariablesInOrderOfAppearance <$> tys'
         tys' = snd <$> Map.assocs m
+    beautList = [c : s | s <- "" : beautList, c <- ['a' .. 'z']]
 
 typeVariablesInOrderOfAppearance :: Ty -> [Ty]
 typeVariablesInOrderOfAppearance (FuncTy argTys retTy ltTy) =


### PR DESCRIPTION
This PR changes this:

```
I can’t match the types `(Prism ¤ ¥)` and `(Lens r254 —­)`. within `(Lens.get (ref  ... ata))`
```

to this:

```
I can’t match the types `(Prism pb qb)` and `(Lens r256 yb)`. within `(Lens.get (ref  ... ata))`
```

While I think using single letter Unicode is cute and all, the character set contains all sort of unprintable and hard-to-read nastiness, and a list that chooses from ASCII strings of increasing length might be more useful.

Of course, it would be  even better if we didn’t use so many type variables. In the lens code I’m working with at the moment, though, type variables are pretty prevalent, and the context of the type error contains no fewer than 272 of them. I have not found a good way to prune the list of variables to only the ones we need to display the error, which would be a good next step.

Cheers