### PR TITLE
Added a dockerfile to build and run carp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:buster-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV CARP_DIR=/Carp
+ENV CARP_GIT=https://github.com/dleslie/Carp
+ENV PATH=$PATH:/root/.local/bin
+
+RUN apt update && \
+    apt install -y git build-essential curl wget \
+    haskell-stack libncurses-dev
+
+RUN stack upgrade --binary-only
+RUN git clone $CARP_GIT $CARP_DIR
+
+WORKDIR $CARP_DIR
+RUN stack build
+RUN stack install
+
+RUN mkdir -p /work
+WORKDIR /work
+
+CMD carp

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV CARP_DIR=/Carp
-ENV CARP_GIT=https://github.com/dleslie/Carp
+ENV CARP_GIT=https://github.com/carp-lang/Carp
 ENV PATH=$PATH:/root/.local/bin
 
 RUN apt update && \


### PR DESCRIPTION
This is a small change that provides a Dockerfile for Carp.

A workdir has been created at `/work`.