### PR TITLE
fix: use correct symbol type in Symbol.prefix

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -598,8 +598,8 @@ commandSymConcat ctx a =
     _ -> evalError ctx ("Can't call concat with " ++ pretty a) (xobjInfo a)
 
 commandSymPrefix :: BinaryCommandCallback
-commandSymPrefix ctx (XObj (Sym (SymPath [] prefix) _) _ _) (XObj (Sym (SymPath [] suffix) _) i t) =
-  pure (ctx, Right (XObj (Sym (SymPath [prefix] suffix) (LookupGlobal CarpLand AVariable)) i t))
+commandSymPrefix ctx (XObj (Sym (SymPath [] prefix) _) _ _) (XObj (Sym (SymPath [] suffix) st) i t) =
+  pure (ctx, Right (XObj (Sym (SymPath [prefix] suffix) st) i t))
 commandSymPrefix ctx x (XObj (Sym (SymPath [] _) _) _ _) =
   pure $ evalError ctx ("Can’t call `prefix` with " ++ pretty x) (xobjInfo x)
 commandSymPrefix ctx _ x =


### PR DESCRIPTION
This PR backports a fix from #1192 for `Symbol.prefix` to use the symbol type from the prefixed symbol instead of resetting it.

Cheers