### PR TITLE
docs: fix order of args in map-reduce docs

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -422,8 +422,8 @@ element, while keeping an accumulator and a list.
 Returns a `Pair` where the first element is the mapped array and the second one
 is the final accumulator.
 
-The function `f` receives two arguments: the first one is the element, and the
-second one is the accumulator. `f` must return `(Pair result accumulator)`.
+The function `f` receives two arguments: the first one is the accumulator, and
+the second one is the element. `f` must return `(Pair accumulator result)`.
 
 Example:
 ```


### PR DESCRIPTION
I made a mistake in the docs in #1201. Whoops.

Cheers