### PR TITLE
fix: fix String.words for multiple word spearators in a row

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -144,7 +144,7 @@ list of those characters.")
 
   (doc words "splits a string into words.")
   (defn words [s]
-    (split-by s &[\tab \space \newline]))
+    (Array.endo-filter &(fn [s] (not (empty? s))) (split-by s &[\tab \space \newline])))
 
   (doc lines "splits a string into lines.")
   (defn lines [s]

--- a/test/string.carp
+++ b/test/string.carp
@@ -184,7 +184,11 @@
   (assert-equal test
                 &[@"erik" @"sved" @"hej" @"foo"]
                 &(words "erik sved\nhej\tfoo")
-                "words works correctly")
+                "words works correctly I")
+  (assert-equal test
+                &[@"erik" @"sved" @"hej" @"foo"]
+                &(words "erik sved\n\nhej\tfoo")
+                "words works correctly II")
   (assert-equal test
                 &[@"erik" @"sved" @"hej" @"foo"]
                 &(lines "erik\nsved\nhej\nfoo")


### PR DESCRIPTION
This PR fixes `String.words` by  ignoring empty words, i.e. multiple spaces in a row. `String-lines` remains untouched, since empty lines might be meaningful.

A test case for this behavior was included.

Cheers