### PR TITLE
fix: don't type check untyped forms in set!

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -1048,8 +1048,12 @@ specialCommandSet ctx [orig@(XObj (Sym path@(SymPath _ _) _) _ _), val] =
     evalAndSet :: Binder -> (Context -> Env -> Either EvalError XObj -> Binder -> IO (Context, Either EvalError XObj)) -> Env -> IO (Context, Either EvalError XObj)
     evalAndSet binder setter env =
       case xobjTy (binderXObj binder) of
-        -- don't type check dynamic bindings
+        -- don't type check dynamic or untyped bindings
+        -- TODO: Figure out why untyped cases are sometimes coming into set!
         Just DynamicTy ->
+          evalDynamic ResolveLocal ctx val
+            >>= \(newCtx, result) -> setter newCtx env result binder
+        Nothing ->
           evalDynamic ResolveLocal ctx val
             >>= \(newCtx, result) -> setter newCtx env result binder
         _ ->

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -1050,18 +1050,17 @@ specialCommandSet ctx [orig@(XObj (Sym path@(SymPath _ _) _) _ _), val] =
       case xobjTy (binderXObj binder) of
         -- don't type check dynamic or untyped bindings
         -- TODO: Figure out why untyped cases are sometimes coming into set!
-        Just DynamicTy ->
-          evalDynamic ResolveLocal ctx val
-            >>= \(newCtx, result) -> setter newCtx env result binder
-        Nothing ->
-          evalDynamic ResolveLocal ctx val
-            >>= \(newCtx, result) -> setter newCtx env result binder
+        Just DynamicTy -> handleUnTyped
+        Nothing -> handleUnTyped
         _ ->
           evalDynamic ResolveLocal ctx val
             >>= \(newCtx, result) ->
               case result of
                 Right evald -> typeCheckValueAgainstBinder newCtx evald binder >>= \(nctx, typedVal) -> setter nctx env typedVal binder
                 left -> pure (newCtx, left)
+      where handleUnTyped :: IO (Context, Either EvalError XObj)
+            handleUnTyped = evalDynamic ResolveLocal ctx val
+                              >>= \(newCtx, result) -> setter newCtx env result binder
     setGlobal :: Context -> Env -> Either EvalError XObj -> Binder -> IO (Context, Either EvalError XObj)
     setGlobal ctx' env value binder =
       pure $ either (failure ctx' orig) (success ctx') value


### PR DESCRIPTION
This is a kludgey temporary fix for #1179. The problem is that set!
occasionally receives untyped forms. In particular, this seems to happen
when the value of the form is determined by a command such as `length`.
This caused hangs when evaluating `Dynamic.mod` in particular.

For now, we just treat these like dynamic values and don't worry about
typechecking them, which seems to do the trick.