### PR TITLE
fix: concretize def forms

### DIFF
--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -400,6 +400,8 @@ setPath (XObj (Lst (defn@(XObj (Defn _) _ _) : XObj (Sym _ _) si st : rest)) i t
   XObj (Lst (defn : XObj (Sym newPath Symbol) si st : rest)) i t
 setPath (XObj (Lst [extr@(XObj (External _) _ _), XObj (Sym _ _) si st, ty]) i t) newPath =
   XObj (Lst [extr, XObj (Sym newPath Symbol) si st, ty]) i t
+setPath (XObj (Lst (def@(XObj Def _ _) : XObj (Sym _ _) si st : rest)) i t) newPath =
+  XObj (Lst (def : XObj (Sym newPath Symbol) si st : rest)) i t
 setPath x _ =
   error ("Can't set path on " ++ show x)
 


### PR DESCRIPTION
Most def forms bind values, so their types are wholly determined at
initial assignment time. However, defs that bind to lambdas may have
polymorphic types by virtue of their use of interfaces:

```
(defn duplicate-arg [f]
  (fn [x] (f x x)))

(def double (duplicate-arg +))

(defn main []
  (println* (double 3)))
```

Previously, the above program would yield a concretization error. This
commit adds concretization handling for def forms, and makes it possible
to call lambdas bound to defs as is done in the program above.

Fixes #364