### PR TITLE
fix: fix repl autocomplete

### DIFF
--- a/src/Env.hs
+++ b/src/Env.hs
@@ -643,7 +643,7 @@ envPublicBindingNames e = concatMap select (Map.toList (binders e))
           if metaIsTrue (binderMeta binder) "private" || metaIsTrue (binderMeta binder) "hidden"
             then []
             else [name]
-        Right e' -> envPublicBindingNames e'
+        Right e' -> map (\n -> name ++ "." ++ n) (envPublicBindingNames e')
 
 -- | Recursively look through all environments for (def ...) forms.
 --


### PR DESCRIPTION
The recent Env refactor commits unwittingly broke the REPL's
autocompletion. This change restores the previous behavior.

Fixes #1224 