### PR TITLE
fix: render submodules in html docs

### DIFF
--- a/core/Statistics.carp
+++ b/core/Statistics.carp
@@ -17,6 +17,7 @@
     quartiles (Array Double),
     iqr Double
   ])
+  (hidden Summary)
 
   (doc mean "Compute the mean of the samples data.")
   (defn mean [data]

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -2,6 +2,7 @@
 
 (defmodule Test
   (deftype State [passed Int, failed Int])
+  (hidden State)
   (use Color.Id)
   (hidden handler)
   (defn handler [state expected actual descr what op]

--- a/docs/core/carp_style.css
+++ b/docs/core/carp_style.css
@@ -18,15 +18,23 @@ a:hover {
 }
 
 .logo {
-    text-align: right;
     float: right;
-    width: 150px;
     font-family: "Hasklig", "Lucida Console", monospace;
+    width: 20%;
+    margin-right: 10%;
 }
 
 .logo img {
     width: 150px;
     margin-bottom: 1em;
+}
+
+details summary {
+  cursor: pointer;
+}
+
+details summary > * {
+  display: inline;
 }
 
 .index {
@@ -46,6 +54,7 @@ ul {
     list-style-type: none;
     font-family: "Hasklig", "Lucida Console", monospace;
     line-height: 1.4em;
+    padding-left: 1em;
 }
 
 .title {
@@ -53,9 +62,13 @@ ul {
 }
 
 .content {
-    margin: 3em auto auto auto;
-    width: 80%;
+    width: 100%;
+}
+
+.module {
     max-width: 800px;
+    margin: auto;
+    margin-top: 5em;
 }
 
 h1 {
@@ -77,20 +90,6 @@ h3 {
 
 .binder {
     margin: 3.5em 0em 0em 0em;
-}
-
-.deprecation-notice {
-  background-color: #f99;
-  text-transform: uppercase;
-  float: right;
-  padding: 5px;
-  margin: -5px;
-}
-
-.deprecation-text {
-  background-color: #f99;
-  padding-left: 5px;
-  padding-right: 5px;
 }
 
 .sig {

--- a/docs/core/carp_style.css
+++ b/docs/core/carp_style.css
@@ -29,6 +29,10 @@ a:hover {
     margin-bottom: 1em;
 }
 
+.index {
+  text-align: left;
+}
+
 .args {
   background-color: #eee;
   padding: 3px;

--- a/docs/sdl/carp_style.css
+++ b/docs/sdl/carp_style.css
@@ -18,15 +18,23 @@ a:hover {
 }
 
 .logo {
-    text-align: right;
     float: right;
-    width: 150px;
     font-family: "Hasklig", "Lucida Console", monospace;
+    width: 20%;
+    margin-right: 10%;
 }
 
 .logo img {
     width: 150px;
     margin-bottom: 1em;
+}
+
+details summary {
+  cursor: pointer;
+}
+
+details summary > * {
+  display: inline;
 }
 
 .index {
@@ -46,6 +54,7 @@ ul {
     list-style-type: none;
     font-family: "Hasklig", "Lucida Console", monospace;
     line-height: 1.4em;
+    padding-left: 1em;
 }
 
 .title {
@@ -53,9 +62,13 @@ ul {
 }
 
 .content {
-    margin: 3em auto auto auto;
-    width: 80%;
+    width: 100%;
+}
+
+.module {
     max-width: 800px;
+    margin: auto;
+    margin-top: 5em;
 }
 
 h1 {

--- a/docs/sdl/carp_style.css
+++ b/docs/sdl/carp_style.css
@@ -29,6 +29,10 @@ a:hover {
     margin-bottom: 1em;
 }
 
+.index {
+  text-align: left;
+}
+
 .args {
   background-color: #eee;
   padding: 3px;

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Obj where
 
@@ -227,6 +227,10 @@ isTypeDef (XObj (Lst (XObj (Defalias _) _ _ : _)) _ _) = True
 isTypeDef (XObj (Lst (XObj (Deftype _) _ _ : _)) _ _) = True
 isTypeDef (XObj (Lst (XObj (DefSumtype _) _ _ : _)) _ _) = True
 isTypeDef _ = False
+
+isMod :: XObj -> Bool
+isMod (XObj (Mod _ _) _ _) = True
+isMod _ = False
 
 -- | This instance is needed for the dynamic Dictionary
 instance Ord Obj where

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -52,15 +52,18 @@ saveDocsForEnvs ctx pathsAndEnvBinders =
   where
     getDependenciesForEnvs = Prelude.concat . Prelude.map getEnvDependencies
     getEnvDependencies (SymPath ps p, e) =
-      Prelude.map
-        (\(n, b) -> (SymPath (ps ++ [p]) n, b))
-        ( Prelude.filter
-            (\(_, Binder _ x) -> isMod x)
-            ( Prelude.filter
-                shouldEmitDocsForBinder
-                (Map.toList (envBindings e))
-            )
-        )
+      let envs =
+            Prelude.map
+              (\(n, b) -> (SymPath (ps ++ [p]) n, b))
+              ( Prelude.filter
+                  (\(_, Binder _ x) -> isMod x)
+                  ( Prelude.filter
+                      shouldEmitDocsForBinder
+                      (Map.toList (envBindings e))
+                  )
+              )
+       in envs
+            ++ getDependenciesForEnvs (Prelude.map (\(n, Binder _ (XObj (Mod env _) _ _)) -> (n, env)) envs)
 
 -- | This function expects a binder that contains an environment, anything else is a runtime error.
 getEnvAndMetaFromBinder :: Binder -> (Env, MetaData)

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -159,7 +159,7 @@ moduleIndex moduleNames =
     gen (m, subs) =
       H.li $
         do
-          moduleLink (show m)
+          moduleLink m
           grouped subs
     order [] = []
     order (m : mods) =
@@ -168,9 +168,9 @@ moduleIndex moduleNames =
     symBelongsToMod (SymPath xs x) (SymPath ys y) =
       List.isPrefixOf (xs ++ [x]) (ys ++ [y])
 
-moduleLink :: String -> H.Html
-moduleLink name =
-  H.a ! A.href (H.stringValue (name ++ ".html")) $ H.toHtml name
+moduleLink :: SymPath -> H.Html
+moduleLink p@(SymPath _ name) =
+  H.a ! A.href (H.stringValue (show p ++ ".html")) $ H.toHtml name
 
 binderToHtml :: String -> Binder -> H.Html
 binderToHtml moduleName (Binder meta xobj) =

--- a/src/RenderDocs.hs
+++ b/src/RenderDocs.hs
@@ -143,9 +143,11 @@ envBinderToHtml envBinder ctx moduleName moduleNames =
                     --span_ "CARP DOCS FOR"
                     H.div ! A.class_ "title" $ H.toHtml title
                     moduleIndex moduleNames
-                H.h1 (H.toHtml moduleName)
-                H.div ! A.class_ "module-description" $ H.preEscapedToHtml moduleDescriptionHtml
-                mapM_ (binderToHtml moduleName . snd) (Prelude.filter shouldEmitDocsForBinder (Map.toList (envBindings env)))
+                H.div ! A.class_ "module" $
+                  do
+                    H.h1 (H.toHtml moduleName)
+                    H.div ! A.class_ "module-description" $ H.preEscapedToHtml moduleDescriptionHtml
+                    mapM_ (binderToHtml moduleName . snd) (Prelude.filter shouldEmitDocsForBinder (Map.toList (envBindings env)))
 
 shouldEmitDocsForBinder :: (String, Binder) -> Bool
 shouldEmitDocsForBinder (_, Binder meta _) =
@@ -158,9 +160,12 @@ moduleIndex moduleNames =
     grouped names = H.ul $ mapM_ gen (order names)
     gen (m, subs) =
       H.li $
-        do
-          moduleLink m
-          grouped subs
+        if Prelude.null subs
+          then moduleLink m
+          else H.details $
+            do
+              H.summary (moduleLink m)
+              grouped subs
     order [] = []
     order (m : mods) =
       let (isIn, isNotIn) = List.partition (symBelongsToMod m) mods

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -125,7 +125,8 @@ functionModule =
   where
     bindEnv env =
       let Just name = envModuleName env
-       in (name, Binder emptyMeta (XObj (Mod env E.empty) Nothing Nothing))
+          meta = Meta.set "hidden" trueXObj emptyMeta
+       in (name, Binder meta (XObj (Mod env E.empty) Nothing Nothing))
     bindings = Map.fromList (map (bindEnv . generateInnerFunctionModule) [0 .. maxArity])
 
 -- | Each arity of functions need their own module to enable copying and string representation


### PR DESCRIPTION
This PR fixes #1235 by adding submodules to the rendered docs. It achieves this by looking at "dependencies" (i.e. inner modules) and rendering them in the HTML in two places: inside the module as a link, and in the sidebar as a submenu.

Cheers