### PR TITLE
fix: check for generic main at build time

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -342,7 +342,11 @@ commandBuild ctx [XObj (Bol shutUp) _ _] = do
         if generateOnly
           then pure (ctx, dynamicNil)
           else case Map.lookup "main" (envBindings env) of
-            Just _ -> compile True
+            Just (Binder _ (XObj _ _ (Just (FuncTy _ IntTy _)))) -> compile True
+            Just (Binder _ (XObj _ _ (Just (FuncTy _ UnitTy _)))) -> compile True
+            Just (Binder _ (XObj _ _ (Just (FuncTy _ _ _)))) -> pure (evalError ctx "`main` was generic at build time, it must return either `Int` or `()`." Nothing)
+            Just (Binder _ (XObj _ _ (Just t))) -> pure (evalError ctx ("`main` is expected to be a function, but was `" ++ show t ++ "`.") Nothing)
+            Just (Binder _ (XObj _ _ Nothing)) -> pure (evalError ctx ("The type of `main` is not set at build time. This should not happen, consider raising an issue with the code that caused it.") Nothing)
             Nothing -> compile False
   where
     removeSpecials env =

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -344,6 +344,7 @@ commandBuild ctx [XObj (Bol shutUp) _ _] = do
           else case Map.lookup "main" (envBindings env) of
             Just (Binder _ (XObj _ _ (Just (FuncTy _ IntTy _)))) -> compile True
             Just (Binder _ (XObj _ _ (Just (FuncTy _ UnitTy _)))) -> compile True
+            -- we do not check for non-generic versions of main, these are already caught during concretization
             Just (Binder _ (XObj _ _ (Just (FuncTy _ _ _)))) -> pure (evalError ctx "`main` was generic at build time, it must return either `Int` or `()`." Nothing)
             Just (Binder _ (XObj _ _ (Just t))) -> pure (evalError ctx ("`main` is expected to be a function, but was `" ++ show t ++ "`.") Nothing)
             Just (Binder _ (XObj _ _ Nothing)) -> pure (evalError ctx ("The type of `main` is not set at build time. This should not happen, consider raising an issue with the code that caused it.") Nothing)


### PR DESCRIPTION
This PR fixes #1246 by inserting a few checks in `commandBuild`.

```
> (defn main [] +)
> :b
`main` was generic at build time, it must return either `Int` or `()`.

Traceback:
  (build) at REPL:1:1.

> (def main 1)
[WARNING] Definition at line 1, column 2 in 'REPL' changed type of 'main' from (Fn [] (Fn [a, a] a)) to Int
> :b
`main` is expected to be a function, but was `Int`.

Traceback:
  (build) at REPL:1:1.
```

Cheers