### PR TITLE
(and) and (or) now handle any number of parameters

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -1,11 +1,5 @@
 ;; Defining the meta data macros early so that they can be used by all the other code.
 
-(defmacro and [x y]
-  (list 'if x y false))
-
-(defmacro or [x y]
-  (list 'if x true y))
-
 ;; Defined early so that `doc` can accept a rest arg
 (defndynamic map-internal [f xs acc]
     (if (= 0 (length xs))
@@ -108,6 +102,24 @@
 (doc private "Mark a binding as private, this will make it inaccessible from other modules.")
 (defmacro private [name]
   (eval (list 'meta-set! name "private" true)))
+
+(hidden      and-)
+(defndynamic and- [xs]
+  (if (= 0 (length xs))
+    true
+    (list 'if (car xs) (and- (cdr xs)) false) ))
+(defmacro and [:rest xs] 
+  (and- xs))
+
+(hidden      or-)
+(defndynamic or- [xs]
+  (if (= 0 (length xs))
+    false
+    (list 'if (car xs) true (or- (cdr xs))) ))
+(defmacro or [:rest xs] 
+  (or- xs))
+
+
 
 (doc todo "sets the todo property for a binding.")
 (defmacro todo [name value]

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -104,17 +104,28 @@
 
 (hidden      and-)
 (defndynamic and- [xs]
+; (defndynamic and- [xs]   ; shorter but currently not entirely stable
+;   (if (= 0 (length xs))
+;      true
+;      (list 'if (car xs) (and- (cdr xs)) false) ))
   (if (= 0 (length xs))
     true
-    (list 'if (car xs) (and- (cdr xs)) false) ))
+    (if (= 1 (length xs))
+      (car xs)
+      (list 'if (car xs) (and- (cdr xs)) false) )))
 (defmacro and [:rest xs] 
   (and- xs))
 
 (hidden      or-)
 (defndynamic or- [xs]
+;    (if (= 0 (length xs))  ; shorter but currently not entirely stable
+;      false
+;      (list 'if (car xs) true (or- (cdr xs))) ))
   (if (= 0 (length xs))
     false
-    (list 'if (car xs) true (or- (cdr xs))) ))
+    (if (= 1 (length xs))
+      (car xs)
+      (list 'if (car xs) true (or- (cdr xs))) )))
 (defmacro or [:rest xs] 
   (or- xs))
 

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -1,5 +1,4 @@
 ;; Defining the meta data macros early so that they can be used by all the other code.
-
 ;; Defined early so that `doc` can accept a rest arg
 (defndynamic map-internal [f xs acc]
     (if (= 0 (length xs))
@@ -120,7 +119,6 @@
   (or- xs))
 
 
-
 (doc todo "sets the todo property for a binding.")
 (defmacro todo [name value]
   (eval (list 'meta-set! name "todo" value)))
@@ -221,12 +219,6 @@
     (if (= (length forms) 1)
       (car forms)
       (list func (car forms) (build-vararg func (cdr forms))))))
-
-(defmacro and* [:rest forms]
-  (build-vararg 'and forms))
-
-(defmacro or* [:rest forms]
-  (build-vararg 'or forms))
 
 (defmacro ignore [form]
   (list 'let (array '_ form) (list)))

--- a/core/Quasiquote.carp
+++ b/core/Quasiquote.carp
@@ -46,7 +46,7 @@ Example:
          (macro-error "unquote-splicing takes exactly one argument.")
        (reduce
          (fn [acc elem]
-           (if (and* (list? elem)
+           (if (and  (list? elem)
                      (= (length elem) 2)
                      (= (car elem) 'unquote-splicing))
              (list 'append acc (cadr elem))

--- a/examples/langtons_ant.carp
+++ b/examples/langtons_ant.carp
@@ -78,7 +78,7 @@
                 1 (inc y)
                 3 (dec y)
                 y)]
-    (if (or* (< new-x 0)
+    (if (or (< new-x 0)
              (< new-y 0)
              (>= new-x @(State.width &state))
              (>= new-y @(State.height &state)))

--- a/test/array.carp
+++ b/test/array.carp
@@ -237,7 +237,7 @@
            five (Array.pop-back! &arr)
            four (Array.pop-back! &arr)]
     (assert-true test
-                 (and* (= &exp &arr)
+                 (and  (= &exp &arr)
                        (= six  6)
                        (= five 5)
                        (= four 4))

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -217,18 +217,18 @@
   (assert-false test
                 (test-= veit "veit")
                 "= macro works as expected across types")
-  (assert-false test      ; debug-1: this compiles but takes >400MBytes extra Memory?!
+  (assert-false test 
                 (and true true false)
                 "vararg-and macro works as expected I")
-  ;~ (assert-true test       ; debug-2: like debug-1, but when both are active, then >4GB memory are used and compilation fails 
-               ;~ (and true true true)
-               ;~ "vararg-and macro works as expected II")
-  ;~ (assert-false test   ; TODO: activate after debugging
-                ;~ (or false false false)
-                ;~ "vararg-or macro works as expected I")
-  ;~ (assert-true test    ; TODO: activate after debugging
-               ;~ (or true false true)
-               ;~ "vararg-or macro works as expected II")
+  (assert-true test 
+               (and true true true)
+               "vararg-and macro works as expected II")
+  (assert-false test 
+                (or false false false)
+                "vararg-or macro works as expected I")
+  (assert-true test 
+               (or true false true)
+               "vararg-or macro works as expected II")
   (assert-equal test
                 "1 thing 2 things"
                 &(str* 1 " thing " 2 " things")

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -52,13 +52,13 @@
 
 (defmacro test-map []
   (let [mapped (Dynamic.map length '((a) (b c) (d e f)))]
-    (and* (= 1 (Dynamic.car mapped)) (= 2 (Dynamic.cadr mapped))
+    (and  (= 1 (Dynamic.car mapped)) (= 2 (Dynamic.cadr mapped))
           (= 3 (Dynamic.caddr mapped)))))
 
 (defmacro test-zip []
   (let [zipped (Dynamic.zip array '('a 'd) '('c 'o) '('e 'g))]
-    (and (= 'ace (Symbol.concat (eval (Dynamic.car zipped))))
-      (= 'dog (Symbol.concat (eval (Dynamic.cadr zipped)))))))
+    (and (= 'ace (Symbol.concat (eval (Dynamic.car  zipped))))
+         (= 'dog (Symbol.concat (eval (Dynamic.cadr zipped)))))))
 
 (defmodule TestDyn
   (defndynamic x [] true))
@@ -218,17 +218,17 @@
                 (test-= veit "veit")
                 "= macro works as expected across types")
   (assert-false test
-                (and* true true false)
-                "and* macro works as expected I")
+                (and true true false)
+                "vararg-and macro works as expected I")
   (assert-true test
-               (and* true true true)
-               "and* macro works as expected II")
+               (and true true true)
+               "vararg-and macro works as expected II")
   (assert-false test
-                (or* false false false)
-                "or* macro works as expected I")
+                (or false false false)
+                "vararg-or macro works as expected I")
   (assert-true test
-               (or* true false true)
-               "or* macro works as expected II")
+               (or true false true)
+               "vararg-or macro works as expected II")
   (assert-equal test
                 "1 thing 2 things"
                 &(str* 1 " thing " 2 " things")

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -217,18 +217,18 @@
   (assert-false test
                 (test-= veit "veit")
                 "= macro works as expected across types")
-  (assert-false test
+  (assert-false test      ; debug-1: this compiles but takes >400MBytes extra Memory?!
                 (and true true false)
                 "vararg-and macro works as expected I")
-  (assert-true test
-               (and true true true)
-               "vararg-and macro works as expected II")
-  (assert-false test
-                (or false false false)
-                "vararg-or macro works as expected I")
-  (assert-true test
-               (or true false true)
-               "vararg-or macro works as expected II")
+  ;~ (assert-true test       ; debug-2: like debug-1, but when both are active, then >4GB memory are used and compilation fails 
+               ;~ (and true true true)
+               ;~ "vararg-and macro works as expected II")
+  ;~ (assert-false test   ; TODO: activate after debugging
+                ;~ (or false false false)
+                ;~ "vararg-or macro works as expected I")
+  ;~ (assert-true test    ; TODO: activate after debugging
+               ;~ (or true false true)
+               ;~ "vararg-or macro works as expected II")
   (assert-equal test
                 "1 thing 2 things"
                 &(str* 1 " thing " 2 " things")

--- a/test/short_circuiting.carp
+++ b/test/short_circuiting.carp
@@ -33,12 +33,12 @@
 
 (defn vararg-and []
   (do (set! g 0)
-      (ignore (and* (inc-true) (inc-true) (inc-false) (inc-true) (inc-true))) ;; 3 expressions will evaluate.
+      (ignore (and (inc-true) (inc-true) (inc-false) (inc-true) (inc-true))) ;; 3 expressions will evaluate.
       g))
 
 (defn vararg-or []
   (do (set! g 0)
-      (ignore (or* (inc-false) (inc-false) (inc-true) (inc-false) (inc-false))) ;; 3 expressions will evaluate.
+      (ignore (or (inc-false) (inc-false) (inc-true) (inc-false) (inc-false))) ;; 3 expressions will evaluate.
       g))
 
 (deftest test
@@ -61,9 +61,9 @@
   (assert-equal test
                 3
                 (vararg-and)
-                "'and*' works")
+                "vararg-'and' works")
   (assert-equal test
                 3
                 (vararg-or)
-                "'or*' works")
+                "vararg-'or' works")
   )


### PR DESCRIPTION
So far the macros ```and```  and ```or``` expected exactly 2 parameters.
The new version - inspired by Scheme - can handle anything from 0 upwards.