### PR TITLE
reorganize Pattern library

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -62,7 +62,8 @@ Returns `[]` if it doesn’t find a matching pattern.")
 Returns an empty string if it doesn’t find a matching pattern.")
   (defn match-str [pattern data]
     (Maybe.from (Pattern.extract &(Pattern.match pattern data) data) @"") )
-  
+
+  ; TODO: remove?!  
   (doc global-match "finds all matches of a pattern in a string as a nested
 array.
 
@@ -97,8 +98,11 @@ list of those characters.")
   (defn from-chars [chars]
     (Pattern.init &(str* @"[" (String.from-chars chars) @"]")))
 
-  (defn global-match-str [p s]
-    (Array.copy-map &(fn [x] @(Array.unsafe-first x)) &(global-match p s)))
+  (defn global-match-str [pattern data]
+    (Array.copy-map 
+      &(fn [m] (Maybe.unsafe-from (extract m data))) 
+      &(find-all-matches pattern data)))
+
 
   (doc split "splits a string by a pattern.")
   (defn split [p s]

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -70,11 +70,11 @@ Returns an empty string if it doesn’t find a matching pattern.")
   (defn match-str [pattern data]
     (Maybe.from (Pattern.extract &(Pattern.match pattern data) data) @"") )
 
-  (doc global-match "finds all match groups of a pattern in a string as a nested
+  (doc match-all-groups "finds all match groups of a pattern in a string as a nested
 array.
 
 Returns `[]` if it doesn’t find a matching pattern.")
-  (register global-match (Fn [&Pattern &String] (Array (Array String))))
+  (register match-all-groups (Fn [&Pattern &String] (Array (Array String))))
   (doc substitute "finds all matches of a pattern in a string and replaces it
 by another pattern `n` times.
 

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -1,23 +1,49 @@
 (system-include "carp_pattern.h")
 
 (defmodule Pattern
+
   (register-type MatchResult "PatternMatchResult" [start Int, end Int])
-  (defn       match2str [match-res] 
-	(fmt "#<MatchResult start=%d end=%d>" 
-	  (MatchResult.start match-res) 
-	  (MatchResult.end   match-res) ))
+  (hidden match2str)
+  (defn   match2str [match-res] 
+	  (fmt "(MatchResult start=%d end=%d)" 
+	    (MatchResult.start match-res) 
+	    (MatchResult.end   match-res) ))
   (implements str Pattern.match2str)
-  (doc match "returns start and end indizes of the first match.")
-  (register match (Fn [&Pattern &String] Pattern.MatchResult))
+
+  (defn extract [match data]
+    (let [start @(MatchResult.start match)
+          end   @(MatchResult.end   match) ]
+      (if (or* (Int.< start 0)
+               (Int.< end   0) )
+        (Maybe.Nothing)
+        (Maybe.Just (String.slice data start end)) )))  ; slice takes end as 1st index AFTER the match
+
+  (doc      match-from "returns start and end indizes of the first match after start-pos. Note that the end index points to the 1st character _after_ the match (like all slice functions).")
+  (register match-from (Fn [&Pattern &String Int] Pattern.MatchResult))
+  (doc  match "returns start and end indizes of the first match after the start of the string. Note that the end index points to the 1st character _after_ the match (like all slice functions).")
+  (defn match [pattern data]
+    (match-from pattern data 0) )
 
   (doc find "finds the index of a pattern in a string.
 
 Returns `-1` if it doesn’t find a matching pattern.")
-  (register find (Fn [&Pattern &String] Int))
-  (doc find-all "finds all indices of a pattern in a string.
+  (defn find [pattern data]
+    @(Pattern.MatchResult.start &(Pattern.match pattern data)) )
+  
+  (doc find-all "finds all indices of a pattern in a string. The patterns may _not_ overlap.
 
 Returns `[]` if it doesn’t find a matching pattern.")
   (register find-all (Fn [&Pattern &String] (Array Int)))
+  ;~ (defn find-all [pattern data]
+    ;~ (let-do [result []
+             ;~ start  0
+             ;~ stop   (String.length data)
+             ;~ ;match  (match
+             ;~ ]
+      ;~ result
+    ;~ )
+  ;~ )
+  
   (doc match-groups "finds the match groups of the first match of a pattern in
 a string.
 
@@ -25,8 +51,10 @@ Returns `[]` if it doesn’t find a matching pattern.")
   (register match-groups (Fn [&Pattern &String] (Array String)))
   (doc match-str "finds the first match of a pattern in a string.
 
-Returns `[]` if it doesn’t find a matching pattern.")
-  (register match-str (Fn [&Pattern &String] String))
+Returns an empty string if it doesn’t find a matching pattern.")
+  (defn match-str [pattern data]
+    (Maybe.from (Pattern.extract &(Pattern.match pattern data) data) @"") )
+  
   (doc global-match "finds all matches of a pattern in a string as a nested
 array.
 

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -4,17 +4,16 @@
 
   (register-type MatchResult "PatternMatchResult" [start Int, end Int])
   (defmodule MatchResult
-    (defn refmatch2str [ref-matchres] 
+    (defn ref-str [ref-matchres] 
       (fmt "(MatchResult start=%d end=%d)" 
         (MatchResult.start ref-matchres) 
         (MatchResult.end   ref-matchres) ))
-    (implements str Pattern.MatchResult.refmatch2str)
-    (implements prn Pattern.MatchResult.refmatch2str)
-    ;
-    (defn match2str [matchres] 
-      (Pattern.MatchResult.refmatch2str &matchres) )
-    (implements str Pattern.MatchResult.match2str)
-    (implements prn Pattern.MatchResult.match2str)
+    (implements str Pattern.MatchResult.ref-str)
+    (implements prn Pattern.MatchResult.ref-str)
+    (defn str [matchres] 
+      (Pattern.MatchResult.ref-str &matchres) )
+    (implements str Pattern.MatchResult.str)
+    (implements prn Pattern.MatchResult.str)
   )
 
   (defn non-match? [match-res]
@@ -41,7 +40,6 @@ Returns `-1` if it doesn’t find a matching pattern.")
   (doc find-all "finds all indices of a pattern in a string. The patterns may _not_ overlap.
 
 Returns `[]` if it doesn’t find a matching pattern.")
-  ;~ (register find-all (Fn [&Pattern &String] (Array Int)))
   (defn find-all-matches [pattern data]
     (let-do [result []
              stop   (String.length data)

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -10,14 +10,14 @@
 	    (MatchResult.end   match-res) ))
   (implements str Pattern.match2str)
 
-  (defn non-match? [match]
-    (or* (Int.< @(MatchResult.start match) 0)
-         (Int.< @(MatchResult.end   match) 0) ))
-  (defn extract [match data]
-    (if (non-match? match)
+  (defn non-match? [match-res]
+    (or (Int.< @(MatchResult.start match-res) 0)
+        (Int.< @(MatchResult.end   match-res) 0) ))
+  (defn extract [match-res data]
+    (if (non-match? match-res)
       (Maybe.Nothing)
-      (Maybe.Just (String.slice data @(MatchResult.start match)
-                                     @(MatchResult.end   match) ))))
+      (Maybe.Just (String.slice data @(MatchResult.start match-res)
+                                     @(MatchResult.end   match-res) ))))
 
   (doc      match-from "returns start and end indizes of the first match after start-pos. Note that the end index points to the 1st character _after_ the match (like all slice functions).")
   (register match-from (Fn [&Pattern &String Int] Pattern.MatchResult))
@@ -38,13 +38,13 @@ Returns `[]` if it doesn’t find a matching pattern.")
   ;~ (defn find-all [pattern data]
     ;~ (let-do [result []
              ;~ stop   (String.length data)
-             ;~ match  (match-from pattern data 0)
-             ;~ start  @(MatchResult.end &match) ]
+             ;~ found  (match-from pattern data 0)
+             ;~ start  @(MatchResult.end &found) ]
       ;~ (while-do (and (Int.<= start stop)
-                     ;~ (not (non-match? &match)) )
-        ;~ (set! result (Array.push-back result match))
-        ;~ (set! match  (match-from pattern data start))
-        ;~ (set! start  @(MatchResult.end &match)) )
+                     ;~ (not (non-match? &found)) )
+        ;~ (set! result (Array.push-back result found))
+        ;~ (set! found  (match-from pattern data start))
+        ;~ (set! start  @(MatchResult.end &found)) )
       ;~ result ))
   
   (doc match-groups "finds the match groups of the first match of a pattern in

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -3,12 +3,21 @@
 (defmodule Pattern
 
   (register-type MatchResult "PatternMatchResult" [start Int, end Int])
-  (hidden match2str)
-  (defn   match2str [match-res] 
-	  (fmt "(MatchResult start=%d end=%d)" 
-	    (MatchResult.start match-res) 
-	    (MatchResult.end   match-res) ))
-  (implements str Pattern.match2str)
+  (defmodule MatchResult
+    ;(hidden refstr)
+    (defn   refstr [match-res] 
+      (fmt "(MatchResult start=%d end=%d)" 
+        (MatchResult.start match-res) 
+        (MatchResult.end   match-res) ))
+    (implements str Pattern.MatchResult.refstr)
+    (implements prn Pattern.MatchResult.refstr)
+    ;
+    ;(hidden str)
+    (defn   str [match-res] 
+      (Pattern.MatchResult.refstr &match-res) )
+    (implements str Pattern.MatchResult.str)
+    (implements prn Pattern.MatchResult.str)
+  )
 
   (defn non-match? [match-res]
     (or (Int.< @(MatchResult.start match-res) 0)

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -10,13 +10,14 @@
 	    (MatchResult.end   match-res) ))
   (implements str Pattern.match2str)
 
+  (defn non-match? [match]
+    (or* (Int.< @(MatchResult.start match) 0)
+         (Int.< @(MatchResult.end   match) 0) ))
   (defn extract [match data]
-    (let [start @(MatchResult.start match)
-          end   @(MatchResult.end   match) ]
-      (if (or* (Int.< start 0)
-               (Int.< end   0) )
-        (Maybe.Nothing)
-        (Maybe.Just (String.slice data start end)) )))  ; slice takes end as 1st index AFTER the match
+    (if (non-match? match)
+      (Maybe.Nothing)
+      (Maybe.Just (String.slice data @(MatchResult.start match)
+                                     @(MatchResult.end   match) ))))
 
   (doc      match-from "returns start and end indizes of the first match after start-pos. Note that the end index points to the 1st character _after_ the match (like all slice functions).")
   (register match-from (Fn [&Pattern &String Int] Pattern.MatchResult))
@@ -36,13 +37,15 @@ Returns `[]` if it doesn’t find a matching pattern.")
   (register find-all (Fn [&Pattern &String] (Array Int)))
   ;~ (defn find-all [pattern data]
     ;~ (let-do [result []
-             ;~ start  0
              ;~ stop   (String.length data)
-             ;~ ;match  (match
-             ;~ ]
-      ;~ result
-    ;~ )
-  ;~ )
+             ;~ match  (match-from pattern data 0)
+             ;~ start  @(MatchResult.end &match) ]
+      ;~ (while-do (and (Int.<= start stop)
+                     ;~ (not (non-match? &match)) )
+        ;~ (set! result (Array.push-back result match))
+        ;~ (set! match  (match-from pattern data start))
+        ;~ (set! start  @(MatchResult.end &match)) )
+      ;~ result ))
   
   (doc match-groups "finds the match groups of the first match of a pattern in
 a string.

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -1,6 +1,15 @@
 (system-include "carp_pattern.h")
 
 (defmodule Pattern
+  (register-type MatchResult "PatternMatchResult" [start Int, end Int])
+  (defn       match2str [match-res] 
+	(fmt "#<MatchResult start=%d end=%d>" 
+	  (MatchResult.start match-res) 
+	  (MatchResult.end   match-res) ))
+  (implements str Pattern.match2str)
+  (doc match "returns start and end indizes of the first match.")
+  (register match (Fn [&Pattern &String] Pattern.MatchResult))
+
   (doc find "finds the index of a pattern in a string.
 
 Returns `-1` if it doesn’t find a matching pattern.")

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -4,19 +4,17 @@
 
   (register-type MatchResult "PatternMatchResult" [start Int, end Int])
   (defmodule MatchResult
-    ;(hidden refstr)
-    (defn   refstr [match-res] 
+    (defn refmatch2str [ref-matchres] 
       (fmt "(MatchResult start=%d end=%d)" 
-        (MatchResult.start match-res) 
-        (MatchResult.end   match-res) ))
-    (implements str Pattern.MatchResult.refstr)
-    (implements prn Pattern.MatchResult.refstr)
+        (MatchResult.start ref-matchres) 
+        (MatchResult.end   ref-matchres) ))
+    (implements str Pattern.MatchResult.refmatch2str)
+    (implements prn Pattern.MatchResult.refmatch2str)
     ;
-    ;(hidden str)
-    (defn   str [match-res] 
-      (Pattern.MatchResult.refstr &match-res) )
-    (implements str Pattern.MatchResult.str)
-    (implements prn Pattern.MatchResult.str)
+    (defn match2str [matchres] 
+      (Pattern.MatchResult.refmatch2str &matchres) )
+    (implements str Pattern.MatchResult.match2str)
+    (implements prn Pattern.MatchResult.match2str)
   )
 
   (defn non-match? [match-res]

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -63,8 +63,7 @@ Returns an empty string if it doesn’t find a matching pattern.")
   (defn match-str [pattern data]
     (Maybe.from (Pattern.extract &(Pattern.match pattern data) data) @"") )
 
-  ; TODO: remove?!  
-  (doc global-match "finds all matches of a pattern in a string as a nested
+  (doc global-match "finds all match groups of a pattern in a string as a nested
 array.
 
 Returns `[]` if it doesn’t find a matching pattern.")

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -34,18 +34,23 @@ Returns `-1` if it doesn’t find a matching pattern.")
   (doc find-all "finds all indices of a pattern in a string. The patterns may _not_ overlap.
 
 Returns `[]` if it doesn’t find a matching pattern.")
-  (register find-all (Fn [&Pattern &String] (Array Int)))
-  ;~ (defn find-all [pattern data]
-    ;~ (let-do [result []
-             ;~ stop   (String.length data)
-             ;~ found  (match-from pattern data 0)
-             ;~ start  @(MatchResult.end &found) ]
-      ;~ (while-do (and (Int.<= start stop)
-                     ;~ (not (non-match? &found)) )
-        ;~ (set! result (Array.push-back result found))
-        ;~ (set! found  (match-from pattern data start))
-        ;~ (set! start  @(MatchResult.end &found)) )
-      ;~ result ))
+  ;~ (register find-all (Fn [&Pattern &String] (Array Int)))
+  (defn find-all-matches [pattern data]
+    (let-do [result []
+             stop   (String.length data)
+             found  (match-from pattern data 0)
+             start  @(MatchResult.end &found) ]
+      (while-do (and (Int.<= start stop)
+                     (not (non-match? &found)) )
+        (set! result (Array.push-back result found))
+        (set! found  (match-from pattern data start))
+        (set! start  @(MatchResult.end &found)) )
+      result ))
+  (defn find-all [pattern data]
+    (Array.copy-map 
+      &(fn [m] @(MatchResult.start m)) 
+      &(find-all-matches pattern data) ))
+  
   
   (doc match-groups "finds the match groups of the first match of a pattern in
 a string.

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -601,7 +601,7 @@ PatternMatchResult Pattern_match(Pattern *p, String *s) {
         Pattern_internal_reprepstate(&ms);
         if ((res = Pattern_internal_match(&ms, s1, pat))) {
             result.start = (s1 - str);
-            result.end = res - str;
+            result.end = res - str - 1;
             break;
         }
     } while (s1++ < ms.src_end && !anchor);

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -542,7 +542,7 @@ Array Array_push_back(Array res, Array tmp) {
     return res;
 }
 
-Array Pattern_global_MINUS_match(Pattern *p, String *s) {
+Array Pattern_match_MINUS_all_MINUS_groups(Pattern *p, String *s) {
     String str = *s;
     Pattern pat = *p;
     int lstr = strlen(str);

--- a/core/carp_pattern.h
+++ b/core/carp_pattern.h
@@ -513,42 +513,6 @@ Array Pattern_match_MINUS_groups(Pattern *p, String *s) {
     return a;
 }
 
-Array Pattern_find_MINUS_all(Pattern *p, String *s) {
-    String str = *s;
-    Pattern pat = *p;
-    int lstr = strlen(str);
-    int lpat = strlen(pat);
-    Array res;
-    res.len = 0;
-    res.capacity = 0;
-    res.data = NULL;
-    /* explicit request or no special characters? */
-    if (Pattern_internal_nospecials(pat, lpat)) {
-        while (1) {
-            /* do a plain search */
-            String s2 = Pattern_internal_lmemfind(str, lstr, pat, lpat);
-            if (!s2) return res;
-            Pattern_internal_update_int_array(&res, s2 - str);
-        }
-    }
-    PatternMatchState ms;
-    String s1 = str;
-    int anchor = (*pat == '^');
-    if (anchor) {
-        pat++;
-        lpat--; /* skip anchor character */
-    }
-    Pattern_internal_prepstate(&ms, str, lstr, pat, lpat);
-    do {
-        Pattern_internal_reprepstate(&ms);
-        if (Pattern_internal_match(&ms, s1, pat)) {
-            Pattern_internal_update_int_array(&res, s1 - str);
-        }
-    } while (s1++ < ms.src_end && !anchor);
-    return res;
-}
-
-/// gub-new
 typedef struct PatternMatchResult { 
     int start;	// negative start or end indicates a non-match
     int end;

--- a/test/pattern.carp
+++ b/test/pattern.carp
@@ -69,8 +69,8 @@
                 "matches? works as exptected on tabs special case")
   (assert-equal test
                 &[@"3" @"4"]
-                (Array.unsafe-nth &(global-match #"(\d)-(\d)" "1-2 2-3 3-4 4-5") 2)
-                "global-match works as expected")
+                (Array.unsafe-nth &(match-all-groups #"(\d)-(\d)" "1-2 2-3 3-4 4-5") 2)
+                "match-all-groups works as expected")
   (assert-equal test
                 "1-2"
                 &(match-str #"(\d)-(\d)" "1-2 2-3 3-4 4-5")


### PR DESCRIPTION
* feat!: Pattern.match now returns start and end indizes of the first match
* feat!: matches from Pattern.find-all can no longer overlap. This fixes #1255.
* feat!: Pattern.global-match-str now returns all matches as String 
* feat!: renamed (Pattern.global-match) to (Pattern.match-all-groups) 
* feat: implemented (Pattern.match-from)
* feat: moved Pattern.match-str and Pattern.find from C to Carp code 
* fix: moved some matching code from C to Carp and removed dead C functions
