### PR TITLE
declare to use c11 

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -30,7 +30,7 @@ defaultProject =
         _ ->
           [ "-fPIC",
             "-g",
-            "-std=c99",
+            "-std=c11",
             -- , "-pedantic"
             "-D_DEFAULT_SOURCE",
             "-Wall",
@@ -157,13 +157,14 @@ main = do
   pure ()
 
 -- | Options for how to run the compiler.
-data FullOptions = FullOptions
-  { optExecMode :: ExecutionMode,
-    optOthers :: OtherOptions,
-    optPreload :: [String],
-    optPostload :: [String],
-    optFiles :: [FilePath]
-  }
+data FullOptions
+  = FullOptions
+      { optExecMode :: ExecutionMode,
+        optOthers :: OtherOptions,
+        optPreload :: [String],
+        optPostload :: [String],
+        optFiles :: [FilePath]
+      }
   deriving (Show)
 
 parseFull :: Parser FullOptions
@@ -175,14 +176,15 @@ parseFull =
     <*> many (strOption (long "eval-postload" <> metavar "CODE" <> help "Eval CODE after loading FILES"))
     <*> parseFiles
 
-data OtherOptions = OtherOptions
-  { otherNoCore :: Bool,
-    otherNoProfile :: Bool,
-    otherLogMemory :: Bool,
-    otherOptimize :: Bool,
-    otherGenerateOnly :: Bool,
-    otherPrompt :: Maybe String
-  }
+data OtherOptions
+  = OtherOptions
+      { otherNoCore :: Bool,
+        otherNoProfile :: Bool,
+        otherLogMemory :: Bool,
+        otherOptimize :: Bool,
+        otherGenerateOnly :: Bool,
+        otherPrompt :: Maybe String
+      }
   deriving (Show)
 
 parseOther :: Parser OtherOptions


### PR DESCRIPTION
feat: builds on OS other than Windows now use ```-std=c11``` instead of ```-std=c99```

The use case is to be able to forward declare functions which use the String type, which in turn needs to be defined and thus redefined (e.g. PR #1256).
This causes a warning (and thus failed builds) on Linux when ```-std=c99``` is supplied to the C compiler.
The problem is gone with C11, which explicitly permits this.

This has been tested on Linux with Clang, tcc (which ignores the parameter), and Zig.
(note: gcc supports the flag, but needs the ```-lm```  flag positioned after the source file name) which is separate issue).