### PR TITLE
TCC on windows 32bit

### DIFF
--- a/core/core.h
+++ b/core/core.h
@@ -1,4 +1,11 @@
 #if defined _WIN32
+
+#ifdef __TINYC__
+// missing definitions for tcc-0.9.27-win32-bin.zip => 32bit TCC
+#define CP_UTF8 65001
+#define strtof strtod
+#endif
+
 #include <windows.h>
 #if !defined __CYGWIN__ && !defined __MINGW32__
 typedef intptr_t ssize_t;


### PR DESCRIPTION
TCC is an incredibly fast C compiler.
Unfortunately on Windows the latest TCC release 0.9.27 does not work out of the box, since 2 minor definitions are missing to compile a simple HelloWorld.Carp.
* related to issue #1263, but does not generally fix it.

note: 2nd attempt cherrypicking the relevant changeset 