### PR TITLE
feat: add machine-info primitive draft

### DIFF
--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -9,7 +9,6 @@ import Control.Monad.State
 import Data.Char
 import Data.Hashable
 import Data.List (intercalate)
-import Data.List.Split (splitOn)
 import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import Info
@@ -1151,42 +1150,3 @@ walk :: (XObj -> XObj) -> XObj -> XObj
 walk f (XObj (Arr xs) i t) = XObj (Arr (map (walk f) xs)) i t
 walk f (XObj (Lst xs) i t) = XObj (Lst (map (walk f) xs)) i t
 walk f x = f x
-
-tyToObj :: Ty -> Obj
-tyToObj UnitTy = Lst []
-tyToObj (StructTy s []) = simpleSym (show s)
-tyToObj (StructTy s typeArgs) =
-  Lst ((XObj (simpleSym (show s)) Nothing Nothing) : (map oX typeArgs))
-  where
-    oX o = XObj (tyToObj o) Nothing Nothing
-tyToObj (FuncTy argTys retTy StaticLifetimeTy) =
-  Lst
-    [ XObj (simpleSym "Fn") Nothing Nothing,
-      XObj (Arr (map oX argTys)) Nothing Nothing,
-      oX retTy
-    ]
-  where
-    oX o = XObj (tyToObj o) Nothing Nothing
-tyToObj (FuncTy argTys retTy lt) =
-  Lst
-    [ XObj (simpleSym "Fn") Nothing Nothing,
-      XObj (Arr (map oX argTys)) Nothing Nothing,
-      oX retTy,
-      oX lt
-    ]
-  where
-    oX o = XObj (tyToObj o) Nothing Nothing
-tyToObj (PointerTy p) =
-  Lst [XObj (simpleSym "Ptr") Nothing Nothing, XObj (tyToObj p) Nothing Nothing]
-tyToObj (RefTy r lt) =
-  Lst
-    [ XObj (simpleSym "Ref") Nothing Nothing,
-      XObj (tyToObj r) Nothing Nothing,
-      XObj (tyToObj lt) Nothing Nothing
-    ]
-tyToObj t = simpleSym (show t)
-
-simpleSym :: String -> Obj
-simpleSym s = Sym (SymPath (init path) (last path)) Symbol
-  where
-    path = splitOn "." s

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -9,6 +9,7 @@ import Control.Monad.State
 import Data.Char
 import Data.Hashable
 import Data.List (intercalate)
+import Data.List.Split (splitOn)
 import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import Info
@@ -1150,3 +1151,42 @@ walk :: (XObj -> XObj) -> XObj -> XObj
 walk f (XObj (Arr xs) i t) = XObj (Arr (map (walk f) xs)) i t
 walk f (XObj (Lst xs) i t) = XObj (Lst (map (walk f) xs)) i t
 walk f x = f x
+
+tyToObj :: Ty -> Obj
+tyToObj UnitTy = Lst []
+tyToObj (StructTy s []) = simpleSym (show s)
+tyToObj (StructTy s typeArgs) =
+  Lst ((XObj (simpleSym (show s)) Nothing Nothing) : (map oX typeArgs))
+  where
+    oX o = XObj (tyToObj o) Nothing Nothing
+tyToObj (FuncTy argTys retTy StaticLifetimeTy) =
+  Lst
+    [ XObj (simpleSym "Fn") Nothing Nothing,
+      XObj (Arr (map oX argTys)) Nothing Nothing,
+      oX retTy
+    ]
+  where
+    oX o = XObj (tyToObj o) Nothing Nothing
+tyToObj (FuncTy argTys retTy lt) =
+  Lst
+    [ XObj (simpleSym "Fn") Nothing Nothing,
+      XObj (Arr (map oX argTys)) Nothing Nothing,
+      oX retTy,
+      oX lt
+    ]
+  where
+    oX o = XObj (tyToObj o) Nothing Nothing
+tyToObj (PointerTy p) =
+  Lst [XObj (simpleSym "Ptr") Nothing Nothing, XObj (tyToObj p) Nothing Nothing]
+tyToObj (RefTy r lt) =
+  Lst
+    [ XObj (simpleSym "Ref") Nothing Nothing,
+      XObj (tyToObj r) Nothing Nothing,
+      XObj (tyToObj lt) Nothing Nothing
+    ]
+tyToObj t = simpleSym (show t)
+
+simpleSym :: String -> Obj
+simpleSym s = Sym (SymPath (init path) (last path)) Symbol
+  where
+    path = splitOn "." s

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -389,7 +389,7 @@ primitiveStructuredInfo (XObj _ i _) ctx (XObj (Sym path _) _ _) =
         genPair (s, x) = makeX (Lst [XObj (Str s) Nothing Nothing, x])
     makeX o = XObj o Nothing Nothing
 primitiveStructuredInfo _ ctx notName =
-  argumentErr ctx "machine-info" "a name" "first" notName
+  argumentErr ctx "structured-info" "a name" "first" notName
 
 dynamicOrMacroWith :: Context -> (SymPath -> [XObj]) -> Ty -> String -> XObj -> IO (Context, Either EvalError XObj)
 dynamicOrMacroWith ctx producer ty name body = do

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -363,7 +363,7 @@ primitiveStructuredInfo (XObj _ i _) ctx (XObj (Sym path _) _ _) =
     workOnBinder (Binder metaData (XObj _ (Just (Info l c f _ _)) t)) =
       makeX
         ( Lst
-            [ makeX (maybe (Lst []) tyToObj t),
+            [ (maybe (makeX (Lst [])) reify t),
               makeX
                 ( Lst
                     [ makeX (Str f),
@@ -377,7 +377,7 @@ primitiveStructuredInfo (XObj _ i _) ctx (XObj (Sym path _) _ _) =
     workOnBinder (Binder metaData (XObj _ _ t)) =
       makeX
         ( Lst
-            [ makeX (maybe (Lst []) tyToObj t),
+            [ (maybe (makeX (Lst [])) reify t),
               makeX (Lst []),
               metaList metaData
             ]

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -350,8 +350,8 @@ primitiveInfo _ ctx notName =
   argumentErr ctx "info" "a name" "first" notName
 
 -- | Get information about a binding.
-primitiveMachineInfo :: UnaryPrimitiveCallback
-primitiveMachineInfo (XObj _ i _) ctx (XObj (Sym path _) _ _) =
+primitiveStructuredInfo :: UnaryPrimitiveCallback
+primitiveStructuredInfo (XObj _ i _) ctx (XObj (Sym path _) _ _) =
   case lookupBinderInTypeEnv ctx path of
     Right bind -> return (ctx, Right $ workOnBinder bind)
     Left _ ->
@@ -388,7 +388,7 @@ primitiveMachineInfo (XObj _ i _) ctx (XObj (Sym path _) _ _) =
       where
         genPair (s, x) = makeX (Lst [XObj (Str s) Nothing Nothing, x])
     makeX o = XObj o Nothing Nothing
-primitiveMachineInfo _ ctx notName =
+primitiveStructuredInfo _ ctx notName =
   argumentErr ctx "machine-info" "a name" "first" notName
 
 dynamicOrMacroWith :: Context -> (SymPath -> [XObj]) -> Ty -> String -> XObj -> IO (Context, Either EvalError XObj)

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -297,6 +297,7 @@ dynamicModule =
       let f = makeUnaryPrim . spath
        in [ f "quote" (\_ ctx x -> pure (ctx, Right x)) "quotes any value." "(quote x) ; where x is an actual symbol",
             f "info" primitiveInfo "prints all information associated with a symbol." "(info mysymbol)",
+            f "machine-info" primitiveMachineInfo "gets all information associated with a symbol." "(machine-info mysymbol)",
             f "managed?" primitiveIsManaged "checks whether a type is managed by Carp by checking whether `delete` was implemented for it. For an explanation of memory management, you can reference [this document](https://carp-lang.github.io/carp-docs/Memory.html)." "(register-type Unmanaged \"void*\")\n(managed? Unmanaged) ; => false",
             f "members" primitiveMembers "returns the members of a type as an array." "(members MyType)",
             f "use" primitiveUse "uses a module, i.e. imports the symbols inside that module into the current module." "(use MyModule)",

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -297,7 +297,7 @@ dynamicModule =
       let f = makeUnaryPrim . spath
        in [ f "quote" (\_ ctx x -> pure (ctx, Right x)) "quotes any value." "(quote x) ; where x is an actual symbol",
             f "info" primitiveInfo "prints all information associated with a symbol." "(info mysymbol)",
-            f "machine-info" primitiveMachineInfo "gets all information associated with a symbol." "(machine-info mysymbol)",
+            f "structured-info" primitiveStructuredInfo "gets all information associated with a symbol as a list of the form `(type|(), info|(), metadata)`." "(structured-info mysymbol)",
             f "managed?" primitiveIsManaged "checks whether a type is managed by Carp by checking whether `delete` was implemented for it. For an explanation of memory management, you can reference [this document](https://carp-lang.github.io/carp-docs/Memory.html)." "(register-type Unmanaged \"void*\")\n(managed? Unmanaged) ; => false",
             f "members" primitiveMembers "returns the members of a type as an array." "(members MyType)",
             f "use" primitiveUse "uses a module, i.e. imports the symbols inside that module into the current module." "(use MyModule)",


### PR DESCRIPTION
This PR adds `machine-info`, meant as a verison of `info` for machines or programs. The name and behavior are up for debate, but I wanted to provide a prototype to get the conversation going.

## The Proposal

A machine-readable version of the compiler-visible information associated with a symbol would be great. `machine-info` attempts to provide that by returning a list of the following form: `(type|(), info|(), metadata)`, where `type` is an S-expression of the type, `info` is a tuple of `(file, line, column)`, and `metadata` is a list of key-value pairs.

## The Value

Allowing for this would, among other things, allow us to express `info` as a Carp expression. It would also allow us to inquire IDE-usable informations from within a REPL.

## Open Questions

Of course the name and format of the return value are questions of taste. I don’t particularly like the name and am open to suggestions. As for the return value, I’d like the format to be easily traversable, so the sublists for optional information made sense. As for the ordering I don’t have any opinions, and if additional info could or should be provided let me know.

Any and all feedback welcome!

Cheers