### PR TITLE
feat: allow for multibranches in case

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -169,7 +169,9 @@ Example:
 )
 ```")
 (defmacro case [form :rest branches]
-  (case-internal form branches))
+  (let [name (gensym)]
+    (list 'let [name form]
+      (case-internal name branches))))
 
 (defmodule Dynamic
   (doc flip

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -149,20 +149,22 @@ Example:
       (macro-error "case has even number of branches; add an else branch")
       (if (= (length xs) 1)
         (car xs)
-        (list 'if
-              (list '= name (car xs))
-              (cadr xs)
-              (case-internal name (cddr xs)))))))
+        (let [values (if (list? (car xs)) (car xs) (list (car xs)))]
+          (list 'if
+                (cons 'or (map (fn [val] (list '= name val)) values))
+                (cadr xs)
+                (case-internal name (cddr xs))))))))
 
 (doc case "takes a form and a list of branches which are value and operation
-pairs. If a value matches, the operation is executed. It takes a catch-all else
-branch that is executed if nothing matches.
+pairs. If a value matches (or any in a list of values), the operation is
+executed. It takes a catch-all else branch that is executed if nothing matches.
 
 Example:
 ```
 (case (+ 10 1)
   10 (println* \"nope\")
   11 (println* \"yup\")
+  (12 13) (println* \"multibranch, but nope\")
   (println* \"else branch\")
 )
 ```")

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -141,6 +141,12 @@ Example:
 (defmacro unless [condition form]
   (list 'if condition (list) form))
 
+(hidden treat-case-handler)
+(defndynamic treat-case-handler [name handler]
+  (if (and (list? handler) (> (length handler) 1) (= ':or (car handler)))
+    (cons 'or (map (fn [val] (list '= name val)) (cdr handler)))
+    (list '= name handler)))
+
 (hidden case-internal)
 (defndynamic case-internal [name xs]
   (if (= (length xs) 0)
@@ -149,22 +155,22 @@ Example:
       (macro-error "case has even number of branches; add an else branch")
       (if (= (length xs) 1)
         (car xs)
-        (let [values (if (list? (car xs)) (car xs) (list (car xs)))]
-          (list 'if
-                (cons 'or (map (fn [val] (list '= name val)) values))
-                (cadr xs)
-                (case-internal name (cddr xs))))))))
+        (list 'if
+              (treat-case-handler name (car xs))
+              (cadr xs)
+              (case-internal name (cddr xs)))))))
 
 (doc case "takes a form and a list of branches which are value and operation
-pairs. If a value matches (or any in a list of values), the operation is
-executed. It takes a catch-all else branch that is executed if nothing matches.
+pairs. If a value matches (or any in a list of values preced by `:or`), the
+operation is executed. It takes a catch-all else branch that is executed if
+nothing matches.
 
 Example:
 ```
 (case (+ 10 1)
   10 (println* \"nope\")
   11 (println* \"yup\")
-  (12 13) (println* \"multibranch, but nope\")
+  (:or 12 13) (println* \"multibranch, but nope\")
   (println* \"else branch\")
 )
 ```")

--- a/core/Gensym.carp
+++ b/core/Gensym.carp
@@ -7,7 +7,7 @@
 (doc gensym-with "Generates symbols dynamically, based on a symbol name.")
 (defndynamic gensym-with [x]
   (do
-    (set! *gensym-counter* (inc *gensym-counter*))
+    (set! *gensym-counter* (+ *gensym-counter* 1))
     (Symbol.concat [x (Symbol.from *gensym-counter*)])))
 
 (doc gensym "Generates symbols dynamically as needed.")

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -34,6 +34,12 @@
     1 true
     false))
 
+(defn test-case-multi []
+  (case 1
+    2 false
+    (:or 1 3) true
+    false))
+
 (defmacro test-not [a] (not a))
 (defmacro test-< [a b] (< a b))
 (defmacro test-> [a b] (> a b))
@@ -84,6 +90,9 @@
   (assert-true test
                (test-case-select)
                "case correctly selects branch")
+  (assert-true test
+               (test-case-multi)
+               "case correctly selects multibranch")
   (assert-true test
                (test-comment)
                "comment ignores input")


### PR DESCRIPTION
This PR changes `case`—backwards-compatible change!—to allow for what I call multibranches, i.e. branches that are reachable by multiple values. It achieves this by using list syntax:

```clojure
(case (+ 10 1)
  (11 12) (println* "its either 11 or 12")
  (println* "its something else")
 )
```

I also took the liberty of optimizing it—and fixing a potential problem with side effects—using `gensym`. Before, something like the above would desugar to:

```clojure
(if (or (= (+ 10 1) 11) (= (+ 10 1) 12) ; => (+ 10 1) is duplicated here, side effects would potentially be executed twice
  (IO.println (ref (str "its either 11 or 12")))
  (IO.println (ref (str "its something else"))))
```

Now, using `gensym` we can write:

```clojure
(let [gensym-generated1037 (+ 10 1)]
  (if (or (= gensym-generated1037 11) (= gensym-generated1037 12))
    (IO.println (ref (str "its either 11 or 12")))
    (IO.println (ref (str "its something else")))))
```

i hope this all makes sense!

Cheers