### PR TITLE
fix: fix dynamic let bindings recursion and binder leaks

### DIFF
--- a/src/Context.hs
+++ b/src/Context.hs
@@ -2,6 +2,7 @@ module Context
   ( ContextError (..),
     replaceGlobalEnv,
     replaceInternalEnv,
+    replaceInternalEnvMaybe,
     replaceTypeEnv,
     replaceHistory,
     replaceProject,
@@ -117,6 +118,11 @@ instance Contextual QualifiedPath where
 replaceInternalEnv :: Context -> Env -> Context
 replaceInternalEnv ctx env =
   ctx {contextInternalEnv = Just env}
+
+-- The previous environment is completely replaced and will not be recoverable.
+replaceInternalEnvMaybe :: Context -> Maybe Env -> Context
+replaceInternalEnvMaybe ctx env =
+  ctx {contextInternalEnv = env}
 
 -- | Replace a context's global environment with a new environment.
 --

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -119,6 +119,8 @@ replaceInternalEnv :: Context -> Env -> Context
 replaceInternalEnv ctx env =
   ctx {contextInternalEnv = Just env}
 
+-- | Replace a context's internal environment with a new environment or nothing.
+--
 -- The previous environment is completely replaced and will not be recoverable.
 replaceInternalEnvMaybe :: Context -> Maybe Env -> Context
 replaceInternalEnvMaybe ctx env =

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -277,9 +277,9 @@ eval ctx xobj@(XObj o info ty) preference resolver =
         Right newCtx -> do
           (finalCtx, evaledBody) <- eval newCtx body (PreferLocal (map (\(name, _) -> (SymPath [] name)) binds)) ResolveLocal
           let Just e = contextInternalEnv finalCtx
-              parentEnv = fromMaybe e (envParent e)
+              parentEnv = envParent e
           pure
-            ( replaceInternalEnv finalCtx parentEnv,
+            ( replaceInternalEnvMaybe finalCtx parentEnv,
               do
                 okBody <- evaledBody
                 Right okBody
@@ -298,7 +298,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
               --   (let [f (fn [x] (if (= x 1) x (f (dec x))))] (f 10))
               let origin = (contextInternalEnv ctx')
                   recFix = (E.recursive origin (Just "let-rec-env") 0)
-                  Right envWithSelf = E.insertX recFix (SymPath [] n) x
+                  Right envWithSelf = if isFn x then E.insertX recFix (SymPath [] n) x else Right recFix
                   ctx'' = replaceInternalEnv ctx' envWithSelf
               (newCtx, res) <- eval ctx'' x preference resolver
               case res of

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -232,6 +232,11 @@ isMod :: XObj -> Bool
 isMod (XObj (Mod _ _) _ _) = True
 isMod _ = False
 
+isFn :: XObj -> Bool
+isFn (XObj (Lst (XObj (Fn _ _) _ _ : _)) _ _) = True
+isFn (XObj (Lst (XObj (Sym (SymPath [] "fn") _) _ _ : _)) _ _) = True
+isFn _ = False
+
 -- | This instance is needed for the dynamic Dictionary
 instance Ord Obj where
   compare (Str a) (Str b) = compare a b


### PR DESCRIPTION
This PR fixes two issues. The first being that dynamic let binders were filled with an unevaluated right hand side as dummy value to enable recursion:

```clojure
; this is allowed
(let [x (fn [n] (if (= n 0) n (x (- n 1))))] (x 10)) ; => 0

; but sadly this also happens
(let [x x] x)
```

The first fix is thus to make sure that the binder trick only happens when the right hand side is a `fn`, which is the only case where recursion might make sense.

The second issue was that binders leaked out of their `let` scope in the global scope:

```clojure
(let [x 1] x) ; => 1

x ; => 1
```

This is because we replaced the internal environment with its parent when leaving the `let` block, _or with itself if it doesn’t have a parent_. The parenthetical does not make sense, especially since internal environments are completely optional. This behavior was dropped alltogether.

I hope all of this makes sense!

Cheers

_Fixes #1280_