### PR TITLE
fix: respect line number in repl

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -501,10 +501,13 @@ apply ctx@Context {contextInternalEnv = internal} body params args =
 
 -- | Parses a string and then converts the resulting forms to commands, which are evaluated in order.
 executeString :: Bool -> Bool -> Context -> String -> String -> IO Context
-executeString doCatch printResult ctx input fileName =
+executeString = executeStringAtLine 1
+
+executeStringAtLine :: Int -> Bool -> Bool -> Context -> String -> String -> IO Context
+executeStringAtLine line doCatch printResult ctx input fileName =
   if doCatch then catch exec (catcher ctx) else exec
   where
-    exec = case parse input fileName of
+    exec = case parseAtLine line input fileName of
       Left parseError ->
         let sourcePos = Parsec.errorPos parseError
             parseErrorXObj =

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -2,6 +2,7 @@
 
 module Parsing
   ( parse,
+    parseAtLine,
     validCharacters,
     balance,
   )
@@ -598,6 +599,11 @@ lispSyntax = do
   result <- Parsec.sepBy sexpr whitespaceOrNothing
   Parsec.eof
   pure result
+
+parseAtLine :: Int -> String -> String -> Either Parsec.ParseError [XObj]
+parseAtLine line text fileName =
+  let initState = ParseState (Info line 1 fileName (Set.fromList []) 0)
+   in Parsec.runParser lispSyntax initState fileName text
 
 parse :: String -> String -> Either Parsec.ParseError [XObj]
 parse text fileName =

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -606,9 +606,7 @@ parseAtLine line text fileName =
    in Parsec.runParser lispSyntax initState fileName text
 
 parse :: String -> String -> Either Parsec.ParseError [XObj]
-parse text fileName =
-  let initState = ParseState (Info 1 1 fileName (Set.fromList []) 0)
-   in Parsec.runParser lispSyntax initState fileName text
+parse = parseAtLine 1
 
 {-# ANN balance "HLint: ignore Use String" #-}
 

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -130,8 +130,8 @@ repl line readSoFar prompt =
             let input' = if concatenated == "\n" then contextLastInput context else concatenated -- Entering an empty string repeats last input
             context' <- liftIO $ executeStringAtLine line True True (resetAlreadyLoadedFiles context) (treatSpecialInput input') "REPL"
             lift $ put context'
-            repl (line + 1) "" (projectPrompt proj)
-          _ -> repl (line + 1) concatenated (if projectBalanceHints proj then balanced else "")
+            repl (line + (length (filter ('\n' ==) input'))) "" (projectPrompt proj)
+          _ -> repl line concatenated (if projectBalanceHints proj then balanced else "")
 
 resetAlreadyLoadedFiles :: Context -> Context
 resetAlreadyLoadedFiles context =

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -112,8 +112,8 @@ treatSpecialInput (':' : rest) =
         Nothing -> rewriteError ("Unknown special command: :" ++ [cmd])
 treatSpecialInput arg = arg
 
-repl :: String -> String -> InputT (StateT Context IO) ()
-repl readSoFar prompt =
+repl :: Int -> String -> String -> InputT (StateT Context IO) ()
+repl line readSoFar prompt =
   do
     context <- lift get
     input <- getInputLine (strWithColor Yellow prompt)
@@ -128,10 +128,10 @@ repl readSoFar prompt =
         case balanced of
           "" -> do
             let input' = if concatenated == "\n" then contextLastInput context else concatenated -- Entering an empty string repeats last input
-            context' <- liftIO $ executeString True True (resetAlreadyLoadedFiles context) (treatSpecialInput input') "REPL"
+            context' <- liftIO $ executeStringAtLine line True True (resetAlreadyLoadedFiles context) (treatSpecialInput input') "REPL"
             lift $ put context'
-            repl "" (projectPrompt proj)
-          _ -> repl concatenated (if projectBalanceHints proj then balanced else "")
+            repl (line + 1) "" (projectPrompt proj)
+          _ -> repl (line + 1) concatenated (if projectBalanceHints proj then balanced else "")
 
 resetAlreadyLoadedFiles :: Context -> Context
 resetAlreadyLoadedFiles context =
@@ -143,4 +143,4 @@ runRepl :: Context -> IO ((), Context)
 runRepl context = do
   historyPath <- configPath "history"
   createDirectoryIfMissing True (takeDirectory historyPath)
-  runStateT (runInputT (readlineSettings historyPath) (repl "" (projectPrompt (contextProj context)))) context
+  runStateT (runInputT (readlineSettings historyPath) (repl 1 "" (projectPrompt (contextProj context)))) context


### PR DESCRIPTION
This PR fixes the behavior of the REPL to respect line numbers.

Example:

```
> (def x 1)
> :i x
x : Int
  Defined at line 1, column 2 in 'REPL'
> (def x 2)
> :i x
x : Int
  Defined at line 3, column 2 in 'REPL' ; <= this used to say line 1 before!
```

Cheers