### PR TITLE
refactor: Cleanup Concretize module

### DIFF
--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -3,7 +3,24 @@
 -- | Module Concretize determines the dependencies of polymorphic objects and
 -- resolves the object into a "concrete" version, where its types are no longer
 -- variables.
-module Concretize where
+module Concretize
+  ( concretizeXObj,
+    concretizeType,
+    depsForCopyFunc,
+    depsForPrnFunc,
+    depsForDeleteFunc,
+    depsForDeleteFuncs,
+    depsOfPolymorphicFunction,
+    typesStrFunctionType,
+    concreteDelete,
+    memberDeletion,
+    memberRefDeletion,
+    concreteCopy,
+    tokensForCopy,
+    memberCopy,
+    replaceGenericTypeSymbolsOnMembers,
+  )
+where
 
 import AssignTypes
 import Constraints

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -201,7 +201,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
             (AppPat (MacroPat _ _ _) _) -> evaluateMacro form'
             (AppPat (CommandPat _ _ _) _) -> evaluateCommand form'
             (AppPat (PrimitivePat _ _ _) _) -> evaluatePrimitive form'
-            (WithPat _ sym@(SymPat path) forms) -> specialCommandWith ctx sym path forms
+            (WithPat _ sym@(SymPat path _) forms) -> specialCommandWith ctx sym path forms
             (DoPat _ forms) -> evaluateSideEffects forms
             (WhilePat _ cond body) -> specialCommandWhile ctx cond body
             (SetPat _ iden value) -> specialCommandSet ctx (iden : [value])
@@ -218,7 +218,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
             -- Importantly, the loop *is only broken on literal nested lists*.
             -- That is, passing a *symbol* that, e.g. resolves to a defn list, won't
             -- break our normal loop.
-            (AppPat self@(ListPat (x@(SymPat _) : _)) args) ->
+            (AppPat self@(ListPat (x@(SymPat _ _) : _)) args) ->
               do
                 (_, evald) <- eval ctx x preference ResolveGlobal
                 case evald of
@@ -227,7 +227,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
                     Right _ -> evaluateApp (self : args)
                     Left er -> pure (evalError ctx (show er) (xobjInfo xobj))
             (AppPat (ListPat _) _) -> evaluateApp form'
-            (AppPat (SymPat _) _) -> evaluateApp form'
+            (AppPat (SymPat _ _) _) -> evaluateApp form'
             [] -> pure (ctx, dynamicNil)
             _ -> pure (throwErr (UnknownForm xobj) ctx (xobjInfo xobj))
     checkStatic' (XObj Def _ _) = Left (HasStaticCall xobj info)
@@ -400,7 +400,7 @@ eval ctx xobj@(XObj o info ty) preference resolver =
     evaluateApp (AppPat f' args) =
       case f' of
         l@(ListPat _) -> go l ResolveLocal
-        sym@(SymPat _) -> go sym resolver
+        sym@(SymPat _ _) -> go sym resolver
         _ -> pure (evalError ctx (format (GenericMalformed xobj)) (xobjInfo xobj))
       where
         go x resolve =

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -330,6 +330,9 @@ data XObj = XObj
   }
   deriving (Show, Eq, Ord)
 
+setObj :: XObj -> Obj -> XObj
+setObj x o = x {xobjObj = o}
+
 instance Hashable XObj where
   hashWithSalt s XObj {..} = s `hashWithSalt` xobjObj
 

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -61,6 +61,7 @@ data TypeError
   | UninhabitedConstructor Ty XObj Int Int
   | InconsistentKinds String [XObj]
   | FailedToAddLambdaStructToTyEnv SymPath XObj
+  | FailedToInstantiateGenericType Ty
 
 instance Show TypeError where
   show (SymbolMissingType xobj env) =
@@ -310,6 +311,8 @@ instance Show TypeError where
     "Failed to add the lambda: " ++ show path ++ " represented by struct: "
       ++ pretty xobj
       ++ " to the type environment."
+  show (FailedToInstantiateGenericType ty) =
+    "I couldn't instantiate the generic type " ++ show ty
 
 machineReadableErrorStrings :: FilePathPrintLength -> TypeError -> [String]
 machineReadableErrorStrings fppl err =


### PR DESCRIPTION
This PR performs a few refactors in efforts to "cleanup" the `Concretize` module, whereby I mean it:

- Removes a bunch of local definitions to make functions easier to modify (no chance of accidentally altering function-local internal state)
- Adds an explicit export list to the module
- Tidies up some monadic usages to make them more terse and remove unneeded function calls.

I've also added some more pattern synonyms.

This is purely a refactor. This shouldn't result in any behavioral changes.