### PR TITLE
fix: make Symbol.prefix work on qualified symbols

### DIFF
--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -614,6 +614,8 @@ commandSymConcat ctx a =
 commandSymPrefix :: BinaryCommandCallback
 commandSymPrefix ctx (XObj (Sym (SymPath [] prefix) _) _ _) (XObj (Sym (SymPath [] suffix) st) i t) =
   pure (ctx, Right (XObj (Sym (SymPath [prefix] suffix) st) i t))
+commandSymPrefix ctx (XObj (Sym (SymPath ps prefix) _) _ _) (XObj (Sym (SymPath [] suffix) st) i t) =
+  pure (ctx, Right (XObj (Sym (SymPath (ps++[prefix]) suffix) st) i t))
 commandSymPrefix ctx x (XObj (Sym (SymPath [] _) _) _ _) =
   pure $ evalError ctx ("Can’t call `prefix` with " ++ pretty x) (xobjInfo x)
 commandSymPrefix ctx _ x =


### PR DESCRIPTION
This commit makes it so that `Symbol.prefix` can take qualified symbols
as prefix arguments, e.g.

`(Symbol.prefix 'Foo.Bar 'baz) => 'Foo.Bar.baz`

Fixes #1285