### PR TITLE
feat: Protocols

### DIFF
--- a/CarpHask.cabal
+++ b/CarpHask.cabal
@@ -46,6 +46,7 @@ library
                        Primitives,
                        PrimitiveError
                        Project,
+                       Protocol,
                        Qualify,
                        Reify,
                        RenderDocs,

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -950,3 +950,4 @@ commandType ctx (XObj x _ _) =
     typeOf Ref = "ref"
     typeOf Deref = "deref"
     typeOf (Interface _ _) = "interface"
+    typeOf (Protocol _ _) = "protocol"

--- a/src/Constraints.hs
+++ b/src/Constraints.hs
@@ -176,6 +176,18 @@ solveOneInternal mappings constraint =
        in case solveOneInternal mappings (Constraint v (RefTy b ltB) i1 i2 ctx ord) of
             Left err -> Left err
             Right ok -> foldM (\m (aa, bb) -> solveOneInternal m (Constraint aa bb i1 i2 ctx ord)) ok (zip args [b, ltB])
+    Constraint (ProtocolTy path _) (ProtocolTy path' _) _ _ _ _ ->
+      if path == path'
+        then Right mappings
+        else Left (UnificationFailure constraint mappings)
+    Constraint t (ProtocolTy (SymPath [] key) ts) _ _ _ _ ->
+      if t `elem` ts
+        then Right (Map.insert key t mappings)
+        else Left (UnificationFailure constraint mappings)
+    Constraint (ProtocolTy (SymPath [] key) ts) t _ _ _ _ ->
+      if t `elem` ts
+        then Right (Map.insert key t mappings)
+        else Left (UnificationFailure constraint mappings)
     -- Else
     Constraint aTy bTy _ _ _ _ ->
       if aTy == bTy

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -926,6 +926,7 @@ toDeclaration (Binder meta xobj@(XObj (Lst xobjs) _ ty)) =
       ""
     XObj (Primitive _) _ _ : _ ->
       ""
+    XObj (Protocol _ _) _ _ : _ -> ""
     _ -> error ("Internal compiler error: Can't emit other kinds of definitions: " ++ show xobj)
 toDeclaration _ = error "Missing case."
 

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -173,6 +173,7 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             (Match _) -> dontVisit
             With -> dontVisit
             MetaStub -> dontVisit
+            (Protocol _ _) -> dontVisit
             C c -> pure c
     visitStr' indent str i shouldEscape =
       -- This will allocate a new string every time the code runs:

--- a/src/Forms.hs
+++ b/src/Forms.hs
@@ -30,6 +30,7 @@ module Forms
     pattern DoPat,
     pattern WhilePat,
     pattern SetPat,
+    pattern ProtocolPat,
   )
 where
 
@@ -430,6 +431,9 @@ pattern CommandPat arity sym params <- XObj (Lst [XObj (Command arity) _ _, sym,
 
 pattern PrimitivePat :: PrimitiveFunctionType -> XObj -> [XObj] -> XObj
 pattern PrimitivePat arity sym params <- XObj (Lst [XObj (Primitive arity) _ _, sym, (ArrPat params)]) _ _
+
+pattern ProtocolPat :: XObj -> [SymPath] -> [SymPath] -> XObj
+pattern ProtocolPat name interfaces instances <- XObj (Lst [XObj (Protocol interfaces instances) _ _, name]) _ _
 
 pattern AppPat :: XObj -> [XObj] -> [XObj]
 pattern AppPat f args <- (f : args)

--- a/src/Interfaces.hs
+++ b/src/Interfaces.hs
@@ -8,6 +8,7 @@ module Interfaces
     retroactivelyRegisterInInterface,
     interfaceImplementedForTy,
     removeInterfaceFromImplements,
+    getImplementations,
     InterfaceError (..),
   )
 where
@@ -74,6 +75,11 @@ getFirstMatchingImplementation ctx paths ty =
   where
     predicate = (== Just ty) . (xobjTy . binderXObj)
     global = contextGlobalEnv ctx
+
+-- | Get the paths of interface implementations.
+getImplementations :: XObj -> [SymPath]
+getImplementations (XObj (Lst ((XObj (Interface _ paths) _ _):_)) _ _) = paths
+getImplementations _ = []
 
 -- | Remove an interface from a binder's list of implemented interfaces
 removeInterfaceFromImplements :: SymPath -> XObj -> Context -> Context

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -128,8 +128,8 @@ instance Show Number where
 -- | The canonical Lisp object.
 data Obj
   = Sym SymPath SymbolMode
-  | MultiSym String [SymPath] -- refering to multiple functions with the same name
-  | InterfaceSym String -- refering to an interface. TODO: rename to InterfaceLookupSym?
+  | MultiSym String [SymPath] -- referring to multiple functions with the same name
+  | InterfaceSym String -- referring to an interface. TODO: rename to InterfaceLookupSym?
   | Num Ty Number
   | Str String
   | Pattern String
@@ -171,6 +171,7 @@ data Obj
   | Deref
   | Interface Ty [SymPath]
   | C String -- C literal
+  | Protocol [SymPath] [SymPath]
   deriving (Show, Eq, Generic)
 
 instance Hashable Obj
@@ -401,6 +402,7 @@ getPath (XObj (Lst (XObj (Mod _ _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj (Interface _ _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj (Command _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Lst (XObj (Primitive _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
+getPath (XObj (Lst (XObj (Protocol _ _) _ _ : XObj (Sym path _) _ _ : _)) _ _) = path
 getPath (XObj (Sym path _) _ _) = path
 getPath x = SymPath [] (pretty x)
 
@@ -486,6 +488,7 @@ pretty = visit 0
         Deref -> "deref"
         Break -> "break"
         Interface _ _ -> "interface"
+        Protocol _ _ -> "defprotocol"
         With -> "with"
 
 prettyUpTo :: Int -> XObj -> String
@@ -551,6 +554,7 @@ prettyUpTo lim xobj =
         Deref -> ""
         Break -> ""
         Interface _ _ -> ""
+        Protocol _ _ -> ""
         With -> ""
 
 prettyCaptures :: Set.Set XObj -> String

--- a/src/Protocol.hs
+++ b/src/Protocol.hs
@@ -2,15 +2,26 @@
 --
 -- Protocols are bundles of interfaces that can be used for forming type
 -- hierarchies.
+--
+-- Protocols have global state in the type environment. The functions
+-- resolveProtocols and updateProtocols allow callees to fetch the latest
+-- protocol state to update the protocol types associated with functions.
+--
+-- Protocols leverage the same polymorphism resolution as type variables, but
+-- permissible substitutions are given by their members.
 module Protocol
-  (registerInstance)
+  (registerInstance
+  ,resolveProtocols
+  ,protocolEq
+  ,updateProtocols
+  ,containsProtocol
+  ,isProtocol)
 where
 
+import Data.Maybe (fromJust)
 import Data.Either (rights)
-import Debug.Trace
 
 import Context
-import Interfaces
 import Obj
 import Qualify
 import Types
@@ -59,35 +70,61 @@ registerInstance ctx protocol inst =
            in pure $ toBinder newX
         updateProtocol x _ _ = Left (NotAProtocol (getPath x))
         addInstance :: Ty -> Ty -> Ty
-        addInstance i (ProtocolTy is) = (ProtocolTy (addIfNotPresent i is))
-        addInstance _ t = t      
+        addInstance i (ProtocolTy n is) = (ProtocolTy n (addIfNotPresent i is))
+        addInstance _ t = t
+
+-- | Given a designation of a protocol, resolve it to the protocol's current
+-- memberships in the given context.
+resolveProtocols :: Context -> Ty -> Ty
+resolveProtocols ctx (FuncTy args ret lt) = (FuncTy (map (resolveProtocols ctx) args) (resolveProtocols ctx ret) lt)
+resolveProtocols ctx p@(ProtocolTy path _) =
+  case lookupBinderInTypeEnv ctx (markQualified path) of
+    Right p' -> fromJust (xobjTy (binderXObj p'))
+    Left  _ ->  p
+resolveProtocols _ t = t
+
+-- | Same as resolveProtocols, but operates on a type environment.
+updateProtocols :: TypeEnv -> Ty -> Ty
+updateProtocols tenv (FuncTy args ret lt) = (FuncTy (map (updateProtocols tenv) args) (updateProtocols tenv ret) lt)
+updateProtocols tenv p@(ProtocolTy path _) =
+  case findTypeBinder tenv path of
+    Right p' -> fromJust (xobjTy (binderXObj p'))
+    Left  _ ->  p
+updateProtocols _ t = t
+
+-- | Check that two types are equal, ignoring differences in protocol membership.
+protocolEq :: Ty -> Ty -> Bool
+protocolEq (FuncTy args ret lt) (FuncTy args' ret' lt') =
+  (foldl (&&) True (zipWith protocolEq args args')) && protocolEq ret ret' && lt == lt'
+protocolEq (ProtocolTy name _) (ProtocolTy name' _) = name == name'
+protocolEq t t' = t == t'
 
 --------------------------------------------------------------------------------
 -- Private utilities
 
 -- | Given a context and path, try to retrieve an associated protocol.
-getProtocol :: Context -> QualifiedPath -> Either ProtocolError XObj 
-getProtocol ctx protocol = 
-  case lookupBinderInTypeEnv ctx protocol of 
+getProtocol :: Context -> QualifiedPath -> Either ProtocolError XObj
+getProtocol ctx protocol =
+  case lookupBinderInTypeEnv ctx protocol of
     Right (Binder _ x@(ProtocolPat _ _ _)) -> pure x
-    _ -> Left $ NotAProtocol (unqualify protocol)   
+    _ -> Left $ NotAProtocol (unqualify protocol)
 
 -- | Just a wrapper around xobjToTy.
 getTypeFromPath :: SymPath -> Either ProtocolError Ty
 getTypeFromPath typath =
   let x = XObj (Sym typath Symbol) Nothing Nothing
    in maybe (Left (NotAType typath)) Right (xobjToTy x)
-  
+
 -- | Given a list of interfaces and a type, verify that the type appears in at
 -- least one implementation of each interface.
 checkImplementations :: Context -> [SymPath] -> Ty -> Either ProtocolError ()
 checkImplementations ctx interfaces t =
-  let actual  = traceShowId $ map binderXObj (rights (map (lookupBinderInTypeEnv ctx . markQualified) interfaces))
-      impls   = traceShowId $ map ((map (typeFromPath (contextGlobalEnv ctx))) . getImplementations) actual
+  let actual  = map binderXObj (rights (map (lookupBinderInTypeEnv ctx . markQualified) interfaces))
+      impls   = map ((map (typeFromPath (contextGlobalEnv ctx))) . getImplementations) actual
       matches = map (any ((flip isSubType) t)) impls
    in if (all (==True) matches)
         then pure ()
-        else Left (NotImplemented t interfaces) 
+        else Left (NotImplemented t (map snd (filter (\(tf, _) -> (not tf)) (zip matches interfaces))))
 
 -- | Get the type of a symbol at a given path.
 --
@@ -99,3 +136,17 @@ typeFromPath env p =
       | envIsExternal e -> forceTy found
       | otherwise -> error "Local bindings shouldn't be ambiguous."
     _ -> error ("Couldn't find " ++ show p ++ " in env:\n" ++ prettyEnvironmentChain env)
+
+-- | Get the paths of interface implementations.
+getImplementations :: XObj -> [SymPath]
+getImplementations (XObj (Lst ((XObj (Interface _ paths) _ _):_)) _ _) = paths
+getImplementations _ = []
+
+containsProtocol :: Ty -> Bool
+containsProtocol (FuncTy args ret _) = (any containsProtocol args) || containsProtocol ret
+containsProtocol (ProtocolTy _ _) = True
+containsProtocol _ = False
+
+isProtocol :: Ty -> Bool
+isProtocol (ProtocolTy _ _) = True
+isProtocol _ = False

--- a/src/Protocol.hs
+++ b/src/Protocol.hs
@@ -1,0 +1,101 @@
+-- | Defines functions for manipulating protocols.
+--
+-- Protocols are bundles of interfaces that can be used for forming type
+-- hierarchies.
+module Protocol
+  (registerInstance)
+where
+
+import Data.Either (rights)
+import Debug.Trace
+
+import Context
+import Interfaces
+import Obj
+import Qualify
+import Types
+import Util
+import Env
+import Forms
+
+--------------------------------------------------------------------------------
+-- Data
+
+-- | The type of protocol errors.
+data ProtocolError =
+  NotAType SymPath
+  | NotAProtocol SymPath
+  | NotImplemented Ty [SymPath]
+
+instance Show ProtocolError where
+  show (NotAType path) =
+    show path ++ "is not a type. Only types may be instances of protocols."
+  show (NotAProtocol path) =
+    show path ++ "is not a protocol."
+  show (NotImplemented ty paths) =
+    "The type " ++ show ty ++ " does not implement the following interfaces: " ++ joinWithComma (map show paths) ++ " which are required by the protocol."
+
+--------------------------------------------------------------------------------
+-- Protocol management functions
+
+-- | Add a type as a new instance of a protocol, returning an updated context.
+--
+-- Types will be rejected if there are no implementations of the protocol's
+-- interfaces that include the type.
+registerInstance :: Context -> SymPath -> SymPath -> Either ProtocolError Context
+registerInstance ctx protocol inst =
+  let qprotocol = markQualified protocol
+   in getProtocol ctx qprotocol
+      >>= \proto@(ProtocolPat _ interfaces _) -> getTypeFromPath inst
+      >>= \ty -> checkImplementations ctx interfaces ty
+      >> (updateProtocol proto inst ty)
+      >>= \newProto -> replaceLeft (NotAProtocol protocol) (replaceTypeBinder ctx qprotocol newProto)
+
+  where updateProtocol :: XObj -> SymPath -> Ty -> Either ProtocolError Binder
+        updateProtocol p@(ProtocolPat name interfaces instances) i iTy =
+          let  info   = xobjInfo p
+               newTy  = fmap (addInstance iTy) (xobjTy p)
+               newX   = XObj (Lst [XObj (Protocol interfaces (addIfNotPresent i instances)) info newTy, name]) info newTy
+           in pure $ toBinder newX
+        updateProtocol x _ _ = Left (NotAProtocol (getPath x))
+        addInstance :: Ty -> Ty -> Ty
+        addInstance i (ProtocolTy is) = (ProtocolTy (addIfNotPresent i is))
+        addInstance _ t = t      
+
+--------------------------------------------------------------------------------
+-- Private utilities
+
+-- | Given a context and path, try to retrieve an associated protocol.
+getProtocol :: Context -> QualifiedPath -> Either ProtocolError XObj 
+getProtocol ctx protocol = 
+  case lookupBinderInTypeEnv ctx protocol of 
+    Right (Binder _ x@(ProtocolPat _ _ _)) -> pure x
+    _ -> Left $ NotAProtocol (unqualify protocol)   
+
+-- | Just a wrapper around xobjToTy.
+getTypeFromPath :: SymPath -> Either ProtocolError Ty
+getTypeFromPath typath =
+  let x = XObj (Sym typath Symbol) Nothing Nothing
+   in maybe (Left (NotAType typath)) Right (xobjToTy x)
+  
+-- | Given a list of interfaces and a type, verify that the type appears in at
+-- least one implementation of each interface.
+checkImplementations :: Context -> [SymPath] -> Ty -> Either ProtocolError ()
+checkImplementations ctx interfaces t =
+  let actual  = traceShowId $ map binderXObj (rights (map (lookupBinderInTypeEnv ctx . markQualified) interfaces))
+      impls   = traceShowId $ map ((map (typeFromPath (contextGlobalEnv ctx))) . getImplementations) actual
+      matches = map (any ((flip isSubType) t)) impls
+   in if (all (==True) matches)
+        then pure ()
+        else Left (NotImplemented t interfaces) 
+
+-- | Get the type of a symbol at a given path.
+--
+-- TODO: Duplicated from Concretize to prevent inclusion loops. Fix.
+typeFromPath :: Env -> SymPath -> Ty
+typeFromPath env p =
+  case searchValue env p of
+    Right (e, Binder _ found)
+      | envIsExternal e -> forceTy found
+      | otherwise -> error "Local bindings shouldn't be ambiguous."
+    _ -> error ("Couldn't find " ++ show p ++ " in env:\n" ++ prettyEnvironmentChain env)

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -311,7 +311,8 @@ dynamicModule =
        in [ f "defdynamic" primitiveDefdynamic "defines a new dynamic value, i.e. a value available at compile time." "(defdynamic name value)",
             f "meta" primitiveMeta "gets the value under `\"mykey\"` in the meta map associated with a symbol. It returns `()` if the key isn’t found." "(meta mysymbol \"mykey\")",
             f "definterface" primitiveDefinterface "defines a new interface (which could be a function or symbol)." "(definterface mysymbol MyType)",
-            f "implements" primitiveImplements "designates a function as an implementation of an interface." "(implements zero Maybe.zero)"
+            f "implements" primitiveImplements "designates a function as an implementation of an interface." "(implements zero Maybe.zero)",
+            f "instance" primitiveInstance "designates a type as an instance of a protocol." "(instance <Protocol> <MyType>)"
           ]
     ternaries' =
       let f = makeTernaryPrim . spath
@@ -330,6 +331,7 @@ dynamicModule =
             f "column" primitiveColumn "returns the column a symbol was defined on." "(column mysymbol)",
             f "register-type" primitiveRegisterType "registers a new type from C." "(register-type Name <optional: c-name> <optional: members>)",
             f "defmodule" primitiveDefmodule "defines a new module in which `expressions` are defined." "(defmodule MyModule <expressions>)",
+            f "defprotocol" primitiveProtocol "defines a new protocol." "(defprotocol [interfaces])",
             f "register" primitiveRegister "registers a new function. This is used to define C functions and other symbols that will be available at link time." "(register name <signature> <optional: override>)",
             f "deftype" primitiveDeftype "defines a new sumtype or struct." "(deftype Name <members>)",
             f "help" primitiveHelp "prints help." "(help)"

--- a/src/TypePredicates.hs
+++ b/src/TypePredicates.hs
@@ -4,6 +4,7 @@ import Types
 
 isTypeGeneric :: Ty -> Bool
 isTypeGeneric (VarTy _) = True
+isTypeGeneric (ProtocolTy _ _) = True
 isTypeGeneric (FuncTy argTys retTy _) = any isTypeGeneric argTys || isTypeGeneric retTy
 isTypeGeneric (StructTy n tyArgs) = isTypeGeneric n || any isTypeGeneric tyArgs
 isTypeGeneric (PointerTy p) = isTypeGeneric p

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -28,6 +28,7 @@ module Types
     getNameFromStructName,
     getStructPath,
     promoteNumber,
+    isSubType,
   )
 where
 
@@ -68,6 +69,7 @@ data Ty
   | InterfaceTy
   | CTy -- C literals
   | Universe -- the type of types of types (the type of TypeTy)
+  | ProtocolTy [Ty] -- the type of protocols
   deriving (Eq, Ord, Generic)
 
 instance Hashable Ty
@@ -195,6 +197,7 @@ instance Show Ty where
   show DynamicTy = "Dynamic"
   show Universe = "Universe"
   show CTy = "C"
+  show (ProtocolTy is) = "(" ++ "Protocol " ++ joinWithSpace (map show is) ++ ")"
 
 showMaybeTy :: Maybe Ty -> String
 showMaybeTy (Just t) = show t
@@ -375,3 +378,8 @@ promoteNumber DoubleTy _ = DoubleTy
 promoteNumber _ DoubleTy = DoubleTy
 promoteNumber a b =
   error ("promoteNumber called with non-numbers: " ++ show a ++ ", " ++ show b)
+
+-- | Checks if one type contains another.
+isSubType :: Ty -> Ty -> Bool
+isSubType (FuncTy args ret _) t = (any (==t) args) || ret == t
+isSubType t t' = t == t'

--- a/src/TypesToC.hs
+++ b/src/TypesToC.hs
@@ -55,4 +55,5 @@ tyToCManglePtr _ ty = f ty
     f (PointerTy _) = err "pointers"
     f (RefTy _ _) = err "references"
     f CTy = "c_code" -- Literal C; we shouldn't emit anything.
+    f (ProtocolTy _) = err "protocols"
     err s = error ("Can't emit the type of " ++ s ++ ".")

--- a/src/TypesToC.hs
+++ b/src/TypesToC.hs
@@ -55,5 +55,5 @@ tyToCManglePtr _ ty = f ty
     f (PointerTy _) = err "pointers"
     f (RefTy _ _) = err "references"
     f CTy = "c_code" -- Literal C; we shouldn't emit anything.
-    f (ProtocolTy _) = err "protocols"
+    f (ProtocolTy _ _) = err "protocols"
     err s = error ("Can't emit the type of " ++ s ++ ".")


### PR DESCRIPTION
This PR adds initial support for `Protocols`, a sort of lightweight form of typeclasses. Given a collection of interfaces, protocols allow users to enforce type restrictions around the implementation of those interfaces. Before we get into the boring minutiae, it might be easier to see an example of how they work.

To define a protocol, use `defprotocol`

```clojure
;; to define a new protocol, we use `defprotocol`
;; defprotocol takes a name and one or more interfaces
(defprotocol Num + -)
:i Num
=> Num : (Protocol Num)
    Defined at line 1, column 14 in 'REPL'
    Required Definitions: +, -
```

Once we have a protocol defined, we can mark types as members of it using `instance`

```clojure
(instance Num Int)
:i Num
=> Num : (Protocol Num: Int)
    Defined at line 1, column 14 in 'REPL'
    Required Definitions: +, -
```

Of course, if the type doesn't implement the required interfaces, it won't be added to the protocol:

```clojure
(instance Num Char)
=> The type Char does not implement the following interfaces: +, - which are required by the protocol. at Core Primitives:0:0.

  Traceback:
    (instance Num Char) at REPL:5:1.
```

We can reference protocols in types to limit the acceptable types in otherwise fully polymorphic positions. To refer to a protocol in a type signature, prefix it with `!`. For example:

```clojure
(sig math (Fn [!Num !Num] !Num))
(defn math [x y] (- x (+ x y)))
```

Protocols leverage the same polymorphism resolution as our regular old variables, so nothing is resolved until we call this function. 

Let's try it with a valid `Num`:

```clojure
(math 2 3)
=> -3
```

and what about a type that doesn't implement the protocol, even though it implements the interfaces?

```clojure
(math 3.0 2.0)
=> I can’t match the types `Double` and `(Protocol Num: Int)`. within `(math 3.0 2.0)`

  3.0 : Double
  At line 12, column 7 in 'REPL'

  Expected first argument to 'math' : (Protocol Num: Int)
  At line 12, column 2 in 'REPL' at REPL:12:1.
```

oops. Lucky for us, `Double` already implements our interfaces:

```clojure
(instance Num Double)
(math 3.0 2.0)
=> -2
```

Finally, protocols can also be used for arbitrary "type tagging" or type unions simply by omitting any interfaces. One can use this to constrain the polymorphism of functions where desired without requiring additional interface implementations:

```clojure
(defprotocol Foo)
(sig foo (Fn [!Foo] String))
(defn foo [_] @"foo")
(instance Foo Int)
:i Foo
=> Foo : (Protocol Foo: Int)
    Defined at line 15, column 14 in 'REPL'
    Required Definitions:
(foo 3)
=> "foo"
(foo \w)
=> I can’t match the types `Char` and `(Protocol Foo: Int)`. within `(foo \w)`

  \w : Char
  At line 22, column 6 in 'REPL'

  Expected first argument to 'foo' : (Protocol Foo: Int)
  At line 22, column 2 in 'REPL' at REPL:22:1. 
```

Now that we know how it works, here are a couple of important implementation notes:

- Protocols have two representations, XObjs, and a corresponding Type. Only the XObj contains a list of the interfaces required, the type only contains a list of types known to be members of the protocol.
- The implementation of the protocols interfaces for a given type is checked at `instance` call time. If an implementation of a required interface doesn't yet exist in the environment when `instance` is called, adding the type to the protocol will fail.
- Interface implementations are checked by simple subtyping. One can't yet for instance, specify the required position of the type in the interface function implementation. Likewise, protocols are more like unions than typeclasses insofar as they stand in for a variable, rather than take one as an argument.
- Protocols are kept track of via the state of the type environment. When a new instance is added, the corresponding protocol is updated in the type env. Unfortunately this means parts of the code base that care about protocols need to call some functions `resolveProtocols` and `updateProtocols` (depending on whether or not the have access to a full context or just the type environment) in order to ensure they have the latest version of the protocol's memberships.
- They don't yet work for higher kinded types. I'll need to add support for this.
- Protocols are always added to the top level of the type environment. 
- In type signatures protocols must always be differentiated using `!`. They can share names with structs. When the `!` is absent, the type system will try to find a struct. Think of this as similar to haskell's `=>` delimiter for type classes vs types.