### PR TITLE
feat: Add additional ignore macros

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -133,6 +133,13 @@ Example:
 (defmacro forever-do [:rest forms]
   (list 'while true (cons 'do forms)))
 
+ (doc ignore-do 
+ ("Wraps side-effecting `forms` in a `do`, " false)
+ "ignoring all of their results."
+ "In other words, executes `forms` only for their side effects.")
+ (defmacro ignore-do [:rest forms]
+   (cons 'do (expand (apply ignore-all forms))))
+
 (doc when "is an `if` without an else branch.")
 (defmacro when [condition form]
   (list 'if condition form (list)))

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -138,7 +138,7 @@ Example:
  "ignoring all of their results."
  "In other words, executes `forms` only for their side effects.")
  (defmacro ignore-do [:rest forms]
-   (cons 'do (expand (apply ignore-all forms))))
+   (cons 'do (expand (apply ignore* forms))))
 
 (doc when "is an `if` without an else branch.")
 (defmacro when [condition form]

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -258,7 +258,7 @@ the filename and module name are the same.")
 (defmacro ignore [form]
   (list 'let (array '_ form) (list)))
 
-(doc ignore* "Wraps all forms passed as an argument in an ignore call.")
+(doc ignore* "Wraps all forms passed as an argument in a call to [`ignore`](#ignore).")
 (defmacro ignore* [:rest forms]
    (map (fn [x] (cons-last x (list 'ignore))) forms))
 

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -258,6 +258,10 @@ the filename and module name are the same.")
 (defmacro ignore [form]
   (list 'let (array '_ form) (list)))
 
+(doc ignore* "Wraps all forms passed as an argument in an ignore call.")
+(defmacro ignore* [:rest forms]
+   (map (fn [x] (cons-last x (list 'ignore))) forms))
+
 (doc const-assert
      "Asserts that the expression `expr` is true at compile time."
      "Otherwise it will fail with the message `msg`."

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -1,0 +1,15 @@
+(load "Test.carp")
+(use Test)
+
+(def test-string @"")
+
+(defn test-ignore-do []
+  (ignore-do (+ 2 2) ;; ignored
+             (set! test-string @"new-string") ;; ignored, but side-effect performed
+             (- 4 4)))
+
+(deftest test
+  (assert-true test
+    (and (= () (test-ignore-do)) (= &test-string "new-string"))
+    "ignore-do performs side effects and ignores all results")
+)


### PR DESCRIPTION
This commit adds two new ignore macros, ignore*, which wraps an
arbitrary number of forms in calls to `ignore` and ignore-do, which
wraps an arbitrary number of forms in ignore, then bundles the whole in
a do call, effectively executing each form only for side effects and
ignoring all results.