### PR TITLE
feat: allow C types to satisfy all type constraints

### DIFF
--- a/src/Constraints.hs
+++ b/src/Constraints.hs
@@ -177,6 +177,8 @@ solveOneInternal mappings constraint =
             Left err -> Left err
             Right ok -> foldM (\m (aa, bb) -> solveOneInternal m (Constraint aa bb i1 i2 ctx ord)) ok (zip args [b, ltB])
     -- Else
+    Constraint _ CTy _ _ _ _ -> Right mappings
+    Constraint CTy _ _ _ _ _ -> Right mappings
     Constraint aTy bTy _ _ _ _ ->
       if aTy == bTy
         then Right mappings

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -291,6 +291,8 @@ areUnifiable (FuncTy argTysA retTyA ltA) (FuncTy argTysB retTyB ltB)
         ltBool = areUnifiable ltA ltB
      in all (== True) (ltBool : retBool : argBools)
 areUnifiable FuncTy {} _ = False
+areUnifiable CTy _ = True
+areUnifiable _ CTy = True
 areUnifiable a b
   | a == b = True
   | otherwise = False


### PR DESCRIPTION
This commit builds on the emit-c feature by permitting C typed values to
be used anywhere in Carp code.

For example, if one wants to use the literal C macro `EDOM`:

```clojure
(register EDOM C "EDOM")

(Int.+ 1 EDOM)
=> 34
```

when compiled, this will produce the call:

```c
Int__PLUS(1, EDOM)
```

So it provides a quite flexible means of using C macros directly. It is,
of course, also radically unsafe. Anyone registering and using values of
the C type better be cautious.

One can get pretty crazy with this feature:

```clojure
(register comment-it C "// commented out;")

(Int.+ 1 comment-it)
=> int _11 = Int__PLUS_(1, // commented out;)
   int* _12 = &_11; // ref
   String _13 = IntRef_str(_12);
```