### PR TITLE
ci: Runs nixpkgs workflow only on master

### DIFF
--- a/.github/workflows/nixpkgs.yml
+++ b/.github/workflows/nixpkgs.yml
@@ -1,7 +1,9 @@
 name: "Nixpkgs CI"
 on:
-  pull_request:
   push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Only runs when commiting to master and on pull requests, like the Windows, MacOS and Linux CI.

This workflow was inconsistent with the other CIs.
