### PR TITLE
feat: add compiler error on maximum sumtype constructors

### DIFF
--- a/docs/LanguageGuide.md
+++ b/docs/LanguageGuide.md
@@ -237,7 +237,7 @@ Note that match works with *values* (not references) takes ownership over the va
 
 Note that this code would not take ownership over `might-be-a-string`. Also, the `s` in the first case is a reference, since it wouldn't be safe to destructure the `Maybe` into values in this situation.
 
-**Note:** A sumtype cannot have more than 256 inhabitants, also known as constructors. If that reads to you like a byte limitation, you’re on the right track. While this is a limitation, it has not proved to be a problem as of yet.
+**Note:** A sumtype cannot have more than 128 inhabitants, also known as constructors. If that reads to you like a byte limitation, you’re on the right track. While this is a limitation, it has not proved to be a problem as of yet.
 
 ### Modules and Name Lookup
 Functions and variables can be stored in modules which are named and can be nested. To use a symbol inside a module

--- a/docs/LanguageGuide.md
+++ b/docs/LanguageGuide.md
@@ -237,6 +237,8 @@ Note that match works with *values* (not references) takes ownership over the va
 
 Note that this code would not take ownership over `might-be-a-string`. Also, the `s` in the first case is a reference, since it wouldn't be safe to destructure the `Maybe` into values in this situation.
 
+**Note:** A sumtype cannot have more than 256 inhabitants, also known as constructors. If that reads to you like a byte limitation, you’re on the right track. While this is a limitation, it has not proved to be a problem as of yet.
+
 ### Modules and Name Lookup
 Functions and variables can be stored in modules which are named and can be nested. To use a symbol inside a module
 you need to qualify it with the module name, like this: `Float.cos`.

--- a/src/PrimitiveError.hs
+++ b/src/PrimitiveError.hs
@@ -19,6 +19,7 @@ data PrimitiveError
   | StructNotFound XObj
   | NonTypeInTypeEnv SymPath XObj
   | InvalidSumtypeCase XObj
+  | TooManySumtypeCases
 
 data PrimitiveWarning
   = NonExistentInterfaceWarning XObj
@@ -74,6 +75,8 @@ instance Show PrimitiveError where
   show (PrimitiveError.InvalidSumtypeCase xobj) =
     "Can't get members for an invalid sumtype case: "
       ++ pretty xobj
+  show TooManySumtypeCases =
+    "Got too many sumtype cases (>128) for type"
 
 instance Show PrimitiveWarning where
   show (NonExistentInterfaceWarning x) =


### PR DESCRIPTION
This PR adds a compiler error and a note to the docs on the maximum constructors we currently allow in a sumtype (128).

Cheers