### PR TITLE
fix: don't emit Unit type the casts

### DIFF
--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -532,7 +532,8 @@ toC toCMode (Binder meta root) = emitterSrc (execState (visit startingIndent roo
             var <- visit indent value
             let Just t = ty
                 fresh = mangle (freshVar info)
-            appendToSrc (addIndent indent ++ tyToCLambdaFix t ++ " " ++ fresh ++ " = " ++ var ++ "; // From the 'the' function.\n")
+            unless (isUnit t)
+              (appendToSrc (addIndent indent ++ tyToCLambdaFix t ++ " " ++ fresh ++ " = " ++ var ++ "; // From the 'the' function.\n"))
             pure fresh
         -- Ref
         [XObj Ref _ _, value] ->


### PR DESCRIPTION
Previously, the forms cast to the type Unit would still result in
variable assignment emissions, which produces invalid C.

Consider the case:

```clojure
;; type of System.exit is (Int -> a)
(defn main []
  (the () (System.exit 0)))
```

This previously produced bad variable assignments. It now works as
expected and emits only the function call.