### PR TITLE
test: add match given-away value error test

### DIFF
--- a/test/output/test/test-for-errors/match-given-away-value.carp.output.expected
+++ b/test/output/test/test-for-errors/match-given-away-value.carp.output.expected
@@ -1,0 +1,1 @@
+match-given-away-value.carp:9:16 Referencing a given-away value 'e'.

--- a/test/test-for-errors/match-given-away-value.carp
+++ b/test/test-for-errors/match-given-away-value.carp
@@ -1,0 +1,9 @@
+(Project.config "file-path-print-length" "short")
+
+(deftype Example (A [String String]))
+
+(defn f []
+  (let-do [e (Example.A @"x" @"y")]
+    (match e
+      (Example.A a b) ())
+    (println* &e)))


### PR DESCRIPTION
Add a test that checks for an error due to referencing a given-away value after match.