### PR TITLE
feat: Adds flag to always output C id with headerparse

### DIFF
--- a/docs/CInterop.md
+++ b/docs/CInterop.md
@@ -16,6 +16,7 @@ This is an extension of what is covered in the [Language Guide](./LanguageGuide.
   - [`preproc`](#unsafe-preproc)
   - [Registering Types](#register-types)
 - [Callbacks](#callbacks)
+- [Headerparse](#headerparse)
 
 
 ## How Carp generates identifiers
@@ -557,4 +558,40 @@ Because everything gets turned into a void pointer all type safety is lost so
 it is the responsibility of the caller to ensure the operation is safe. It is
 also important to ensure the lifetime of the `Ptr` doesn't not exceed the
 lifetime of the function/env it represents.
+
+## Headerparse
+
+`headerparse` is a Haskell script to aid in writing C bindings by parsing a C
+header and generating `register` and `register-type` for you. It resides in the
+`./headersparse` folder in Carp source repo and can be used in the following
+way:
+
+```sh
+stack runhaskell ./headerparse/Main.hs -- ../path/to/c/header.h
+```
+
+The script accepts the following flags:
+
+* `[-p|--prefixtoremove thePrefix]` Removes a prefix from the C identifiers
+* `[-f|--kebabcase]` Converts identifiers to kebab-case
+* `[-c|--emitcname]` Always emit the C identifier name after the binding
+
+### Example
+
+Invoking the script on this C header:
+
+```sh
+stack runhaskell ./headerparse/Main.hs -- -p "MyModule_" -f ../path/to/aheader.h
+```
+
+```c
+// aheader.h
+bool MyModule_runThisFile(const char *file);
+```
+
+Will output the following:
+
+```clojure
+(register run-this-file (λ [(Ptr CChar)] Bool) "MyModule_runThisFile")
+```
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -53,6 +53,7 @@ data Ty
   | StringTy
   | PatternTy
   | CharTy
+  | CCharTy
   | FuncTy [Ty] Ty Ty -- In order of appearance: (1) Argument types, (2) Return type, (3) Lifetime
   | VarTy String
   | UnitTy
@@ -171,6 +172,7 @@ instance Show Ty where
   show StringTy = "String"
   show PatternTy = "Pattern"
   show CharTy = "Char"
+  show CCharTy = "CChar"
   show (FuncTy argTys retTy StaticLifetimeTy) = "(" ++ fnOrLambda ++ " [" ++ joinWithComma (map show argTys) ++ "] " ++ show retTy ++ ")"
   show (FuncTy argTys retTy lt) = "(" ++ fnOrLambda ++ " [" ++ joinWithComma (map show argTys) ++ "] " ++ show retTy ++ " " ++ show lt ++ ")"
   show (VarTy t) = t

--- a/src/TypesToC.hs
+++ b/src/TypesToC.hs
@@ -39,6 +39,7 @@ tyToCManglePtr _ ty = f ty
     f StringTy = "String"
     f PatternTy = "Pattern"
     f CharTy = "Char"
+    f CCharTy = "CChar"
     f UnitTy = "void"
     f (VarTy x) = x
     f (FuncTy argTys retTy _) = "Fn__" ++ joinWithUnderscore (map (tyToCManglePtr True) argTys) ++ "_" ++ tyToCManglePtr True retTy


### PR DESCRIPTION
Adds -c|--emitcname flag to headerparse to always emit the C identifier
in `register` definitions (useful when the register will be in a
module).

Fixes a bug where the kebab case flag would not output C identifiers
making the emitted C identifiers not match with the ones in the headers.

Adds docs entry about headerparse in CInterop doc.

Makes headerparse emit `CChar` instead of `Char` when encountering a
signature containing `char`.
