### PR TITLE
fix: ensure registered types with fields emit path

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -4,8 +4,7 @@
 as, Regular Expressions. [See the docs for more
 information](../LanguageGuide.html#patterns).")
 (defmodule Pattern
-
-  (register-type MatchResult "PatternMatchResult" [start Int, end Int])
+  (register-type MatchResult [start Int, end Int])
   (defmodule MatchResult
     (defn ref-str [ref-matchres] 
       (fmt "(MatchResult start=%d end=%d)" 

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -269,7 +269,7 @@ primitiveRegisterTypeWithFields ctx x t override members =
           [ lookupBinderInTypeEnv contextWithDefs (markQualified (SymPath [] "str")),
             lookupBinderInTypeEnv contextWithDefs (markQualified (SymPath [] "prn"))
           ]
-    path = SymPath [] t
+    path = SymPath (contextPath ctx) t
     preExistingModule = case lookupBinderInGlobalEnv ctx path of
       Right (Binder _ (XObj (Mod found et) _ _)) -> Just (found, et)
       _ -> Nothing


### PR DESCRIPTION
This fixes an issue where by types with fields registered in modules
weren't emitted with their module paths. This makes the behavior between
RegisterTypeWithoutFields and RegisterTypeWithFields the same. They both
account for the current module path in which the type is registered and
output the emitted typedef appropriately.

This fix also eliminates the need for a workaround in core/Pattern.carp.
We previously had to register MatchResult with an override because of
the old behavior, but now the override is no longer needed (since
MatchResult is defined as PatternMatchResult in its source header).  The
call (register MatchResult) within (defmodule Pattern) emits
"PatternMatchResult" by default since we now account for module paths
for registered types.