### PR TITLE
docs: Instructions to ensure correct handling of utf-8

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -29,6 +29,20 @@ You should now be able to start Carp from anywhere:
 $ carp
 ```
 
+## Ensuring an UTF-8 aware LC_CTYPE locale in POSIX environments
+
+To be able to handle UTF-8 correctly when using `carp`'s interactive repl (binaries from `carp` always handle UTF-8 correctly),
+all POSIX aware environments (Linux, MacOs or even Emacs's eshell inside a Windows 10)
+need to have an `LC_CTYPE` environment variable set and exported to an UTF-8 aware value.
+
+For example, add this to your `.bashrc` or similar:
+```bash
+export LC_CTYPE=C.UTF-8
+```
+Take into account that the the environment variable `LC_ALL`, when set, overrides the value of `LC_CTYPE`.
+So you may want to `unset` `LC_ALL` or to set and export it to an UTF-8 aware value.
+You can see the values of `LC_ALL` and `LC_CTYPE` with the command `locale`.
+
 ## C compiler
 
 The `carp` executable will emit a single file with C code, `main.c` and try to compile it using an external C compiler.
@@ -59,3 +73,7 @@ Please let us know if you have trouble getting these bindings to work! We have t
 ## Footnote for Windows
 You can install clang with mingw64 but you'll also want to run `vcvarsall.bat amd64` or `vcvarsall.bat x86` each time you start your shell to help clang find the right headers.
 See https://github.com/carp-lang/Carp/issues/700 or https://github.com/carp-lang/Carp/issues/1323 for more information.
+
+Also when compiling files with `carp` from Windows you must ensure that :
+* the file is encoded either as ANSI or UTF-8. (Using another encoding like UTF-8-BOM doesn't work.)
+* using either Unix (LF) or Windows (CR LF) as linefeed/newline. (Using Macintosh (CR) as newline doesn't work.)


### PR DESCRIPTION
Should also update the release page with :
* For POSIX : ensure that the `LC_CTYPE` locale has an UTF-8 aware value

It would also be nice to implement something along the lines of this elisp snippet in `app/Main.hs` to warn the user. (Couldn't do it myself because I don't know haskell)

```elisp
(defun lc-ctype-is-utf8-compatible? (lc-ctype-value-str)
  (when (and
         ;; In Unix systems LC_CTYPE has always a value,
         ;; but Windows 10 doesn't have value for LC_CTYPE (and doesn't need it to handle UTF-8 correctly)
         lc-ctype-value-str
         ;; When lc-ctype-value-str has a value,
         ;; it is a very reliable heuristic to detect a POSIX system.
         (string-match
          ;; regex to match
          ;; either “.utf8” or “.utf-8”
          ;; at the end of the string
          "\\.utf-?8$"
          ;; downcase because the locale is case insensitive
          (downcase lc-ctype-value-str)))
    (message "Your `LC_CTYPE` environment variable isn't UTF-8 compatible.
This may cause odd behaviours in the repl. Please export it to a UTF-8 compatible value like `C.UTF-8`")))
```