### PR TITLE
fix: Fixes nix install by using correct pkg-configDepends config key

### DIFF
--- a/.github/workflows/nixpkgs.yml
+++ b/.github/workflows/nixpkgs.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@v16
       with:
-        nix_path: nixpkgs=channel:nixos-20.09
+        nix_path: nixpkgs=channel:nixos-21.05
     - run: nix-build

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ let
         cabal-install clang gdb
         ormolu hlint flamegraph ghc-prof-flamegraph
       ] ++ lib.optionals stdenv.isLinux [ linuxPackages.perf tinycc zig ];
-      pkgconfigDepends = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf glfw ];
+      pkg-configDepends = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf glfw ];
       enableLibraryProfiling = profiling;
       enableExecutableProfiling = profiling;
       enableSharedLibraries = false;


### PR DESCRIPTION
As reported by Hrafn Blóðbók, nix updated references to pkgconfig in its codebase to use the `pkg-config` spelling, this seems to break the installation of Carp using nix.

See this PR: https://github.com/NixOS/nixpkgs/commit/9bb3fccb5b55326cb3c2c507464a8a28d44d1730

The current error when installing:
```
error: anonymous function at /nix/var/nix/profiles/per-user/root/channels/nixos/pkgs/development/haskell-modules/generic-builder.nix:13:1 called with unexpected argument 'pkgconfigDepends'

       at /nix/var/nix/profiles/per-user/root/channels/nixos/lib/customisation.nix:69:16:

           68|     let
           69|       result = f origArgs;
             |                ^
           70|
```

We might need to update the nix action as well, just pushing it like this for now.
