### PR TITLE
fix: fix type signature of Array.unsafe-raw

### DIFF
--- a/src/ArrayTemplates.hs
+++ b/src/ArrayTemplates.hs
@@ -282,8 +282,7 @@ templateUnsafeRaw :: (String, Binder)
 templateUnsafeRaw =
   defineTemplate
     (SymPath ["Array"] "unsafe-raw")
-    -- TODO: Fix me! Order of members of Ref is incorrect.
-    (FuncTy [RefTy (VarTy "q") (StructTy (ConcreteNameTy (SymPath [] "Array")) [VarTy "t"])] (PointerTy (VarTy "t")) StaticLifetimeTy)
+    (FuncTy [RefTy (StructTy (ConcreteNameTy (SymPath [] "Array")) [VarTy "t"]) (VarTy "q")] (PointerTy (VarTy "t")) StaticLifetimeTy)
     "returns an array `a` as a raw pointer—useful for interacting with C."
     (toTemplate "$t* $NAME (Array* a)")
     (toTemplate "$DECL { return a->data; }")


### PR DESCRIPTION
The Ref in the type signature had the array and lifetime type in the
incorrect position.