### PR TITLE
fix: mangle field names in setter templates

### DIFF
--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -288,7 +288,7 @@ setterGenerator = TG.mkTemplateGenerator tgen decl body deps
     body GeneratorArg {tenv, env, instanceT = (FuncTy [_, ty] _ _), value = (TC.StructField name _)} =
       multilineTemplate
         [ "$DECL {",
-          memberDeletion tenv env (name, ty),
+          memberDeletion tenv env (mangle name, ty),
           "    p." ++ (mangle name) ++ " = newValue;",
           "    return p;",
           "}\n"
@@ -319,7 +319,7 @@ mutatorGenerator = TG.mkTemplateGenerator tgen decl body deps
     body GeneratorArg {tenv, env, instanceT = (FuncTy [_, ty] _ _), value = (TC.StructField name _)} =
       multilineTemplate
         [ "$DECL {",
-          memberRefDeletion tenv env (name, ty),
+          memberRefDeletion tenv env (mangle name, ty),
           "    pRef->" ++ mangle name ++ " = newValue;",
           "}\n"
         ]

--- a/test/regression.carp
+++ b/test/regression.carp
@@ -100,6 +100,13 @@
 (defn poly-nest-two [x] (Bar.Qux.init (Bar.Baz x)))
 (defn poly-nest-three [x] (PolyNest (Bar.Baz x)))
 
+;; struct field names are mangled correctly (#1378)
+(deftype Mangled 
+  [short Int  ;; c reserved word
+   default-value String ;; invalid var name symbol (-)
+  ]
+ )
+
 (deftest test
   (assert-equal test
                 1
@@ -160,4 +167,9 @@
                 @(Bar.Baz.it (PolyNest.it &(poly-nest-three 2)))
                 "test that polymorphic types in modules can be referred to using
                 other types outside the module")
+  (assert-equal test
+    "bar" 
+    (Mangled.default-value &(Mangled.set-default-value (Mangled.init 0 @"foo")
+    @"bar"))
+    "struct field names are mangled correctly")
 )


### PR DESCRIPTION
This fixes a regression whereby the names of struct fields weren't
mangled in calls to setters/mutators, resulting in invalid C code if the
user happened to use reserved words in their struct field names such as
"short" or a disallowed character like a dash.

Fixes #1378 