### PR TITLE
fix: fix leading % format in fmt

### DIFF
--- a/core/Format.carp
+++ b/core/Format.carp
@@ -14,7 +14,7 @@
         (if (= \% (String.char-at s (inc idx))) ; this is an escaped %
           `(ref
             (String.append
-                "%"
+                %(String.slice s 0 (inc idx))
                 %(fmt-internal (String.slice s (+ idx 2) len) args)))
           (if (= 0 (length args)) ; we need to insert something, but have nothing
             (macro-error

--- a/test/format.carp
+++ b/test/format.carp
@@ -35,6 +35,10 @@
                 &(fmt "%d %% %.1f %s" 10 12.0 "yay")
                 "fmt macro works")
   (assert-equal test
+                "hi % 12.0"
+                &(fmt "hi %% %.1f" 12.0)
+                "fmt macro works with leading % (regression test)")
+  (assert-equal test
                 "1 [2 3] h"
                 &(let [x 1
                        y [2 3]


### PR DESCRIPTION
The macro `fmt` had a bug that lead to the start of the string being cut off when the first formatting directive was a literal percent (as in `%%`). Example:

```clojure
> (IO.println &(fmt "hi %% bye"))
% bye
```

Now this behavior is fixed and a regression test case was added.

Cheers