### PR TITLE
ci: Fixes scoop install as admin user

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
       - if: matrix.os == 'Windows'
         name: Install Scoop
         run: |
-          iwr -useb get.scoop.sh | iex
+          iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+          ./install-scoop.ps1 -RunAsAdmin
           echo "~\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\ProgramData\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
            artefact-name: "x86_64-macos"
 
          - os: Windows
-           runner: windows-latest
+           runner: windows-2022
            artefact-name: "x86_64-windows"
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,25 +27,28 @@ jobs:
       - uses: actions/cache@v1
         name: Cache stack dependencies
         with:
-          path: C:\\Users\\runneradmin\\AppData\\Local\\Programs\\stack
+          path: C:\Users\runneradmin\AppData\Local\Programs\stack
           key: ${{ runner.os }}-stack-deps-${{ github.sha }}
           restore-keys: ${{ runner.os }}-stack-deps
 
       - uses: actions/cache@v1
         name: Cache stack build
         with:
-          path: C:\\Users\\runneradmin\\AppData\\Roaming\\stack\
+          path: C:\Users\runneradmin\AppData\Roaming\stack
           key: ${{ runner.os }}-stack-build-${{ github.sha }}
           restore-keys: ${{ runner.os }}-stack-build
-
-      - name: Install Clang
-        run: scoop install llvm --global
 
       - name: Build
         run: stack build
 
       - name: Run Compiler Tests
         run: stack test
+
+      # Disabling sanitize-addresses because it fails with following error:
+      # https://github.com/actions/virtual-environments/issues/4978
+      - name: Disable Debug.sanitize-addresses
+        shell: bash
+        run: find ./test ./examples -type f -name '*.carp' | xargs sed 's/^\((Debug.sanitize-addresses)\)/; \1/g' -i
 
       - name: Run Carp Tests
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Install Scoop
         run: |
-          iwr -useb get.scoop.sh | iex
+          iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+          ./install-scoop.ps1 -RunAsAdmin
           echo "~\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\ProgramData\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2016
+    runs-on: windows-2022
 
     steps:
       - name: Check out


### PR DESCRIPTION
This fixes error in Windows pipelines by [forcing the scoop installer](https://github.com/ScoopInstaller/Install#for-admin) to run.

I don't believe there is much point in not-running as Admin given the environment the CI runs in.

Edit: had to upgrade the Windows version because 2016 is getting deprecated but it comes with ASAN errors we've seen before.