### PR TITLE
feat: add maybe and result thread macros

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -46,6 +46,26 @@ Example:
 (defmacro -> [:rest forms]
   (thread-first-internal forms))
 
+(doc ?-> 
+  ("threads the value contained in a maybe through the following " false)
+  "forms iff, the Maybe is a Just."
+  ""
+  "Returns Nothing if the Maybe is Maybe.Nothing.")
+(defmacro ?-> [maybe :rest forms]
+  (list 'match maybe
+    (list 'Maybe.Just 'v) (list 'Maybe.Just (thread-first-internal (cons 'v forms)))
+    '_ (list 'Maybe.Nothing)))
+
+(doc /-> 
+  ("threads the value contained in a Result through the following" false) 
+  "forms iff, the Result is a Success"
+  ""
+  "Returns the erorr if the Result is Result.Error.")
+(defmacro /-> [result :rest forms]
+  (list 'match result
+    (list 'Result.Success 'v) (list 'Result.Success (thread-first-internal (cons 'v forms)))
+    'y 'y))
+
 (doc --> "threads the first form through the following ones, making it the last
 argument.
 


### PR DESCRIPTION
These macros each thread the value of a Maybe or Result through
subsequent forms only when the Maybe or Result is a Just/Success value,
returning Nothing/Error otherwise.

It's a convenient way to execute some sequence of forms when a
Maybe/Result returning function is successful, immediately returning the
error value otherwise.

Example:

```clojure
(defn foo [x] (?-> x (+ 2) (+ 4)))
(foo (Maybe.Just 2)) ;=> (Maybe.Just 6)
(foo (Maybe.Nothing)) ;=> (Maybe.Nothing)
(defn foo [x] (/-> x (+ 2) (+ 4)))
(foo (Result.Success 2)) ;=> (Result.Success 6) ;; you'd actually need a `the` to type check the RESULT in real code 
(foo (Result.Error @"err")) ;=> (Result.Error @"err")
```