### PR TITLE
chore: Updates Stackage version to 19.2

### DIFF
--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -627,17 +627,15 @@ balance text =
       parens <- Parsec.getState
       case parens of
         [] -> push c
-        '"' : xs -> case c of
-          '\\' -> do
-            _ <- Parsec.anyChar -- consume next
-            pure ()
-          '"' -> Parsec.putState xs -- close string
-          _ -> pure () -- inside string
         (x : xs) -> case (x, c) of
           ('(', ')') -> Parsec.putState xs
           ('[', ']') -> Parsec.putState xs
           ('{', '}') -> Parsec.putState xs
-          ('"', '"') -> Parsec.putState xs
+          ('"', '"') -> Parsec.putState xs -- close string
+          ('"', '\\') -> do
+            _ <- Parsec.anyChar -- consume next
+            pure ()
+          ('"', _) -> pure ()
           --('\\', _) -> Parsec.putState xs -- ignore char after '\'
           _ -> push c
     push :: Char -> Parsec.Parsec String String ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-15.3
+resolver: lts-19.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/dynamic_map.carp
+++ b/test/dynamic_map.carp
@@ -1,189 +1,206 @@
 (load "Test.carp")
 (use Test)
 
+(doc list-equal-unordered "Checks two lists have the same values, not necessarily in the same order")
+(defndynamic list-equal-unordered [lx ly]
+  (if (not (= (length lx) (length ly)))
+   false
+   (car (reduce (fn [state x]
+                 (let [keep-going (car state)
+                       l (cadr state)]
+                   (if (not keep-going)
+                     '(false ())
+                     (let [index (List.find-index l (curry = x))]
+                        (if (nil? index)
+                          '(false ())
+                          (list true (List.remove-nth l index)))))))
+               (list true ly)
+               lx))))
+
 (deftest test
   (assert-dynamic-equal test
                         "2"
                         (Map.get (Map.put (Map.create) "1" "2") "1")
-                        "basic put and get works"
-  )
+                        "basic put and get works")
+
   (assert-dynamic-equal test
                         "3"
                         (Map.get (Map.put (Map.put (Map.create) "1" "2") "1" "3") "1")
-                        "put, update and get"
-  )
+                        "put, update and get")
+
   (assert-dynamic-equal test
                         nil
                         (Map.get (Map.create) "1")
-                        "get works with defaults"
-  )
+                        "get works with defaults")
+
   (assert-dynamic-equal test
                         true
                         (Map.empty? (Map.update (Map.create) "x" inc))
-                        "update works with empty map"
-  )
+                        "update works with empty map")
+
   (assert-dynamic-equal test
                         2
                         (Map.get (Map.update {"x" 1} "x" inc) "x")
-                        "update works"
-    )
+                        "update works")
+
   (assert-dynamic-equal test
                         \x
                         (Map.get-with-default {1 \x} 1 \_)
-                        "get-with-default works I"
-  )
+                        "get-with-default works I")
+
   (assert-dynamic-equal test
                         \_
                         (Map.get-with-default {1 \x} 2 \_)
-                        "get-with-default works II"
-  )
+                        "get-with-default works II")
+
   (assert-dynamic-equal test
                         8
                         (Map.get (Map.update-with-default (Map.create) "x" inc 7) "x")
-                        "update-with-default works with empty map"
-  )
+                        "update-with-default works with empty map")
+
   (assert-dynamic-equal test
                         2
                         (Map.get (Map.update-with-default {"x" 1} "x" inc 7) "x")
-                        "update-with-default works"
-  )
+                        "update-with-default works")
+
   (assert-dynamic-equal test
                         1
                         (Map.len (Map.put (Map.create) "1" "2"))
-                        "len works"
-  )
+                        "len works")
+
   (assert-dynamic-equal test
                         0
                         (Map.len (Map.create))
-                        "length works on empty map"
-  )
+                        "length works on empty map")
+
   (assert-dynamic-equal test
                         false
                         (Map.contains? (Map.create) "1")
-                        "contains? works on empty map"
-  )
+                        "contains? works on empty map")
+
   (assert-dynamic-equal test
                         true
                         (Map.contains? (Map.put (Map.create) "1" "2") "1")
-                        "contains? works"
-  )
+                        "contains? works")
+
   (assert-dynamic-equal test
                         true
                         (Map.contains? (Map.put (Map.create) -7 "2") -7)
-                        "contains? works with negative keys"
-  )
+                        "contains? works with negative keys")
+
   (assert-dynamic-equal test
                         false
                         (Map.contains? (Map.put (Map.create) 1 "2") -7)
-                        "contains? works with negative keys"
-  )
+                        "contains? works with negative keys")
+
   (assert-dynamic-equal test
                         true
                         (Map.empty? (Map.create))
-                        "empty? works on empty map"
-  )
+                        "empty? works on empty map")
+
   (assert-dynamic-equal test
                         false
                         (Map.empty? (Map.put (Map.create) "1" "2"))
-                        "empty? works"
-  )
+                        "empty? works")
+
   (assert-dynamic-equal test
                         true
                         (Map.empty? (Map.remove (Map.put (Map.create) "1" "2") "1"))
-                        "remove works"
-  )
+                        "remove works")
+
   (assert-dynamic-equal test
                         true
                         (Map.all? (fn [p] (or (even? (car p)) (cadr p)))
                                   {1 true 2 false 4 false})
-                        "Map.all? works I"
-  )
+                        "Map.all? works I")
+
   (assert-dynamic-equal test
                         false
                         (Map.all? (fn [p] (or (even? (car p)) (cadr p)))
                                   {1 true 2 false 5 false})
-                        "Map.all? works II"
-  )
+                        "Map.all? works II")
+
   (assert-dynamic-equal test
                         true
                         (Map.= {1 2 3 4} {1 2 3 4})
-                        "Map.= works I"
-  )
+                        "Map.= works I")
+
   (assert-dynamic-equal test
                         false
                         (Map.= {1 2 3 4} {1 2 3 5})
-                        "Map.= works II"
-  )
+                        "Map.= works II")
+
   (assert-dynamic-equal test
                         false
                         (Map.= {1 2 3 4} {1 2})
-                        "Map.= works III"
-  )
+                        "Map.= works III")
+
   (assert-dynamic-equal test
                         2
                         (Map.len (Map.from-array [(Pair.init 1 2)
                                                   (Pair.init 3 4)]))
-                        "creating a map from an array works"
-  )
+                        "creating a map from an array works")
+
   (assert-dynamic-equal test
                         "{ 1 2 }"
                         (Map.str (Map.from-array [(Pair.init 1 2)]))
-                        "stringification works I"
-  )
+                        "stringification works I")
+
   (assert-dynamic-equal test
                         ; TODO: should we escape strings?
                         "{ hi bye }"
                         (Map.str (Map.from-array [(Pair.init "hi" "bye")]))
-                        "stringification works II"
-  )
+                        "stringification works II")
+
   (assert-dynamic-equal test
                         [(Pair.init 1 2)]
                         (Map.to-array (Map.put (Map.create) 1 2))
-                        "Map.to-array works 1"
-  )
+                        "Map.to-array works 1")
+
   (assert-dynamic-equal test
                         2
                         (length (Map.to-array (Map.from-array [(Pair.init 1 2)
                                                                (Pair.init 3 4)])))
-                        "Map.to-array works 2"
-  )
+                        "Map.to-array works 2")
+
   (assert-dynamic-equal test
-                        "{ 1 12 3 34 }"
-                        (Map.str (Map.map (fn [p] (+ (cadr p) (* 10 (car p)))) {1 2 3 4}))
-                        "map works"
-  )
+                        { 1 12 3 34}
+                        (Map.map (fn [p] (+ (cadr p) (* 10 (car p)))) {1 2 3 4})
+                        "map works")
+
   (assert-dynamic-equal test
                         641
                         (Map.kv-reduce (fn [sum p] (+ sum (+ (* 100 (car p)) (* 10 (cadr p)))))
                                        1
                                        {1 1 2 1 3 2})
-                        "kv-reduce works"
-  )
-  (assert-dynamic-equal test
-                        '(1 2 3)
-                        (Map.keys {1 1 2 1 3 2})
-                        "keys works"
-  )
-  (assert-dynamic-equal test
-                        '(1 1 2)
-                        (Map.vals {1 1 2 1 3 2})
-                        "vals works"
-  )
+                        "kv-reduce works")
+
+  (assert-dynamic-op test
+                     '(1 2 3)
+                     (Map.keys {1 1 2 1 3 2})
+                     "keys works"
+                     list-equal-unordered)
+
+  (assert-dynamic-op test
+                     '(1 1 2)
+                     (Map.vals {1 1 2 1 3 2})
+                     "vals works"
+                     list-equal-unordered)
+
   (assert-dynamic-equal test
                         3
                         (Map.get {(Pair.init 1 2) 3} (Pair.init 1 2))
-                        "Pairs work as keys"
-  )
+                        "Pairs work as keys")
+
   (assert-dynamic-op test
                      {1 "hi" 2 "bye"}
                      (Map.reverse {"hi" 1 "bye" 2})
                      "reverse works"
-                     Map.=
-  )
+                     Map.=)
+
   (assert-dynamic-op test
                      {1 "hi" 2 "bye" 3 "!"}
                      (Map.merge {1 "bye" 3 "!"} {2 "bye" 1 "hi"})
                      "merge works"
-                     Map.=
-  )
-)
+                     Map.=))
+

--- a/test/dynamic_map.carp
+++ b/test/dynamic_map.carp
@@ -2,8 +2,8 @@
 (use Test)
 
 (doc list-equal-unordered "Checks two lists have the same values, not necessarily in the same order")
-(defndynamic list-equal-unordered [lx ly]
-  (if (not (= (length lx) (length ly)))
+(defndynamic list-equal-unordered [xs ys]
+  (if (not (= (length xs) (length ys)))
    false
    (car (reduce (fn [state x]
                  (let [keep-going (car state)
@@ -14,8 +14,8 @@
                         (if (nil? index)
                           '(false ())
                           (list true (List.remove-nth l index)))))))
-               (list true ly)
-               lx))))
+               (list true ys)
+               xs))))
 
 (deftest test
   (assert-dynamic-equal test


### PR DESCRIPTION
Comes with GHC 9.0.2.

Some tests in `test/dynamic_map.carp` were updated to not be order dependent. 