### PR TITLE
feat: register MAX and MIN macros for stdint types

### DIFF
--- a/core/Double.carp
+++ b/core/Double.carp
@@ -6,6 +6,7 @@
   (implements pi Double.pi)
   (def e 2.718281828459045)
   (register MAX Double "CARP_DBL_MAX")
+  (implements MAX MAX)
   (register = (Fn [Double Double] Bool))
   (register < (Fn [Double Double] Bool))
   (register > (Fn [Double Double] Bool))

--- a/core/Float.carp
+++ b/core/Float.carp
@@ -5,6 +5,7 @@ suffixed with `f`.")
 (defmodule Float
   (def pi 3.1415926536f)
   (register MAX Float "CARP_FLT_MAX")
+  (implements MAX MAX)
   (register neg (Fn [Float] Float))
   (register + (Fn [Float Float] Float))
   (register - (Fn [Float Float] Float))

--- a/core/Int.carp
+++ b/core/Int.carp
@@ -41,7 +41,9 @@
 
 (defmodule Int
   (register MAX Int "CARP_INT_MAX")
+  (implements MAX MAX)
   (register MIN Int "CARP_INT_MIN")
+  (implements MIN MIN)
   (register bit-shift-left (λ [Int Int] Int))
   (register bit-shift-right (λ [Int Int] Int))
   (register bit-and (λ [Int Int] Int))

--- a/core/Interfaces.carp
+++ b/core/Interfaces.carp
@@ -63,6 +63,8 @@
 (definterface sqrt (λ [a] a))
 (definterface tan (λ [a] a))
 (definterface tanh (λ [a] a))
+(definterface MAX a)
+(definterface MIN a)
 
 (definterface slice (Fn [&a Int Int] a))
 

--- a/core/Long.carp
+++ b/core/Long.carp
@@ -4,7 +4,9 @@
 `l`.")
 (defmodule Long
   (register MAX Long "LONG_MAX")
+  (implements MAX MAX)
   (register MIN Long "LONG_MIN")
+  (implements MIN MIN)
   (register + (λ [Long Long] Long))
   (register - (λ [Long Long] Long))
   (register * (λ [Long Long] Long))

--- a/core/StdInt.carp
+++ b/core/StdInt.carp
@@ -29,7 +29,9 @@ integer.")
   (register from-long (λ [Long] Int8))
   (register copy (Fn [&Int8] Int8))
   (register MAX Int8 "CARP_INT8_MAX")
+  (implements MAX MAX)
   (register MIN Int8 "CARP_INT8_MIN")
+  (implements MIN MIN)
 
   (defn zero [] (from-long 0l))
 
@@ -77,7 +79,9 @@ integer.")
   (register from-long (λ [Long] Int16))
   (register copy (Fn [&Int16] Int16))
   (register MAX Int16 "CARP_INT16_MAX")
+  (implements MAX MAX)
   (register MIN Int16 "CARP_INT16_MIN")
+  (implements MIN MIN)
 
   (defn zero [] (from-long 0l))
 
@@ -125,7 +129,9 @@ integer.")
   (register from-long (λ [Long] Int32))
   (register copy (Fn [&Int32] Int32))
   (register MAX Int32 "CARP_INT32_MAX")
+  (implements MAX MAX)
   (register MIN Int32 "CARP_INT32_MIN")
+  (implements MIN MIN)
 
   (defn zero [] (from-long 0l))
 
@@ -173,7 +179,9 @@ integer.")
   (register from-long (λ [Long] Int64))
   (register copy (Fn [&Int64] Int64))
   (register MAX Int64 "CARP_INT64_MAX")
+  (implements MAX MAX)
   (register MIN Int64 "CARP_INT64_MIN")
+  (implements MIN MIN)
 
   (defn zero [] (from-long 0l))
 
@@ -221,6 +229,7 @@ integer.")
   (register from-long (λ [Long] Uint8))
   (register copy (Fn [&Uint8] Uint8))
   (register MAX Uint8 "CARP_UINT8_MAX")
+  (implements MAX MAX)
 
   (defn zero [] (from-long 0l))
 
@@ -268,6 +277,7 @@ integer.")
   (register from-long (λ [Long] Uint16))
   (register copy (Fn [&Uint16] Uint16))
   (register MAX Uint16 "CARP_UINT16_MAX")
+  (implements MAX MAX)
 
   (defn zero [] (from-long 0l))
 
@@ -315,6 +325,7 @@ integer.")
   (register from-long (λ [Long] Uint32))
   (register copy (Fn [&Uint32] Uint32))
   (register MAX Uint32 "CARP_UINT32_MAX")
+  (implements MAX MAX)
 
   (defn zero [] (from-long 0l))
 
@@ -362,6 +373,7 @@ integer.")
   (register from-long (λ [Long] Uint64))
   (register copy (Fn [&Uint64] Uint64))
   (register MAX Uint64 "CARP_UINT64_MAX")
+  (implements MAX MAX)
 
   (defn zero [] (from-long 0l))
 

--- a/core/StdInt.carp
+++ b/core/StdInt.carp
@@ -28,6 +28,8 @@ integer.")
   (register to-long (λ [Int8] Long))
   (register from-long (λ [Long] Int8))
   (register copy (Fn [&Int8] Int8))
+  (register MAX Int8 "CARP_INT8_MAX")
+  (register MIN Int8 "CARP_INT8_MIN")
 
   (defn zero [] (from-long 0l))
 
@@ -74,6 +76,8 @@ integer.")
   (register to-long (λ [Int16] Long))
   (register from-long (λ [Long] Int16))
   (register copy (Fn [&Int16] Int16))
+  (register MAX Int16 "CARP_INT16_MAX")
+  (register MIN Int16 "CARP_INT16_MIN")
 
   (defn zero [] (from-long 0l))
 
@@ -120,6 +124,8 @@ integer.")
   (register to-long (λ [Int32] Long))
   (register from-long (λ [Long] Int32))
   (register copy (Fn [&Int32] Int32))
+  (register MAX Int32 "CARP_INT32_MAX")
+  (register MIN Int32 "CARP_INT32_MIN")
 
   (defn zero [] (from-long 0l))
 
@@ -166,6 +172,8 @@ integer.")
   (register to-long (λ [Int64] Long))
   (register from-long (λ [Long] Int64))
   (register copy (Fn [&Int64] Int64))
+  (register MAX Int64 "CARP_INT64_MAX")
+  (register MIN Int64 "CARP_INT64_MIN")
 
   (defn zero [] (from-long 0l))
 
@@ -212,6 +220,7 @@ integer.")
   (register to-long (λ [Uint8] Long))
   (register from-long (λ [Long] Uint8))
   (register copy (Fn [&Uint8] Uint8))
+  (register MAX Uint8 "CARP_UINT8_MAX")
 
   (defn zero [] (from-long 0l))
 
@@ -258,6 +267,7 @@ integer.")
   (register to-long (λ [Uint16] Long))
   (register from-long (λ [Long] Uint16))
   (register copy (Fn [&Uint16] Uint16))
+  (register MAX Uint16 "CARP_UINT16_MAX")
 
   (defn zero [] (from-long 0l))
 
@@ -304,6 +314,7 @@ integer.")
   (register to-long (λ [Uint32] Long))
   (register from-long (λ [Long] Uint32))
   (register copy (Fn [&Uint32] Uint32))
+  (register MAX Uint32 "CARP_UINT32_MAX")
 
   (defn zero [] (from-long 0l))
 
@@ -350,6 +361,7 @@ integer.")
   (register to-long (λ [Uint64] Long))
   (register from-long (λ [Long] Uint64))
   (register copy (Fn [&Uint64] Uint64))
+  (register MAX Uint64 "CARP_UINT64_MAX")
 
   (defn zero [] (from-long 0l))
 

--- a/core/carp_stdint.h
+++ b/core/carp_stdint.h
@@ -7,6 +7,20 @@ typedef int16_t Int16;
 typedef int32_t Int32;
 typedef int64_t Int64;
 
+uint8_t CARP_UINT8_MAX = UINT8_MAX;
+uint16_t CARP_UINT16_MAX = UINT16_MAX;
+uint32_t CARP_UINT32_MAX = UINT32_MAX;
+uint64_t CARP_UINT64_MAX = UINT64_MAX;
+
+int8_t CARP_INT8_MAX = INT8_MAX;
+int8_t CARP_INT8_MIN = INT8_MIN;
+int16_t CARP_INT16_MAX = INT16_MAX;
+int16_t CARP_INT16_MIN = INT16_MIN;
+int32_t CARP_INT32_MAX = INT32_MAX;
+int32_t CARP_INT32_MIN = INT32_MIN;
+int64_t CARP_INT64_MAX = INT64_MAX;
+int64_t CARP_INT64_MIN = INT64_MIN;
+
 Uint8 Uint8__PLUS_(Uint8 x, Uint8 y) {
     return x + y;
 }

--- a/src/Info.hs
+++ b/src/Info.hs
@@ -12,12 +12,14 @@ module Info
     makeTypeVariableNameFromInfo,
     setDeletersOnInfo,
     addDeletersToInfo,
+    uniqueDeleter,
   )
 where
 
 import Path (takeFileName)
 import qualified Set
 import SymPath
+import Data.List (unionBy)
 
 -- | Information about where the Obj originated from.
 data Info = Info
@@ -57,6 +59,20 @@ instance Show Deleter where
   show (FakeDeleter var) = "(FakeDel " ++ show var ++ ")"
   show (PrimDeleter var) = "(PrimDel " ++ show var ++ ")"
   show (RefDeleter var) = "(RefDel " ++ show var ++ ")"
+
+-- | Get the variable name associated with a deleter.
+deleterVar :: Deleter -> String
+deleterVar (ProperDeleter _ _ v) = v
+deleterVar (FakeDeleter v) = v
+deleterVar (PrimDeleter v) = v
+deleterVar (RefDeleter v) = v
+
+-- | Given two sets of deleters, take only a single deleter for each variable.
+--
+-- Left biased in the case of duplicates.
+uniqueDeleter :: Set.Set Deleter -> Set.Set Deleter -> Set.Set Deleter
+uniqueDeleter xs ys =
+  Set.fromList (unionBy (\x y -> deleterVar x == deleterVar y) (Set.toList xs) (Set.toList ys))
 
 -- | Whether or not the full path of a source file or a short path should be
 -- printed.

--- a/src/Memory.hs
+++ b/src/Memory.hs
@@ -447,7 +447,8 @@ manageMemory typeEnv globalEnv root =
       do
         visitedExpr <- visit expr
         addToLifetimesMappingsIfRef True expr
-        result <- transferOwnership typeEnv globalEnv expr name
+        -- ensures this deleter is the only deleter associated with name for the duration of the let scope (shadowing).
+        result <- exclusiveTransferOwnership typeEnv globalEnv expr name
         whenRightReturn result $ do
           okExpr <- visitedExpr
           pure (name, okExpr)
@@ -521,6 +522,21 @@ transferOwnership typeEnv globalEnv from to =
       manage typeEnv globalEnv to --(trace ("Transfered from " ++ getName from ++ " '" ++ varOfXObj from ++ "' to " ++ getName to ++ " '" ++ varOfXObj to ++ "'") to)
       pure (Right ())
 
+-- | Transfer ownership, and ensure the resulting set has only *one* deleter per variable.
+--
+-- Multiple deleters can arise when one variable shadows an earlier one from a wider scope.
+-- see issue #597
+exclusiveTransferOwnership :: TypeEnv -> Env -> XObj -> XObj -> State MemState (Either TypeError ())
+exclusiveTransferOwnership tenv genv from to =
+  do result <- unmanage tenv genv from
+     whenRight result $ do
+       MemState pre deps lts <- get
+       put (MemState Set.empty deps lts) -- add just this new deleter to the set
+       manage tenv genv to
+       MemState post postDeps postLts <- get
+       put (MemState (uniqueDeleter post pre) postDeps postLts) -- replace any duplicates and union with the prior set
+       pure (Right ())
+
 -- | Control that an `xobj` is OK to reference
 canBeReferenced :: TypeEnv -> Env -> XObj -> State MemState (Either TypeError ())
 canBeReferenced typeEnv globalEnv xobj =
@@ -574,7 +590,9 @@ refTargetIsAlive xobj =
                   [] ->
                     --trace ("Can't use reference " ++ pretty xobj ++ " (with lifetime '" ++ lt ++ "', depending on " ++ show deleterName ++ ") at " ++ prettyInfoFromXObj xobj ++ ", it's not alive here:\n" ++ show xobj ++ "\nMappings: " ++ prettyLifetimeMappings lifetimeMappings ++ "\nAlive: " ++ show deleters ++ "\n") $
                     --pure (Right xobj)
-                    pure (Left (UsingDeadReference xobj deleterName))
+                    pure (case xobjObj xobj of
+                           (Lst (LetPat _ _ body)) -> (Left (UsingDeadReference body deleterName))
+                           _ -> (Left (UsingDeadReference xobj deleterName)))
                   _ ->
                     --trace ("CAN use reference " ++ pretty xobj ++ " (with lifetime '" ++ lt ++ "', depending on " ++ show deleterName ++ ") at " ++ prettyInfoFromXObj xobj ++ ", it's not alive here:\n" ++ show xobj ++ "\nMappings: " ++ prettyLifetimeMappings lifetimeMappings ++ "\nAlive: " ++ show deleters ++ "\n") $
                     pure (Right xobj)

--- a/test/interface.carp
+++ b/test/interface.carp
@@ -36,6 +36,17 @@
 (defn pikachu [times] (String.repeat times "pika"))
 (implements monster pikachu)
 
+;; issue #1414, make sure we don't overwrite the lookup mode of implementations
+(definterface FOO a)
+(defmodule Foo
+  (register FOO Int "CARP_INT_MAX")
+  (implements FOO FOO)
+)
+(defmodule Bar
+  (defn bar []
+    FOO)
+)
+
 (deftest test
   (assert-equal test
     &2
@@ -59,4 +70,8 @@
     &(monster 3)
     "Implementations may be overwritten, when multiple implementations of the same type
      are provided.")
+  (assert-equal test
+    Int.MAX
+    (Bar.bar)
+    "regression for issue #1414")
 )

--- a/test/memory.carp
+++ b/test/memory.carp
@@ -57,6 +57,13 @@
     (do (print "")
         ())))
 
+;; regression test for issue #597
+;; should compile fine.
+(defn shadow-1 [x]
+  (let [x [1 2 3]
+        y &x]
+    ()))
+
 (defn f []
   @"")
 
@@ -595,4 +602,5 @@
   (assert-no-leak test box-1 "box-1 does not leak")
   (assert-no-leak test box-2 "box-2 does not leak")
   (assert-no-leak test blit-1 "blit-1 does not leak")
+  (assert-no-leak test (fn [] (shadow-1 2)) "shadow-1 does not leak")
   )

--- a/test/output/test/test-for-errors/return_ref_in_let.carp.output.expected
+++ b/test/output/test/test-for-errors/return_ref_in_let.carp.output.expected
@@ -1,1 +1,1 @@
-return_ref_in_let.carp:4:3 The reference '(let [xs (ref [1 2 3])] xs)' isn't alive.
+return_ref_in_let.carp:5:5 The reference 'xs' isn't alive.


### PR DESCRIPTION
Adds MAX and MIN for each INT<N> type and MAX for each UINT<N> type.
These are macros defined by stdint.h and are sometimes useful for bounds
determinations and conversions and such.