### PR TITLE
fix: respect let binding shadowing in memory management

### DIFF
--- a/src/Info.hs
+++ b/src/Info.hs
@@ -12,12 +12,14 @@ module Info
     makeTypeVariableNameFromInfo,
     setDeletersOnInfo,
     addDeletersToInfo,
+    uniqueDeleter,
   )
 where
 
 import Path (takeFileName)
 import qualified Set
 import SymPath
+import Data.List (unionBy)
 
 -- | Information about where the Obj originated from.
 data Info = Info
@@ -57,6 +59,20 @@ instance Show Deleter where
   show (FakeDeleter var) = "(FakeDel " ++ show var ++ ")"
   show (PrimDeleter var) = "(PrimDel " ++ show var ++ ")"
   show (RefDeleter var) = "(RefDel " ++ show var ++ ")"
+
+-- | Get the variable name associated with a deleter.
+deleterVar :: Deleter -> String
+deleterVar (ProperDeleter _ _ v) = v
+deleterVar (FakeDeleter v) = v
+deleterVar (PrimDeleter v) = v
+deleterVar (RefDeleter v) = v
+
+-- | Given two sets of deleters, take only a single deleter for each variable.
+--
+-- Left biased in the case of duplicates.
+uniqueDeleter :: Set.Set Deleter -> Set.Set Deleter -> Set.Set Deleter
+uniqueDeleter xs ys =
+  Set.fromList (unionBy (\x y -> deleterVar x == deleterVar y) (Set.toList xs) (Set.toList ys))
 
 -- | Whether or not the full path of a source file or a short path should be
 -- printed.

--- a/src/Memory.hs
+++ b/src/Memory.hs
@@ -590,7 +590,9 @@ refTargetIsAlive xobj =
                   [] ->
                     --trace ("Can't use reference " ++ pretty xobj ++ " (with lifetime '" ++ lt ++ "', depending on " ++ show deleterName ++ ") at " ++ prettyInfoFromXObj xobj ++ ", it's not alive here:\n" ++ show xobj ++ "\nMappings: " ++ prettyLifetimeMappings lifetimeMappings ++ "\nAlive: " ++ show deleters ++ "\n") $
                     --pure (Right xobj)
-                    pure (Left (UsingDeadReference xobj deleterName))
+                    pure (case xobjObj xobj of
+                           (Lst (LetPat _ _ body)) -> (Left (UsingDeadReference body deleterName))
+                           _ -> (Left (UsingDeadReference xobj deleterName)))
                   _ ->
                     --trace ("CAN use reference " ++ pretty xobj ++ " (with lifetime '" ++ lt ++ "', depending on " ++ show deleterName ++ ") at " ++ prettyInfoFromXObj xobj ++ ", it's not alive here:\n" ++ show xobj ++ "\nMappings: " ++ prettyLifetimeMappings lifetimeMappings ++ "\nAlive: " ++ show deleters ++ "\n") $
                     pure (Right xobj)


### PR DESCRIPTION
Previously, we didn't account for shadowing in let bindings in our
memory management routines. This led to rare situations in which
multiple deleters might be added for a single variable name, for
example:

```clojure
(defn n [xs]
  (let [xs [1 2 3]
        n &xs]
    n))
```

The borrow checker would fail on this code since it would assign `xs`
two deleters, one for the untyped argument and another for the let
binding.

Instead, we now perform *exclusive* ownership transfer for the duration
of the let scope--when a shadow is introduced, the previous deleters for
that variable name are dropped until the end of the let scope, since we
evaluate all instances of the shadowed name to the more local binding.
At the end of the let scope, the original deleter is restored.

The code in the issue now produces: 

```clojure
The reference 'n' (depending on the variable 'xs') isn't alive at line 4, column 5 in '/Users/scottolsen/shadow.carp'. at /Users/scottolsen/shadow.carp:1:2.

Traceback:
  (defn n [xs] (let [xs [1 2 3] n (ref xs)] n)) at /Users/scottolsen/shadow.carp:1:1.
(load "../../shadow.carp") at REPL:1:1.
```

fixes #597 