### PR TITLE
fix: respect symbol modes on interface concretization

### DIFF
--- a/test/interface.carp
+++ b/test/interface.carp
@@ -36,6 +36,17 @@
 (defn pikachu [times] (String.repeat times "pika"))
 (implements monster pikachu)
 
+;; issue #1414, make sure we don't overwrite the lookup mode of implementations
+(definterface FOO a)
+(defmodule Foo
+  (register FOO Int "CARP_INT_MAX")
+  (implements FOO FOO)
+)
+(defmodule Bar
+  (defn bar []
+    FOO)
+)
+
 (deftest test
   (assert-equal test
     &2
@@ -59,4 +70,8 @@
     &(monster 3)
     "Implementations may be overwritten, when multiple implementations of the same type
      are provided.")
+  (assert-equal test
+    Int.MAX
+    (Bar.bar)
+    "regression for issue #1414")
 )


### PR DESCRIPTION
When concretizing interfaces (finding the appropriate implementation at
a call site) we previously set the lookup mode of all such resolved
symbols to CarpLand AFunction. This incorrectly overwrites the lookup
mode of Externally registered types, causing them to emit incorrect C
when the user specifies an override.

We now preserve whatever lookup mode is assigned to the implementation
the concretization resolves the interface to. This not only fixes the
external override emission issue, but should be more correct in general.

fixes https://github.com/carp-lang/Carp/issues/1414