### PR TITLE
docs: Updates markdown docs to only have one h1

### DIFF
--- a/docs/DynamicSemantics.md
+++ b/docs/DynamicSemantics.md
@@ -25,8 +25,6 @@ This document will help us rewrite Carp's dynamic evaluator (defined in Eval.hs)
 
 <hr>
 
-# Semantics
-
 ## Index
 [TODO]
 

--- a/docs/ReleaseChecklist.md
+++ b/docs/ReleaseChecklist.md
@@ -2,30 +2,30 @@
 
 Do all of these things (somewhat) in order:
 
-# 1. Update Cabal project version
+## 1. Update Cabal project version
 
 See the second line of the file [CarpHask.cabal](../CarpHask.cabal).
 
-# 2. Update the "Welcome to Carp X.Y.Z" REPL message
+## 2. Update the "Welcome to Carp X.Y.Z" REPL message
 
 See [Main.hs](../App/Main.hs).
 
-# 3. Update the blurb in README.md
+## 3. Update the blurb in README.md
 
 See [README.md](../README.md)
 
-# 4. Update the changelog
+## 4. Update the changelog
 
 See [CHANGELOG.md](../CHANGELOG.md)
 
-# 5. Make a commit on master
+## 5. Make a commit on master
 
 ```bash
 $ git add .
 $ git commit -m "build: Release X.Y.Z"
 ```
 
-# 6. Tag the commit and push it
+## 6. Tag the commit and push it
 
 ```bash
 $ git tag vX.Y.Z

--- a/docs/Tooling.md
+++ b/docs/Tooling.md
@@ -6,7 +6,7 @@
 ## Emacs
 [https://github.com/carp-lang/carp-emacs](https://github.com/carp-lang/carp-emacs)
 
-# Atom
+## Atom
 [language-carp](https://atom.io/packages/language-carp) offers highlight with both TextMate and Tree-sitter, where tree-sitter grammar is more powerful.
 
 ## Other editors


### PR DESCRIPTION
This is a tiny PR to ensure there is only one h1/single # per markdown document. It was throwing off some documentation generation.