### PR TITLE
fix: quasiquoting breaks List.pairs

### DIFF
--- a/core/List.carp
+++ b/core/List.carp
@@ -320,7 +320,7 @@ elements is uneven, the trailing element will be discarded.")
     (defndynamic pairs [l]
       (if (< (length l) 2)
         '()
-        (cons `(%(car l) %(cadr l)) (List.pairs (cddr l)))))
+        (cons (list (car l) (cadr l)) (List.pairs (cddr l)))))
 
     (doc nth "gets the nth element of the list `l`.")
     (defndynamic nth [l n]


### PR DESCRIPTION
This PR fixes `Dynamic.List.pairs` to not depend on quasiquoting for now, because that seems to break it for some reason 😬 

Cheers