### PR TITLE
fix: don't allow lambdas to leak captures

### DIFF
--- a/src/Info.hs
+++ b/src/Info.hs
@@ -10,6 +10,7 @@ module Info
     freshVar,
     machineReadableInfo,
     makeTypeVariableNameFromInfo,
+    deleterVar,
     setDeletersOnInfo,
     addDeletersToInfo,
     uniqueDeleter,

--- a/src/Memory.hs
+++ b/src/Memory.hs
@@ -111,6 +111,7 @@ manageMemory typeEnv globalEnv root =
       case lst of
         [defn@(XObj (Defn maybeCaptures) _ _), nameSymbol@(XObj (Sym _ _) _ _), args@(XObj (Arr argList) _ _), body] ->
           let captures = maybe [] Set.toList maybeCaptures
+              captureDeleters = Set.fromList (map (FakeDeleter . getName) captures)
            in do
                 mapM_ (manage typeEnv globalEnv) argList
                 -- Add the captured variables (if any, only happens in lifted lambdas) as fake deleters
@@ -129,10 +130,11 @@ manageMemory typeEnv globalEnv root =
                 mapM_ (addToLifetimesMappingsIfRef False) captures -- For captured variables inside of lifted lambdas
                 visitedBody <- visit body
                 result <- unmanage typeEnv globalEnv body
+                capturesRetained <- assertOwnershipRetained captureDeleters xobj
                 whenRightReturn result $
-                  do
-                    okBody <- visitedBody
-                    Right (XObj (Lst [defn, nameSymbol, args, okBody]) i t)
+                  do capturesRetained -- if any captures are given away in the body, it's an error
+                     okBody <- visitedBody
+                     Right (XObj (Lst [defn, nameSymbol, args, okBody]) i t)
 
         -- Fn / λ (Lambda)
         [fn@(XObj (Fn _ captures) _ _), args@(XObj (Arr _) _ _), body] ->
@@ -512,6 +514,19 @@ unmanage typeEnv globalEnv xobj =
                     pure (Right ())
             tooMany -> error ("Too many variables with the same name in set: " ++ show tooMany)
         else pure (Right ())
+
+-- | Assert that the current memory state retains ownership over a set of nodes.
+--
+-- If the provided set of deleters is not present in the memory state at the
+-- point at which this is called, the state has given up ownership of one or
+-- more of the values in the set.
+assertOwnershipRetained :: Set.Set Deleter -> XObj -> State MemState (Either TypeError ())
+assertOwnershipRetained deleters xobj =
+  do MemState deleters' _ _ <- get
+     if (deleters `Set.isSubsetOf` deleters')
+       then pure (Right ())
+       else let leaks = map deleterVar (Set.toList (deleters Set.\\ deleters'))
+             in pure (Left (FunctionLeaksCapture leaks xobj))
 
 -- | A combination of `manage` and `unmanage`.
 transferOwnership :: TypeEnv -> Env -> XObj -> XObj -> State MemState (Either TypeError ())

--- a/src/Set.hs
+++ b/src/Set.hs
@@ -54,3 +54,6 @@ size (Set s) = S.size s
 
 map :: Ord b => (a -> b) -> Set a -> Set b
 map f (Set s) = Set $ S.map f s
+
+isSubsetOf :: Ord v => Set v -> Set v -> Bool
+isSubsetOf (Set x) (Set y) = x `S.isSubsetOf` y

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -63,6 +63,7 @@ data TypeError
   | FailedToAddLambdaStructToTyEnv SymPath XObj
   | FailedToInstantiateGenericType Ty
   | InvalidStructField XObj
+  | FunctionLeaksCapture [String] XObj
 
 instance Show TypeError where
   show (SymbolMissingType xobj env) =
@@ -325,6 +326,9 @@ instance Show TypeError where
       ++ " to the type environment."
   show (FailedToInstantiateGenericType ty) =
     "I couldn't instantiate the generic type " ++ show ty
+  show (FunctionLeaksCapture leaks xobj) = 
+    "The function "  ++ pretty xobj ++ " gives away the captured variables: " 
+    ++ joinWithComma leaks ++ ". Functions must keep ownership of variables captured from another environment."
 
 machineReadableErrorStrings :: FilePathPrintLength -> TypeError -> [String]
 machineReadableErrorStrings fppl err =
@@ -443,6 +447,7 @@ machineReadableErrorStrings fppl err =
           ++ pretty xobj
           ++ " to the type environment."
       ]
+    e@(FunctionLeaksCapture _ xobj) -> [machineReadableInfoFromXObj fppl xobj ++ show e] 
     _ ->
       [show err]
 


### PR DESCRIPTION
When lambdas close over some external environment variable, if that variable is a linear value, their environment becomes the owner of the captured value and the value will be freed with the environment. If the lambda moves this variable out of its own scope, however, e.g. by returning it in its body, both the caller and the lambda environment will wind up owning the value, resulting in double frees.

For now, we prevent this scenario by simply disallowing functions to leak variables captured from another scope. Doing so is now an error. Of course, one can still copy these values without issue.

We achieve this through set operations. If the memory state loses the fake deleters for the set of a lambdas captured bindings after its body is evaluated, we've encountered an ownership leak, and report an error.

```clojure
(defn example []
  (let [capture @""
        lambda (fn [] capture)])) ;; this is now an error

(defn example []
  (let [capture @""
        lambda (fn [] @&capture)])) ;; this is still OK
```

fixes #1040