### PR TITLE
chore: disable unused-but-set-variable for clang

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -36,6 +36,7 @@ defaultProject =
             "-Wall",
             "-Werror",
             "-Wno-unused-variable",
+            "-Wno-unused-but-set-variable",
             "-Wno-self-assign"
           ],
       projectLibFlags = case platform of


### PR DESCRIPTION
At some point (I believe version 13.0.0?) clang added a warning that catches variables that were assigned but unused. This version of clang (or later) is now bundled w/ github's macos images and is causing our tests to fail in continuous integration. We can currently generate C code that trips this warning, so for now I've disabled it as we do some other warnings related to variable usages.