### PR TITLE
refactor: change project flag configuration behavior

### DIFF
--- a/core/Project.carp
+++ b/core/Project.carp
@@ -13,3 +13,13 @@
 Example usage: `(save-docs Int Float String)`")
 (defmacro save-docs [:rest modules]
   (eval (list 'save-docs-ex (list quote (collect-into modules array)) [])))
+
+(defmodule Project
+  (hidden append-flag)
+  (defndynamic append-flag [flag-set flag]
+    (Project.config flag-set (cons flag (Project.get-config flag-set))))
+
+  (defmacro append-cflag [flag] (Project.append-flag "cflag" flag))
+  (defmacro append-libflag [flag] (Project.append-flag "libflag" flag))
+  (defmacro append-pkgflag [flag] (Project.append-flag "pkgconfigflag" flag))
+)

--- a/src/Obj.hs
+++ b/src/Obj.hs
@@ -218,6 +218,10 @@ isBool :: XObj -> Bool
 isBool (XObj (Bol _) _ _) = True
 isBool _ = False
 
+isStr :: XObj -> Bool
+isStr (XObj (Str _) _ _) = True
+isStr _ = False
+
 isExternalFunction :: XObj -> Bool
 isExternalFunction (XObj (Lst (XObj (External _) _ _ : _)) _ _) = True
 isExternalFunction _ = False

--- a/src/ProjectConfig.hs
+++ b/src/ProjectConfig.hs
@@ -46,7 +46,7 @@ projectGetPreproc proj =
 -- | Get the project's C compiler flags.
 projectGetCFlags :: ProjectGetter
 projectGetCFlags proj =
-  let fs = projectPreproc proj
+  let fs = projectCFlags proj
    in wrapList (map wrapString fs)
 
 -- | Set the project's C compiler flags

--- a/src/ProjectConfig.hs
+++ b/src/ProjectConfig.hs
@@ -1,9 +1,17 @@
 -- | Defines a frontend for manipulating Project level data.
 module ProjectConfig (projectKeyMap) where
 
+import Data.Either (rights)
 import Info
 import qualified Map
 import Obj
+    ( XObj(XObj),
+      Obj(Str, Lst, Bol),
+      unwrapStringXObj,
+      wrapString,
+      wrapList,
+      wrapArray,
+      isStr )
 import Project
 import Util
 
@@ -50,20 +58,11 @@ projectGetCFlags proj =
    in wrapList (map wrapString fs)
 
 -- | Set the project's C compiler flags
---
--- NOTE: This retains existing behavior in which one can only add one flag at
--- a time and the flags are append only. A slightly more functional interface
--- would take a list of flags as arguments; e.g. to add *one* flag:
---
---   (Project.config "cflags" (cons "-my-flag" (Project.get-config "cflags")))
---
---   or to wipe the flags whole-cloth (e.g. for a different target)
---
---   (Project.config "cflags" ("-my" "-new" "-flags"))
---
---   likewise for flag removal etc.
 projectSetCFlags :: ProjectSetter
-projectSetCFlags proj (XObj (Str f) _ _) = Right (proj {projectCFlags = addIfNotPresent f (projectCFlags proj)})
+projectSetCFlags proj (XObj (Lst flags) _ _) =
+  if not $ all isStr flags
+    then Left "can't use a non-string as a C compiler flag"
+    else Right proj {projectCFlags = rights $ map unwrapStringXObj flags}
 projectSetCFlags _ _ = Left "can't use a non-string as a C compiler flag"
 
 -- | Get the project's C compiler library flags.
@@ -73,20 +72,11 @@ projectGetLibFlags proj =
    in wrapList (map wrapString ls)
 
 -- | Set the project's C compiler library flags
---
--- NOTE: This retains existing behavior in which one can only add one flag at
--- a time and the flags are append only. A slightly more functional interface
--- would take a list of flags as arguments; e.g. to add *one* flag:
---
---   (Project.config "libflags" (cons "-lmylib" (Project.get-config "libflags")))
---
---   or to wipe the flags whole-cloth (e.g. for a different target)
---
---   (Project.config "libflags" ("-lmy" "-lnew" "-llibflags"))
---
---   likewise for flag removal etc.
 projectSetLibFlags :: ProjectSetter
-projectSetLibFlags proj (XObj (Str flag) _ _) = Right (proj {projectLibFlags = addIfNotPresent flag (projectLibFlags proj)})
+projectSetLibFlags proj (XObj (Lst flags) _ _) =
+  if not $ all isStr flags
+    then Left "can't use a non-string as a C compiler library flag"
+    else Right proj {projectLibFlags = rights $ map unwrapStringXObj flags}
 projectSetLibFlags _ _ = Left "can't use non-string as library flag"
 
 -- | Get the pkg-config flags for the project.
@@ -96,21 +86,11 @@ projectGetPkgConfigFlags proj =
    in wrapArray (map wrapString fs)
 
 -- | Set the project's pkg-config flags
---
--- NOTE: This retains existing behavior in which one can only add one flag at
--- a time and the flags are append only. A slightly more functional interface
--- would take a list of flags as arguments; e.g. to add *one* flag:
---
---   (Project.config "pkgconfigflags" (cons "-lmylib" (Project.get-config
---   "pkgconfigflags")))
---
---   or to wipe the flags whole-cloth (e.g. for a different target)
---
---   (Project.config "pkgconfigflags" ("-lmy" "-lnew" "-llibflags"))
---
---   likewise for flag removal etc.
 projectSetPkgConfigFlags :: ProjectSetter
-projectSetPkgConfigFlags proj (XObj (Str flag) _ _) = Right (proj {projectPkgConfigFlags = addIfNotPresent flag (projectPkgConfigFlags proj)})
+projectSetPkgConfigFlags proj (XObj (Lst flags) _ _) =
+  if not $ all isStr flags
+    then Left "can't use a non-string as a C compiler library flag"
+    else Right proj {projectPkgConfigFlags = rights $ map unwrapStringXObj flags}
 projectSetPkgConfigFlags _ _ = Left "can't use non-string as pkg-config flag"
 
 projectGetEchoC :: ProjectGetter


### PR DESCRIPTION
This PR changes the behavior of the project flag setting dynamic functions. Instead of appending a single string to the flagset, they now take a list of strings, which serve as the new flagset:

```
(Project.get-config "cflag")
=> (...a bunch of default platform flags; "-wall" ...)
(Project.config "cflag" '("-my" "-new" "-flags"))
(Project.get-config "cflag")
=> ("-my" "-new" "-flags")
```

In order to append flags, users now need to `cons` to a `config-get`:

```
(Project.config "cflag" (cons "-new" (Project.get-config "cflag")))
```

This is a **breaking change**, as passing a single string is now an error.

I considered overloading the behavior as an alternative so that we wouldn't break existing callers, but I feel this would ultimately lead to unintuitive behavior (calling with a single string appends while calling with a list of strings overrides ... users might wonder why the list doesn't append all the strings in the list instead).

This PR also fixes a bug w/ fetching project C flags and provides helper macros for appending flags to existing project flag sets given the new behavior.