### PR TITLE
feat(core): add interleave, dedup, and unique to Array

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -410,6 +410,43 @@ It will create a copy. If you want to avoid that, consider using [`endo-filter`]
             (break))))
       result))
 
+  (doc interleave "interleaves two arrays. The resulting array will be as long as twice the length of the shortest input array.")
+  (defn interleave [a b]
+    (let [len-a (length a)
+          len-b (length b)
+          min-len (if (< len-a len-b) len-a len-b)
+          res []]
+      (do
+        (for [i 0 min-len]
+          (do
+            (set! res (push-back res @(unsafe-nth a i)))
+            (set! res (push-back res @(unsafe-nth b i)))))
+        res)))
+
+  (doc dedup "removes consecutive duplicates from an array. (The elements must support `=`).")
+  (defn dedup [a]
+    (if (empty? a)
+      []
+      (let [res [@(unsafe-nth a 0)]]
+        (do
+          (for [i 1 (length a)]
+            (let [x (unsafe-nth a i)]
+              (if (not (= x (unsafe-last &res)))
+                (set! res (push-back res @x))
+                ())))
+          res))))
+
+  (doc unique "removes all duplicates from an array. (The elements must support `=`).")
+  (defn unique [a]
+    (let [res []]
+      (do
+        (for [i 0 (length a)]
+          (let [x (unsafe-nth a i)]
+            (if (not (contains? &res x))
+              (set! res (push-back res @x))
+              ())))
+        res)))
+
   (doc partition
     "Partitions an array `arr` into an array of arrays of length `n`
     sequentially filled with the `arr`'s original values.

--- a/test/array_extensions.carp
+++ b/test/array_extensions.carp
@@ -1,0 +1,37 @@
+(load "Test.carp")
+(use Test)
+
+(deftest test-array-extensions
+  (let-do [a1 [1 2 3]
+           a2 [4 5 6]
+           a3 [1 2 3 4]
+           a4 [5 6]
+           t1 (assert-equal test-array-extensions
+                            &[1 4 2 5 3 6]
+                            &(Array.interleave &a1 &a2)
+                            "interleave works for equal length")
+           t2 (assert-equal (ref t1)
+                            &[1 5 2 6]
+                            &(Array.interleave &a3 &a4)
+                            "interleave works for different length (stops at shortest)")
+           
+           d1 [1 1 2 2 3 3 1 1]
+           t3 (assert-equal (ref t2)
+                            &[1 2 3 1]
+                            &(Array.dedup &d1)
+                            "dedup works for consecutive duplicates")
+           t4 (assert-equal (ref t3)
+                            &[]
+                            &(Array.dedup &(the (Array Int) []))
+                            "dedup works for empty array")
+           
+           u1 [1 2 3 2 1 4 3]
+           t5 (assert-equal (ref t4)
+                            &[1 2 3 4]
+                            &(Array.unique &u1)
+                            "unique works for all duplicates")
+           t6 (assert-equal (ref t5)
+                            &[]
+                            &(Array.unique &(the (Array Int) []))
+                            "unique works for empty array")]
+    t6))


### PR DESCRIPTION
Adds three useful utility functions to the Array module:
- `Array.interleave`: Combines two arrays by alternating elements.
- `Array.dedup`: Removes consecutive duplicates ((n)$).
- `Array.unique`: Removes all duplicates ((n^2)$), preserving order.

Includes tests in `test/array_extensions.carp`.