### PR TITLE
perf: make String.lines faster

### DIFF
--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -180,24 +180,4 @@ list of those characters.")
   (doc collapse-whitespace "collapses groups of whitespace into single spaces.")
   (defn collapse-whitespace [s]
     (Pattern.substitute #"\s+" s " " -1))
-
-  (doc split-by "splits a string by separators.")
-  (defn split-by [s separators]
-    (let-do [result []
-             start 0
-             idx (index-of-any-from s separators -1)]
-      (while (/= idx -1)
-        (do
-          (set! result (Array.push-back result (byte-slice s start idx)))
-          (set! start (Int.inc idx))
-          (set! idx (index-of-any-from s separators idx))))
-      (Array.push-back result (byte-slice s start (length s)))))
-
-  (doc words "splits a string into words.")
-  (defn words [s]
-    (Array.endo-filter &(fn [s] (not (empty? s))) (split-by s &[\tab \space \newline])))
-
-  (doc lines "splits a string into lines.")
-  (defn lines [s]
-    (split-by s &[\newline]))
 )

--- a/core/Pattern.carp
+++ b/core/Pattern.carp
@@ -183,19 +183,15 @@ list of those characters.")
 
   (doc split-by "splits a string by separators.")
   (defn split-by [s separators]
-    (let-do [pat (Pattern.from-chars separators)
-             idx (Pattern.find-all &pat s)
-             lidx (Array.length &idx)
-             result (Array.allocate (Int.inc lidx))]
-      (Array.aset-uninitialized! &result 0
-        (slice s 0 (if (> lidx 0) @(Array.unsafe-nth &idx 0) (length s))))
-      (for [i 0 (Int.dec (Array.length &idx))]
-        (Array.aset-uninitialized! &result (Int.inc i)
-          (slice s (Int.inc @(Array.unsafe-nth &idx i)) @(Array.unsafe-nth &idx (Int.inc i)))))
-      (when (> lidx 0)
-        (Array.aset-uninitialized! &result lidx
-          (suffix s (Int.inc @(Array.unsafe-nth &idx (Int.dec lidx))))))
-      result))
+    (let-do [result []
+             start 0
+             idx (index-of-any-from s separators -1)]
+      (while (/= idx -1)
+        (do
+          (set! result (Array.push-back result (byte-slice s start idx)))
+          (set! start (Int.inc idx))
+          (set! idx (index-of-any-from s separators idx))))
+      (Array.push-back result (byte-slice s start (length s)))))
 
   (doc words "splits a string into words.")
   (defn words [s]

--- a/core/String.carp
+++ b/core/String.carp
@@ -220,6 +220,26 @@
   (doc  ascii-to-upper "converts each character in this string to upper case using toupper() from standard C library. Note: this will only work for ASCII characters.")
   (defn ascii-to-upper [s]
     (String.from-bytes &(Array.endo-map &(fn [c] (Byte.toupper- c)) (String.to-bytes s))) )
+
+  (doc split-by "splits a string by separators.")
+  (defn split-by [s separators]
+    (let-do [result []
+             start 0
+             idx (index-of-any-from s separators -1)]
+      (while (/= idx -1)
+        (do
+          (set! result (Array.push-back result (byte-slice s start idx)))
+          (set! start (Int.inc idx))
+          (set! idx (index-of-any-from s separators idx))))
+      (Array.push-back result (byte-slice s start (length s)))))
+
+  (doc words "splits a string into words.")
+  (defn words [s]
+    (Array.endo-filter &(fn [s] (not (empty? s))) (split-by s &[\tab \space \newline])))
+
+  (doc lines "splits a string into lines.")
+  (defn lines [s]
+    (split-by s &[\newline]))
 )
 
 (defmodule StringCopy

--- a/core/String.carp
+++ b/core/String.carp
@@ -33,10 +33,14 @@
   (register str        (Fn [&String] String))
   (doc prn "Converts a string to a string for printing.")
   (register prn        (Fn [&String] String))
+  (doc index-of-any-from "Returns the index of the first occurrence of any of `chars` in `s` after index `from`, or -1 if not found.")
+  (register index-of-any-from (Fn [&String &(Array Char) Int] Int))
   (doc index-of "Returns the index of the first occurrence of `c` in `s`, or -1 if not found.")
-  (register index-of   (Fn [&String Char] Int))
+  (defn index-of [s c]
+    (index-of-any-from s &[c] -1))
   (doc index-of-from "Returns the index of the first occurrence of `c` in `s` starting from `from`, or -1 if not found.")
-  (register index-of-from (Fn [&String Char Int] Int))
+  (defn index-of-from [s c i]
+    (index-of-any-from s &[c] i))
   (doc index-of-string "Returns the index of the first occurrence of `needle` in `s`, or -1 if not found.")
   (register index-of-string (Fn [&String &String] Int))
   (doc char-at "Returns the character at the specified index.")
@@ -111,6 +115,9 @@
   (defn empty? [s]
     (Int.= (length s) 0))
   (implements empty? String.empty?)
+
+  (doc byte-slice "Return part of a string, from byte index `a` to byte index `b`.")
+  (register byte-slice (Fn [&String Int Int] String))
 
   (doc slice "Return part of a string, beginning at index `a` and ending at index `b`.")
   (defn slice [s a b]

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -362,25 +362,27 @@ uint8_t Byte_from_MINUS_string_MINUS_internal(const String* s, byte* target) {
     return *err == 0;
 }
 
-int String_index_MINUS_of_MINUS_from(const String* s, char c, int i) {
-    /* Return index of first occurrence of `c` in `s` AFTER index i
-     * Returns -1 if not found
-     */
-    ++i;  // skip first character as we want AFTER i
+int String_index_MINUS_of_MINUS_any_MINUS_from(const String* s,
+                                               const Array* chars, int i) {
+    const Char* cs = (const Char*)chars->data;
+    size_t nc = chars->len;
     size_t len = strlen(*s);
-    for (; i < len; ++i) {
-        if (c == (*s)[i]) {
-            return i;
+    for (++i; i < len; ++i) {
+        for (size_t j = 0; j < nc; j++) {
+            if ((unsigned char)(*s)[i] == cs[j]) return i;
         }
     }
     return -1;
 }
 
-int String_index_MINUS_of(const String* s, char c) {
-    /* Return index of first occurrence of `c` in `s`
-     * Returns -1 if not found
-     */
-    return String_index_MINUS_of_MINUS_from(s, c, -1);
+
+
+String String_byte_MINUS_slice(const String* s, int a, int b) {
+    int len = b - a;
+    String ptr = CARP_MALLOC(len + 1);
+    memcpy(ptr, *s + a, len);
+    ptr[len] = '\0';
+    return ptr;
 }
 
 int String_index_MINUS_of_MINUS_string(const String* s, const String* needle) {

--- a/core/carp_string.h
+++ b/core/carp_string.h
@@ -375,8 +375,6 @@ int String_index_MINUS_of_MINUS_any_MINUS_from(const String* s,
     return -1;
 }
 
-
-
 String String_byte_MINUS_slice(const String* s, int a, int b) {
     int len = b - a;
     String ptr = CARP_MALLOC(len + 1);


### PR DESCRIPTION
This PR makes `String.lines` faster by not using patterns but a regular string indexing.

Using this script:

```clojure
(load "Bench.carp")

(def big-string @"")

(defn-do setup []
  (set! big-string @"")
  (for [i 0 1000]
    (set! big-string (String.append &big-string "this is a line of moderate length for benchmarking\n"))))

(defn-do main []
  (setup)
  (Bench.bench (fn [] (String.lines &big-string))))
```

I observe these numbers:

```
# before
Total time elapsed: 37.8041s
Best case: 373.605ms
Worst case: 386.365ms
Standard deviation: 1.09158ms

# after
Total time elapsed: 904.533ms
Best case: 1.23942ms
Worst case: 1.2958ms
Standard deviation: 4.62482µs
```

Or a 373x speedup.

Cheers