### PR TITLE
feat: add coverage

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -74,7 +74,8 @@ defaultProject =
       projectPkgConfigFlags = [],
       projectCModules = [],
       projectLoadStack = [],
-      projectPreproc = []
+      projectPreproc = [],
+      projectLineDirectives = False
     }
 
 -- | Starting point of the application.
@@ -92,6 +93,7 @@ main = do
       profile = not $ otherNoProfile otherOptions
       optimize = otherOptimize otherOptions
       generateOnly = otherGenerateOnly otherOptions
+      lineDirectives = otherLineDirectives otherOptions
       prompt = otherPrompt otherOptions
       carpDir = lookup "CARP_DIR" sysEnv
       ifCarpDirSet comp =
@@ -110,6 +112,7 @@ main = do
                 ++ projectCFlags p,
             projectCore = core,
             projectGenerateOnly = generateOnly,
+            projectLineDirectives = lineDirectives,
             projectCarpDir = fromMaybe (projectCarpDir p) carpDir,
             projectPrompt = fromMaybe (projectPrompt p) prompt
           }
@@ -184,7 +187,8 @@ data OtherOptions = OtherOptions
     otherLogMemory :: Bool,
     otherOptimize :: Bool,
     otherGenerateOnly :: Bool,
-    otherPrompt :: Maybe String
+    otherPrompt :: Maybe String,
+    otherLineDirectives :: Bool
   }
   deriving (Show)
 
@@ -197,6 +201,7 @@ parseOther =
     <*> switch (long "optimize" <> help "Optimized build")
     <*> switch (long "generate-only" <> help "Stop after generating the C code")
     <*> optional (strOption (long "prompt" <> help "Set REPL prompt"))
+    <*> switch (long "line-directives" <> help "Emit #line directives mapping C output to Carp source")
 
 parseExecMode :: Parser ExecutionMode
 parseExecMode =

--- a/core/Coverage.carp
+++ b/core/Coverage.carp
@@ -1,0 +1,69 @@
+(load "Test.carp")
+
+(doc Coverage "provides code coverage support for Carp programs.
+
+There are two workflows:
+
+### Manual workflow (with `-x`)
+
+Use `enable` in your test file, then run gcov yourself afterwards:
+
+```
+(load \"Test.carp\")
+(load \"Coverage.carp\")
+(Coverage.enable)
+
+(deftest test
+  (assert-equal test 2 (+ 1 1) \"math\"))
+```
+
+Then: `carp -x test.carp && gcov -o out out/main.c`
+
+### Integrated workflow
+
+Use `Coverage.deftest` which handles build, run, and report:
+
+```
+(load \"Coverage.carp\")
+
+(Coverage.deftest test
+  (assert-equal test 2 (+ 1 1) \"math\"))
+```
+
+Then: `carp test.carp`
+
+Both workflows require gcov (ships with gcc/clang).")
+
+(defmodule Coverage
+  (doc enable "Enable code coverage instrumentation.
+Turns on #line directives and adds --coverage to C compiler flags.
+Call this before `(build)` or `deftest`.")
+  (defmacro enable []
+    (do
+      (Project.config "line-directives" true)
+      (Project.config "cflag" "--coverage")))
+
+  (doc report "Generate a coverage report by running gcov on the compiled output.
+Call this after `(build)` and `(run)` have completed.")
+  (defmacro report []
+    (let [dir (Project.get-config "output-directory")
+          gcov (if (= "darwin" (host-os))
+                 "xcrun llvm-cov gcov"
+                 "gcov")]
+      (shell (Dynamic.String.concat
+        [gcov " " dir "/*.gcda"]))))
+
+  (doc deftest "Define and run a test with coverage reporting.
+
+Equivalent to calling `Coverage.enable`, then `deftest`, then
+`(build)`, `(run)`, `Coverage.report`, and `(quit)`.
+
+Do not use with `carp -x`; just use `carp test.carp`.")
+  (defmacro deftest [name :rest forms]
+    (do
+      (Coverage.enable)
+      (eval (cons 'deftest (cons name forms)))
+      (build)
+      (run)
+      (Coverage.report)
+      (quit))))

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Run the test suite with code coverage and report per-file line coverage
+# for core/. Requires gcov (gcc) or llvm-cov (clang/Xcode).
+#
+# Usage: ./scripts/coverage.sh [test-glob]
+#   test-glob  Optional glob for test files (default: ./test/*.carp)
+#
+# Examples:
+#   ./scripts/coverage.sh                    # all tests
+#   ./scripts/coverage.sh ./test/array.carp  # single test
+#
+# The numbers are conservative: for each core file, we take the max
+# lines-hit across individual test runs. Real merged coverage would be
+# higher since different tests often cover complementary lines.
+
+set -eu
+
+# Resolve gcov command (macOS needs xcrun llvm-cov gcov)
+if [ "$(uname -s)" = "Darwin" ]; then
+    GCOV="xcrun llvm-cov gcov"
+else
+    GCOV="gcov"
+fi
+
+# Use the repo's carp.sh wrapper
+CARP_SH="./scripts/carp.sh"
+if [ ! -x "$CARP_SH" ]; then
+    echo "Error: run this script from the carp repo root." >&2
+    exit 1
+fi
+
+TEST_GLOB="${1:-./test/*.carp}"
+RAW=$(mktemp)
+trap 'rm -f "$RAW"' EXIT
+
+for test_file in $TEST_GLOB; do
+    [ -f "$test_file" ] || continue
+    rm -rf out/
+
+    if "$CARP_SH" --line-directives \
+       --eval-preload '(Project.config "cflag" "--coverage")' \
+       -x "$test_file" >/dev/null 2>&1; then
+
+        current_file=""
+        $GCOV -r out/*.gcda 2>/dev/null | while IFS= read -r line; do
+            case "$line" in
+                File\ *)
+                    current_file=$(echo "$line" | sed "s/^File '//;s/'$//")
+                    ;;
+                Lines\ executed:*)
+                    if echo "$current_file" | grep -q '^core/.*\.carp$'; then
+                        pct=$(echo "$line" | sed 's/.*:\(.*\)% of.*/\1/')
+                        total=$(echo "$line" | sed 's/.*of \([0-9]*\).*/\1/')
+                        hits=$(echo "$pct $total" | awk '{printf "%d", $1*$2/100}')
+                        echo "$current_file $total $hits" >> "$RAW"
+                    fi
+                    ;;
+            esac
+        done
+
+        rm -f ./*.gcov
+    fi
+
+    echo -n "." >&2
+done
+
+echo "" >&2
+
+if [ ! -s "$RAW" ]; then
+    echo "No coverage data collected." >&2
+    exit 1
+fi
+
+sort "$RAW" | awk '
+{
+    file = $1; total = $2; hits = $3
+    if (file != prev && prev != "") {
+        printf "%-45s %4d / %4d  (%5.1f%%)\n", prev, mh, mt, (mt > 0 ? mh * 100.0 / mt : 0)
+        gh += mh; gt += mt
+    }
+    if (file != prev) { mh = hits; mt = total }
+    else { if (hits > mh) mh = hits; if (total > mt) mt = total }
+    prev = file
+}
+END {
+    if (prev != "") {
+        printf "%-45s %4d / %4d  (%5.1f%%)\n", prev, mh, mt, (mt > 0 ? mh * 100.0 / mt : 0)
+        gh += mh; gt += mt
+    }
+    printf "\n%-45s %4d / %4d  (%5.1f%%)\n", "TOTAL (max per file, conservative)", gh, gt, (gt > 0 ? gh * 100.0 / gt : 0)
+}
+'
+
+rm -rf out/

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -193,8 +193,9 @@ commandBuild ctx [XObj (Bol shutUp) _ _] = do
       src = do
         typeDecl <- typeEnvToDeclarations typeEnv env
         decl <- envToDeclarations typeEnv env
-        c <- envToC env Functions
-        initGlobals <- fmap (wrapInInitFunction (projectCore proj)) (globalsToC env)
+        let emitLines = projectLineDirectives proj
+        c <- envToC env Functions emitLines
+        initGlobals <- fmap (wrapInInitFunction (projectCore proj)) (globalsToC emitLines env)
         pure
           ( "//Types:\n" ++ typeDecl
               ++ "\n\n//Declarations:\n"
@@ -312,6 +313,18 @@ commandHostOS ctx =
 commandHostArch :: NullaryCommandCallback
 commandHostArch ctx =
   pure (ctx, Right (XObj (Str arch) (Just dummyInfo) (Just StringTy)))
+
+-- | Command for running an arbitrary shell command string.
+commandShell :: UnaryCommandCallback
+commandShell ctx (XObj (Str cmd) _ _) = liftIO $ do
+  exitCode <- try (callCommand cmd) :: IO (Either SomeException ())
+  case exitCode of
+    Right () -> pure (ctx, dynamicNil)
+    Left e -> do
+      putStrLnWithColor Red ("Shell command failed: " ++ show e)
+      pure (ctx, dynamicNil)
+commandShell ctx x =
+  pure (evalError ctx ("`shell` expected a string argument, but got `" ++ pretty x ++ "`.") (xobjInfo x))
 
 -- | Command for adding a header file include to the project.
 commandAddInclude :: (String -> Includer) -> UnaryCommandCallback

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -119,13 +119,25 @@ renderEmitterState = TL.unpack . TB.toLazyText . emitterBuilder
 appendToSrc :: String -> State EmitterState ()
 appendToSrc moreSrc = modify (\s -> s {emitterBuilder = emitterBuilder s <> TB.fromString moreSrc})
 
-toC :: ToCMode -> [(SymPath, Binder)] -> Binder -> String
-toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visit startingIndent root) emptyEmitterState)
+toC :: ToCMode -> Bool -> [(SymPath, Binder)] -> Binder -> String
+toC toCMode emitLines mutualGroup (Binder meta root) = renderEmitterState (execState (visit startingIndent root) emptyEmitterState)
   where
     startingIndent = case toCMode of
       Functions -> 0
       Globals -> 4
       All -> 0
+    emitLineDir :: XObj -> State EmitterState ()
+    emitLineDir xobj = when emitLines $
+      case xobjInfo xobj of
+        Just i
+          | infoLine i > 0 && infoFile i /= "dummy-file" ->
+            appendToSrc ("#line " ++ show (infoLine i) ++ " \"" ++ infoFile i ++ "\"\n")
+        _ -> pure ()
+    emitLineDirInfo :: Info -> State EmitterState ()
+    emitLineDirInfo i =
+      when emitLines $
+        when (infoLine i > 0 && infoFile i /= "dummy-file") $
+          appendToSrc ("#line " ++ show (infoLine i) ++ " \"" ++ infoFile i ++ "\"\n")
     visit :: Int -> XObj -> State EmitterState String
     visit indent xobj =
       let dontVisit = error (show (DontVisitObj xobj))
@@ -263,6 +275,7 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
                     isMain = name == "main"
                     params = [(mangle n, forceTy p) | p@(XObj (Sym (SymPath _ n) _) _ _) <- argList, not (isUnit (forceTy p))]
                     canTCO = not isMain && hasSelfTailCalls body && isSafeForTCO argList
+                emitLineDirInfo info
                 appendToSrc (defnDecl ++ " {\n")
                 when isMain $
                   appendToSrc (addIndent innerIndent ++ "carp_init_globals(argc, argv);\n")
@@ -270,9 +283,11 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
                   then do
                     let tcoIndent = innerIndent + indentAmount
                     appendToSrc (addIndent innerIndent ++ "while(1) {\n")
+                    emitLineDir body
                     visitTCO tcoIndent params retTy (infoDelete info) Nothing body
                     appendToSrc (addIndent innerIndent ++ "}\n")
                   else do
+                    emitLineDir body
                     ret <- visit innerIndent body
                     delete innerIndent (infoDelete info)
                     case retTy of
@@ -364,6 +379,7 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
                           appendToSrc (addIndent indent' ++ tyToCLambdaFix bindingTy ++ " " ++ mangle symName ++ " = " ++ ret ++ ";\n")
                     letBindingToC _ _ = error "Invalid binding."
                 mapM_ (uncurry letBindingToC) (pairwise bindings)
+                emitLineDir body
                 ret <- visit indent' body
                 when isNotVoid $
                   appendToSrc (addIndent indent' ++ letBodyRet ++ " = " ++ ret ++ ";\n")
@@ -381,11 +397,13 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
                    in appendToSrc (addIndent indent ++ tyToCLambdaFix ifT ++ " " ++ ifRetVar ++ ";\n")
                 exprVar <- visit indent expr
                 appendToSrc (addIndent indent ++ "if (" ++ exprVar ++ ") {\n")
+                emitLineDir ifTrue
                 trueVar <- visit indent' ifTrue
                 delete indent' (infoDelete (infoOrUnknown $ xobjInfo ifTrue))
                 when isNotVoid $
                   appendToSrc (addIndent indent' ++ ifRetVar ++ " = " ++ trueVar ++ ";\n")
                 appendToSrc (addIndent indent ++ "} else {\n")
+                emitLineDir ifFalse
                 falseVar <- visit indent' ifFalse
                 delete indent' (infoDelete (infoOrUnknown $ xobjInfo ifFalse))
                 when isNotVoid $
@@ -474,6 +492,7 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
               emitCase _ _ x =
                 error ("Fell through: " ++ show x)
               emitCaseEnd caseLhsInfo caseExpr = do
+                emitLineDir caseExpr
                 caseExprRetVal <- visit indent' caseExpr
                 when isNotVoid $
                   appendToSrc (addIndent indent' ++ retVar ++ " = " ++ caseExprRetVal ++ ";\n")
@@ -500,6 +519,7 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
                 appendToSrc (addIndent indent ++ tyToCLambdaFix exprTy ++ " " ++ conditionVar ++ " = " ++ exprRetVar ++ ";\n")
                 delete indent (infoDelete exprInfo)
                 appendToSrc (addIndent indent ++ "while (" ++ conditionVar ++ ") {\n")
+                emitLineDir body
                 _ <- visit indent' body
                 exprRetVar' <- visitWhileExpression indent'
                 delete indent' (infoDelete info)
@@ -751,8 +771,10 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
       XObj (Lst [XObj If _ _, expr, ifTrue, ifFalse]) _ _ -> do
         exprVar <- visit indent' expr
         appendToSrc (addIndent indent' ++ "if (" ++ exprVar ++ ") {\n")
+        emitLineDir ifTrue
         visitTCO (indent' + indentAmount) params retTy (accDels `Set.union` infoDelete (infoOrUnknown $ xobjInfo ifTrue)) mutualInfo ifTrue
         appendToSrc (addIndent indent' ++ "} else {\n")
+        emitLineDir ifFalse
         visitTCO (indent' + indentAmount) params retTy (accDels `Set.union` infoDelete (infoOrUnknown $ xobjInfo ifFalse)) mutualInfo ifFalse
         appendToSrc (addIndent indent' ++ "}\n")
       XObj (Lst (XObj Do _ _ : exprs@(_ : _))) _ _ -> do
@@ -767,6 +789,7 @@ toC toCMode mutualGroup (Binder meta root) = renderEmitterState (execState (visi
               unless (isUnit bt) $ appendToSrc (addIndent indent'' ++ tyToCLambdaFix bt ++ " " ++ mangle n ++ " = " ++ ret ++ ";\n")
             emitBinding _ _ = error "Invalid binding."
         mapM_ (uncurry emitBinding) (pairwise bindings)
+        emitLineDir body'
         visitTCO indent'' params retTy (accDels `Set.union` maybe Set.empty infoDelete minfo) mutualInfo body'
         appendToSrc (addIndent indent' ++ "}\n")
       XObj (Lst [XObj The _ _, _, value]) _ _ ->
@@ -1150,21 +1173,21 @@ projectPreprocToC proj = intercalate "\n" preprocs ++ "\n\n"
   where
     preprocs = projectPreproc proj
 
-binderToC :: ToCMode -> Binder -> Either ToCError String
-binderToC toCMode binder =
+binderToC :: ToCMode -> Bool -> Binder -> Either ToCError String
+binderToC toCMode emitLines binder =
   let xobj = binderXObj binder
    in case xobj of
         XObj (External _) _ _ -> Right ""
         XObj (ExternalType _) _ _ -> Right ""
         XObj (Command _) _ _ -> Right ""
-        XObj (Mod env _) _ _ -> envToC env toCMode
+        XObj (Mod env _) _ _ -> envToC env toCMode emitLines
         _ -> case xobjTy xobj of
           Just t ->
             if isTypeGeneric t
               then Right ""
               else do
                 checkForUnresolvedSymbols xobj
-                pure (toC toCMode [] binder)
+                pure (toC toCMode emitLines [] binder)
           Nothing -> Left (BinderIsMissingType binder)
 
 binderToDeclaration :: TypeEnv -> Binder -> Either ToCError String
@@ -1220,8 +1243,8 @@ findMutualGroups env =
     hasRef (PointerTy p) = hasRef p
     hasRef _ = False
 
-envToC :: Env -> ToCMode -> Either ToCError String
-envToC env toCMode =
+envToC :: Env -> ToCMode -> Bool -> Either ToCError String
+envToC env toCMode emitLines =
   let binders' = Map.toList (envBindings env)
       mutualGroups = findMutualGroups env
       mutualPaths = Set.fromList [pathToC path | group <- mutualGroups, (path, _) <- group]
@@ -1230,14 +1253,14 @@ envToC env toCMode =
         Nothing -> False
       emitGroup group = do
         mapM_ (checkForUnresolvedSymbols . binderXObj . snd) group
-        pure (toC toCMode group (snd (head group)))
+        pure (toC toCMode emitLines group (snd (head group)))
    in do
-        okCodes <- mapM (binderToC toCMode . snd) (filter (not . isMutual) binders')
+        okCodes <- mapM (binderToC toCMode emitLines . snd) (filter (not . isMutual) binders')
         mutualCodes <- mapM emitGroup mutualGroups
         pure (concat mutualCodes ++ concat okCodes)
 
-globalsToC :: Env -> Either ToCError String
-globalsToC globalEnv =
+globalsToC :: Bool -> Env -> Either ToCError String
+globalsToC emitLines globalEnv =
   let allGlobalBinders = findAllGlobalVariables globalEnv
    in do
         okCodes <-
@@ -1245,7 +1268,7 @@ globalsToC globalEnv =
             ( \(score, binder) ->
                 fmap
                   (\s -> if s == "" then "" else ("\n    // Depth " ++ show score ++ "\n") ++ s)
-                  (binderToC Globals binder)
+                  (binderToC Globals emitLines binder)
             )
             (sortGlobalVariableBinders globalEnv allGlobalBinders)
         pure (concat okCodes)

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -740,7 +740,7 @@ printC xobj =
     Left e ->
       strWithColor Red (show e ++ ", can't print resulting code.\n")
     Right _ ->
-      strWithColor Green (toC All [] (Binder emptyMeta xobj))
+      strWithColor Green (toC All False [] (Binder emptyMeta xobj))
 
 buildMainFunction :: XObj -> XObj
 buildMainFunction xobj =

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -184,7 +184,7 @@ define hidden ctx qualifiedXObj = do
     defineInTypeEnv = pure . fromRight ctx . (insertTypeBinder ctx qpath)
     defineInGlobalEnv :: Binder -> IO Context
     defineInGlobalEnv newBinder =
-      when (projectEchoC (contextProj ctx) && canBeEmitted annXObj) (putStrLn (toC All [] (Binder emptyMeta annXObj)))
+      when (projectEchoC (contextProj ctx) && canBeEmitted annXObj) (putStrLn (toC All False [] (Binder emptyMeta annXObj)))
         >> case (lookupBinderInGlobalEnv ctx qpath) of
           Left _ -> pure (fromRight ctx (insertInGlobalEnv ctx qpath newBinder))
           Right oldBinder -> redefineExistingBinder oldBinder newBinder

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -56,7 +56,8 @@ data Project = Project
     projectBalanceHints :: Bool,
     projectForceReload :: Bool, -- Setting this to true will make the `load-once` command work just like `load`.
     projectCModules :: [FilePath],
-    projectLoadStack :: [FilePath]
+    projectLoadStack :: [FilePath],
+    projectLineDirectives :: Bool
   }
 
 projectFlags :: Project -> String
@@ -96,7 +97,8 @@ instance Show Project where
         "Balance Hints: " ++ showB projectBalanceHints,
         "Force Reload: " ++ showB projectForceReload,
         "C modules:\n    " ++ joinIndented projectCModules,
-        "Load stack:\n    " ++ joinIndented projectLoadStack
+        "Load stack:\n    " ++ joinIndented projectLoadStack,
+        "Line directives: " ++ showB projectLineDirectives
       ]
     where
       showB b = if b then "true" else "false"

--- a/src/ProjectConfig.hs
+++ b/src/ProjectConfig.hs
@@ -308,6 +308,15 @@ projectSetCModules _ _ = Left "can't use non-string as c module"
 projectGetLoadStack :: ProjectGetter
 projectGetLoadStack proj = wrapArray (map wrapString (projectLoadStack proj))
 
+-- | Get the line-directives configuration option for the project.
+projectGetLineDirectives :: ProjectGetter
+projectGetLineDirectives proj = XObj (Bol (projectLineDirectives proj)) Nothing Nothing
+
+-- | Set the line-directives configuration option for the project.
+projectSetLineDirectives :: ProjectSetter
+projectSetLineDirectives proj (XObj (Bol b) _ _) = Right (proj {projectLineDirectives = b})
+projectSetLineDirectives _ _ = Left "can't use non-bool as line-directives option"
+
 -- | Mapping of compiler defined project keys to getter and setter functions.
 -- This helps ensure we automatically enable access of project configuration
 -- fields from Carp as they are added to the compiler.
@@ -344,5 +353,6 @@ projectKeyMap =
       ("paren-balance-hints", (Just projectGetBalanceHints, Just projectSetBalanceHints)),
       ("force-reload", (Just projectGetForceReload, Just projectSetForceReload)),
       ("cmod", (Just projectGetCModules, Just projectSetCModules)),
-      ("load-stack", (Just projectGetLoadStack, Nothing))
+      ("load-stack", (Just projectGetLoadStack, Nothing)),
+      ("line-directives", (Just projectGetLineDirectives, Just projectSetLineDirectives))
     ]

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -286,6 +286,7 @@ dynamicModule =
             f "relative-include" commandAddRelativeInclude "adds a relative include, i.e. a C `include` with quotes. It also prepends the current directory." "(relative-include \"myheader.h\")",
             f "read-file" commandReadFile "reads a file into a string." "(read-file \"myfile.txt\")",
             f "get-env" commandGetEnv "gets an environment variable. The result will be `()` if it isn’t set." "(read-file \"CARP_DIR\")",
+            f "shell" commandShell "runs a shell command string." "(shell \"echo hello\")",
             f "hash" commandHash "calculates the hash associated with a value." "(hash '('my 'value)) ; => 3175346968842793108",
             f "round" commandRound "rounds its numeric argument." "(round 2.4) ; => 2",
             f "dynamic-type" commandType "Gets the dynamic type as a string." "(dynamic-type '()) ; => \"list\""


### PR DESCRIPTION
Disclosure: I used Claude Code to help me with this extensively.

This PR adds optional coverage mechanics. All we do is emit `#line` directives in C, and then use standard C coverage tools to get the information back, plus a bit of a harness.

This is an example test with coverage:

```clojure
(load "Test.carp")
(load "Coverage.carp")
(Coverage.enable)

(deftest test
  (assert-equal test 2 (+ 1 1) "math"))
```

This is the output of the newly minted coverage script:

```
⇒ scripts/coverage.sh
..................................................................
core/Array.carp                                347 /  428  ( 81.1%)
core/ArrayExt.carp                              30 /   30  (100.0%)
core/Binary.carp                               269 /  385  ( 69.9%)
core/Blitable.carp                               0 /   45  (  0.0%)
core/Bool.carp                                  83 /  199  ( 41.7%)
core/Box.carp                                   53 /   73  ( 72.6%)
core/Byte.carp                                  11 /   35  ( 31.4%)
core/Char.carp                                  58 /   60  ( 96.7%)
core/Color.carp                                190 /  577  ( 32.9%)
core/ControlMacros.carp                        225 /  404  ( 55.7%)
core/Derive.carp                                33 /   79  ( 41.8%)
core/Double.carp                                32 /   40  ( 80.0%)
core/Filepath.carp                              21 /   21  (100.0%)
core/Float.carp                                 32 /   40  ( 80.0%)
core/Generics.carp                             680 /  692  ( 98.3%)
core/Geometry.carp                               9 /    9  (100.0%)
core/Heap.carp                                 139 /  268  ( 51.9%)
core/Int.carp                                   36 /   50  ( 72.0%)
core/IO.carp                                    82 /  166  ( 49.4%)
core/Long.carp                                   4 /   19  ( 21.1%)
core/Macros.carp                               101 /  217  ( 46.5%)
core/Map.carp                                  587 /  688  ( 85.3%)
core/Maybe.carp                                119 /  227  ( 52.4%)
core/Pattern.carp                              140 /  179  ( 78.2%)
core/Pointer.carp                                4 /    6  ( 66.7%)
core/Random.carp                                15 /   84  ( 17.9%)
core/Result.carp                               142 /  355  ( 40.0%)
core/Sort.carp                                  37 /  210  ( 17.6%)
core/StaticArray.carp                          165 /  179  ( 92.2%)
core/Statistics.carp                           167 /  167  (100.0%)
core/StdInt.carp                                12 /   64  ( 18.8%)
core/String.carp                               236 /  634  ( 37.2%)
core/System.carp                                25 /   88  ( 28.4%)
core/Test.carp                                  90 /  153  ( 58.8%)
core/Unit.carp                                  31 /   72  ( 43.1%)
core/Vector.carp                               112 /  181  ( 61.9%)

TOTAL (max per file, conservative)            4317 / 7124  ( 60.6%)
```

Bonus: the `line` pragma will also ensure that LLDB and GDB tell us where in the Carp program we are instead of the C program!

Cheers