### PR TITLE
Two phase eval

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -127,7 +127,7 @@ Example:
 
 (doc defn-do "is a `defn` with an implicit `do` body.")
 (defmacro defn-do [name arguments :rest body]
-  (eval (list 'defn name arguments (cons 'do body))))
+  (list 'defn name arguments (cons 'do body)))
 
 (doc forever-do "is a `forever` with an implicit `do` body.")
 (defmacro forever-do [:rest forms]

--- a/core/Derive.carp
+++ b/core/Derive.carp
@@ -71,7 +71,7 @@ the generated function to avoid collisions.")
           deriver (get-deriver f Derive.derivers)]
       (if (empty? deriver)
         (macro-error (String.concat ["no deriver found for interface " (str f) "!"]))
-        (eval ((cadr deriver) t name))))))
+        ((cadr deriver) t name)))))
 
 (use Derive)
 

--- a/core/Introspect.carp
+++ b/core/Introspect.carp
@@ -76,9 +76,9 @@
 
   (doc implements? "Does `function` implement `interface`?")
   (defmacro implements? [interface function]
-    (eval (list 'any?
-                (list 'fn (array 'x) (list '= 'x interface))
-                (list 'meta function "implements"))))
+    (list 'any?
+          (list 'fn (array 'x) (list '= 'x interface))
+          (list 'meta function "implements")))
 
   (doc arity
     "What's the arity of this binding?

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -82,27 +82,27 @@
                                             (Dynamic.String.concat [x newline])))
                                 strings
                                 ())]
-    (eval (list 'meta-set! name "doc" (Dynamic.String.concat (list-to-array-internal separated []))))))
+    (list 'meta-set! name "doc" (Dynamic.String.concat (list-to-array-internal separated [])))))
 
 (doc print-doc "Print the documentation for a binding.")
 (defmacro print-doc [name]
-  (eval (list 'macro-log (list 'meta name "doc"))))
+  (list 'macro-log (list 'meta name "doc")))
 
 (doc sig "Annotate a binding with the desired signature.")
 (defmacro sig [name signature]
-  (eval (list 'meta-set! name "sig" signature)))
+  (list 'meta-set! name "sig" signature))
 
 (doc print-sig "Print the annotated signature for a binding.")
 (defmacro print-sig [name]
-  (eval (list 'macro-log (list 'meta name "sig"))))
+  (list 'macro-log (list 'meta name "sig")))
 
 (doc hidden "Mark a binding as hidden, this will make it not print with the 'info' command.")
 (defmacro hidden [name]
-  (eval (list 'meta-set! name "hidden" true)))
+  (list 'meta-set! name "hidden" true))
 
 (doc private "Mark a binding as private, this will make it inaccessible from other modules.")
 (defmacro private [name]
-  (eval (list 'meta-set! name "private" true)))
+  (list 'meta-set! name "private" true))
 
 (doc c-name
   "Override the identifiers Carp generates for a given symbol in C output."
@@ -112,7 +112,7 @@
   "(c-name foo-bar \"foo_bar\")"
   "```")
 (defmacro c-name [sym cname]
-  (eval (list 'meta-set! sym "c-name" cname)))
+  (list 'meta-set! sym "c-name" cname))
 
 (hidden      and-)
 (defndynamic and- [xs]
@@ -152,15 +152,15 @@ other expressions, otherwise it returns the value of the last form in `xs`.
 
 (doc todo "sets the todo property for a binding.")
 (defmacro todo [name value]
-  (eval (list 'meta-set! name "todo" value)))
+  (list 'meta-set! name "todo" value))
 
 (doc private? "Is this binding private?")
 (defmacro private? [name]
-  (eval (list 'not (list 'list? (list 'meta name "private")))))
+  (list 'not (list 'list? (list 'meta name "private"))))
 
 (doc hidden? "Is this binding hidden?")
 (defmacro hidden? [name]
-  (eval (list 'not (list 'list? (list 'meta name "hidden")))))
+  (list 'not (list 'list? (list 'meta name "hidden"))))
 
 (hidden annotate-helper)
 (defndynamic annotate-helper [name annotation]
@@ -168,26 +168,26 @@ other expressions, otherwise it returns the value of the last form in `xs`.
 
 (doc annotate "Add an annotation to this binding.")
 (defmacro annotate [name annotation]
-  (eval (list 'meta-set! name "annotations" (eval (annotate-helper name annotation)))))
+  (list 'meta-set! name "annotations" (annotate-helper name annotation)))
 
 (doc deprecated "Declares that a binding is deprecated, using an optional explanation.")
 (defmacro deprecated [name :rest explanation]
   (let [v (if (= (length explanation) 0) true (car explanation))]
-    (eval (list 'meta-set! name "deprecated" v))))
+    (list 'meta-set! name "deprecated" v)))
 
 (doc defn- "Declares a function while marking it as private and hidden.")
 (defmacro defn- [name args form]
-  (do
-   (eval (list 'private name))
-   (eval (list 'hidden name))
-   (list 'defn name args form)))
+  (list 'do
+        (list 'private name)
+        (list 'hidden name)
+        (list 'defn name args form)))
 
 (doc def- "Declares a variable while marking it as private and hidden.")
 (defmacro def- [name value]
-  (do
-   (eval (list 'private name))
-   (eval (list 'hidden name))
-   (list 'def name value)))
+  (list 'do
+        (list 'private name)
+        (list 'hidden name)
+        (list 'def name value)))
 
 (hidden cond-internal)
 (defndynamic cond-internal [xs]
@@ -235,11 +235,11 @@ other expressions, otherwise it returns the value of the last form in `xs`.
 (defndynamic use-all-fn [names]
   (if (= (length names) 0)
     (macro-error "Trying to call use-all without arguments")
-    (do
-      (eval (list 'use (car names)))
-      (if (= (length names) 1)
-        ()
-        (use-all-fn (cdr names))))))
+    (if (= (length names) 1)
+      (list 'use (car names))
+      (list 'do
+            (list 'use (car names))
+            (use-all-fn (cdr names))))))
 
 (doc use-all "is a variadic version of `use`.")
 (defmacro use-all [:rest names]
@@ -248,9 +248,9 @@ other expressions, otherwise it returns the value of the last form in `xs`.
 (doc load-and-use "loads a file and uses the module with in it. Assumes that
 the filename and module name are the same.")
 (defmacro load-and-use [name]
-  (do
-    (eval (list 'load (str name ".carp")))
-    (eval (list 'use name))))
+  (list 'do
+        (list 'load (str name ".carp"))
+        (list 'use name)))
 
 (doc comment "ignores `forms`.")
 (defmacro comment [:rest forms]
@@ -282,14 +282,13 @@ the filename and module name are the same.")
 
 (doc defdynamic-once "Creates a dynamic variable and sets its value if it's not already defined.")
 (defmacro defdynamic-once [var expr]
-  (eval
-    (list 'if (list 'defined? var)
-          ()
-          (list 'defdynamic var expr))))
+  (list 'if (list 'defined? var)
+        ()
+        (list 'defdynamic var expr)))
 
 (doc inline-c "Inlines some custom C code.")
 (defmacro inline-c [name defcode :rest declcode]
-  (eval (list 'deftemplate name (list) defcode (if (empty? declcode) "" (car declcode)))))
+  (list 'deftemplate name (list) defcode (if (empty? declcode) "" (car declcode))))
 
 (doc bottom "aborts the program if reached.")
 (deftemplate bottom (Fn [] a) "$a $NAME()" "$DECL { abort(); }")
@@ -355,7 +354,7 @@ the filename and module name are the same.")
     (doc pragma
        "Emits a #pragma compiler directive in Carp's c output.")
     (defmacro pragma [:rest args]
-      (eval (Unsafe.C.emit-c-line ["#pragma "] args)))
+      (Unsafe.C.emit-c-line ["#pragma "] args))
 
     (doc define
       "Emits a #define compiler directive in Carp's c output.")
@@ -368,13 +367,17 @@ the filename and module name are the same.")
       (Unsafe.C.emit-c-line ["#undef "] [name]))
 
     (defndynamic if- [if-pre name then else]
-      (do (eval (Unsafe.C.emit-c-line [if-pre] [name]))
-          (eval (Unsafe.C.emit-c-line ["  "] [then]))
-          (if (not (empty? else))
-              (do (eval (Unsafe.C.emit-c-line ["#else"] []))
-                  (eval (Unsafe.C.emit-c-line ["  "] else)))
-              ())
-          (eval (Unsafe.C.emit-c-line ["#endif"] []))))
+      (if (empty? else)
+          (list 'do
+                (Unsafe.C.emit-c-line [if-pre] [name])
+                (Unsafe.C.emit-c-line ["  "] [then])
+                (Unsafe.C.emit-c-line ["#endif"] []))
+          (list 'do
+                (Unsafe.C.emit-c-line [if-pre] [name])
+                (Unsafe.C.emit-c-line ["  "] [then])
+                (Unsafe.C.emit-c-line ["#else"] [])
+                (Unsafe.C.emit-c-line ["  "] else)
+                (Unsafe.C.emit-c-line ["#endif"] []))))
 
     (doc ifpre
       "Emits a #if compiler directive in Carp's c output.")
@@ -394,12 +397,12 @@ the filename and module name are the same.")
     (doc warning
       "Emits a #warning compiler directive in Carp's c output.")
     (defmacro warning [message]
-      (eval (Unsafe.C.emit-c-line ["#warning "] [message])))
+      (Unsafe.C.emit-c-line ["#warning "] [message]))
 
     (doc error
       "Emits a #error compiler directive in Carp's c output.")
     (defmacro error [message]
-    (eval (Unsafe.C.emit-c-line ["#error "] [message])))
+    (Unsafe.C.emit-c-line ["#error "] [message]))
 
     (hidden asmify)
     (defndynamic asmify [instruction]
@@ -420,12 +423,12 @@ the filename and module name are the same.")
       "(Unsafe.C.asm addr \"mov %1, %0\\n\" \"add $1, %0\\n\" : \"=r\" (dst) : \"r\" (src))"
       "```")
     (defmacro asm [name :rest instructions]
-      (do
-        (eval (list 'Unsafe.C.define (String.concat [(str name) "()"])
-          (String.concat [
-            "__asm__("
-            (String.concat (collect-into (Dynamic.map Unsafe.C.asmify instructions) array))
-            ");"])))
-        (eval (list 'register name '(Fn [] ())))))
+      (list 'do
+            (list 'Unsafe.C.define (String.concat [(str name) "()"])
+                  (String.concat [
+                    "__asm__("
+                    (String.concat (collect-into (Dynamic.map Unsafe.C.asmify instructions) array))
+                    ");"]))
+            (list 'register name '(Fn [] ()))))
   )
 )

--- a/core/Platform.carp
+++ b/core/Platform.carp
@@ -45,7 +45,7 @@
 (doc target-only "conditionally compile forms when b is true.")
 (defndynamic target-only [b forms]
   (when b
-    (eval (cons 'do forms))))
+    (cons 'do forms)))
 
 (doc mac-only "compile forms only on Mac.")
 (defmacro mac-only [:rest forms]

--- a/core/Project.carp
+++ b/core/Project.carp
@@ -12,7 +12,7 @@
 
 Example usage: `(save-docs Int Float String)`")
 (defmacro save-docs [:rest modules]
-  (list 'save-docs-ex (collect-into modules array) []))
+  (list 'save-docs-ex (list 'quote (collect-into modules array)) []))
 
 (defmodule Project
   (hidden append-flag)

--- a/core/Project.carp
+++ b/core/Project.carp
@@ -12,7 +12,7 @@
 
 Example usage: `(save-docs Int Float String)`")
 (defmacro save-docs [:rest modules]
-  (eval (list 'save-docs-ex (list quote (collect-into modules array)) [])))
+  (list 'save-docs-ex (collect-into modules array) []))
 
 (defmodule Project
   (hidden append-flag)

--- a/core/Random.carp
+++ b/core/Random.carp
@@ -27,8 +27,8 @@
   (doc gen-seed-at-startup "toggles reseeding the random number generator at startup.")
   (defmacro gen-seed-at-startup [toggle]
     (if toggle
-      (eval '(defmodule Random (def _ (do (seed) true))))
-      (eval '(defmodule Random (def _ (do false))))))
+      '(defmodule Random (def _ (do (seed) true)))
+      '(defmodule Random (def _ (do false)))))
 
    (doc gen-seed-at-startup? "checks whether the random number generator was reseeded at startup.
 
@@ -112,4 +112,3 @@ Use `Dynamic.Random.gen-seed-at-startup?` to check this in dynamic code.")
     (Byte.from-int (Int.random)))
   (implements random Byte.random)
 )
-

--- a/core/Test.carp
+++ b/core/Test.carp
@@ -181,11 +181,10 @@ Example:
         `(do %@(with-test-internal name forms))))))
 
 (defmacro deftest [name :rest forms]
-  (eval
-    `(defn main []
-      (let [%name &(Test.State.init 0 0)]
-        %(cons-last
-          `@(Test.State.failed %name)
-          (cons-last
-            `(Test.print-test-results %name)
-            `(do %@(with-test-internal name forms))))))))
+  `(defn main []
+    (let [%name &(Test.State.init 0 0)]
+      %(cons-last
+        `@(Test.State.failed %name)
+        (cons-last
+          `(Test.print-test-results %name)
+          `(do %@(with-test-internal name forms)))))))

--- a/core/Tuples.carp
+++ b/core/Tuples.carp
@@ -51,6 +51,26 @@
           (defn reverse [t]
             (init %@(map (fn [x] `(copy (%x t))) (reverse props))))))))
 
+  (private deftuple-derive-zero-)
+  (hidden deftuple-derive-zero-)
+  (defndynamic deftuple-derive-zero- [name props]
+    (list 'defmodule name
+      (list 'defn 'zero (array)
+        (cons 'init (map (fn [_] '(zero)) props)))
+      (list 'implements 'zero (Symbol.prefix name 'zero))))
+
+  (private deftuple-derive-eq-)
+  (hidden deftuple-derive-eq-)
+  (defndynamic deftuple-derive-eq- [name props]
+    (list 'defmodule name
+      (list 'defn '= (array 'o1 'o2)
+        (reduce
+          (fn [acc p]
+            (list 'and (list '= (list p 'o1) (list p 'o2)) acc))
+          true
+          props))
+      (list 'implements '= (Symbol.prefix name '=))))
+
   (doc deftuple "defines a tuple type.
 
 For example:
@@ -59,12 +79,11 @@ For example:
 (deftuple Pair a b)
 ```")
   (defmacro deftuple [name :rest props]
-    (do
-      (eval (deftuple-type- name props))
-      (eval `(derive %name zero))
-      (eval `(derive %name =))
-      (eval (deftuple-module- name props))
-    ))
+    (list 'do
+          (deftuple-type- name props)
+          (deftuple-derive-zero- name props)
+          (deftuple-derive-eq- name props)
+          (deftuple-module- name props)))
 )
 
 (doc Pair "is a 2-tuple, i.e. a datatype with two members.")

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -1182,6 +1182,8 @@ binderToC toCMode emitLines binder =
         XObj (Command _) _ _ -> Right ""
         XObj (Mod env _) _ _ -> envToC env toCMode emitLines
         _ -> case xobjTy xobj of
+          Just MacroTy -> Right ""
+          Just DynamicTy -> Right ""
           Just t ->
             if isTypeGeneric t
               then Right ""

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -18,8 +18,8 @@ import Emit
 import qualified Env as E
 import EvalError
 import EvalIR (EvalIR (..), lowerExpr)
-import EvalTypes (LookupPreference (..))
-import EvalVM (runEvalIRVM)
+import EvalTypes (EvalPhase (..), LookupPreference (..))
+import EvalVM (runEvalIRVMWithPhase)
 import Expand
 import Infer
 import Info
@@ -51,14 +51,20 @@ evalStatic ctx xobj = evalIR ctx (lowerExpr ctx xobj) PreferGlobal
 
 -- | IR entry point for evaluator execution.
 evalIR :: Context -> EvalIR -> LookupPreference -> IO (Context, Either EvalError XObj)
-evalIR = runEvalIRVM
+evalIR = evalIRWithPhase PhaseExecute
+
+evalIRWithPhase :: EvalPhase -> Context -> EvalIR -> LookupPreference -> IO (Context, Either EvalError XObj)
+evalIRWithPhase = runEvalIRVMWithPhase
 
 -- | Public evaluator entry now routes through IR by default.
 eval :: Context -> XObj -> LookupPreference -> IO (Context, Either EvalError XObj)
 eval ctx xobj preference = evalIR ctx (lowerExpr ctx xobj) preference
 
+evalExpand :: Context -> XObj -> IO (Context, Either EvalError XObj)
+evalExpand ctx xobj = evalIRWithPhase PhaseExpand ctx (lowerExpr ctx xobj) PreferDynamic
+
 macroExpand :: Context -> XObj -> IO (Context, Either EvalError XObj)
-macroExpand ctx xobj = expand MacroExpandOnly evalDynamic ctx xobj
+macroExpand ctx xobj = expand MacroExpandOnly evalExpand ctx xobj
 
 -- | Parses a string and then converts the resulting forms to commands, which are evaluated in order.
 executeString :: Bool -> Bool -> Context -> String -> String -> IO Context
@@ -354,7 +360,7 @@ annotateWithinContext ctx xobj = do
   case sig of
     Left err -> pure (ctx, Left err)
     Right okSig -> do
-      (_, expansionResult) <- expandAll (evalDynamic) ctx xobj
+      (_, expansionResult) <- expandAll evalExpand ctx xobj
       case expansionResult of
         Left err -> pure (ctx, Left err)
         Right expanded ->
@@ -706,7 +712,7 @@ commandExpand = macroExpand
 -- | i.e. (Int.+ 2 3) => "_0 = 2 + 3"
 commandC :: UnaryCommandCallback
 commandC ctx xobj = do
-  (newCtx, result) <- expandAll (evalDynamic) ctx xobj
+  (newCtx, result) <- expandAll evalExpand ctx xobj
   case result of
     Left err -> pure (newCtx, Left err)
     Right expanded -> do
@@ -724,7 +730,7 @@ commandC ctx xobj = do
 -- | This function will return the compiled AST.
 commandExpandCompiled :: UnaryCommandCallback
 commandExpandCompiled ctx xobj = do
-  (newCtx, result) <- expandAll (evalDynamic) ctx xobj
+  (newCtx, result) <- expandAll evalExpand ctx xobj
   case result of
     Left err -> pure (newCtx, Left err)
     Right expanded -> do

--- a/src/EvalTypes.hs
+++ b/src/EvalTypes.hs
@@ -1,6 +1,7 @@
 module EvalTypes
   ( LookupPreference (..),
     EvalExecMode (..),
+    EvalPhase (..),
   )
 where
 
@@ -12,6 +13,11 @@ data EvalExecMode
   = ExecFunction
   | ExecDynamic
   | ExecMacro
+  deriving (Show, Eq)
+
+data EvalPhase
+  = PhaseExecute
+  | PhaseExpand
   deriving (Show, Eq)
 
 data LookupPreference

--- a/src/EvalVM.hs
+++ b/src/EvalVM.hs
@@ -4,6 +4,7 @@ module EvalVM
   ( compileEvalIR,
     runEvalCode,
     runEvalIRVM,
+    runEvalIRVMWithPhase,
   )
 where
 
@@ -171,26 +172,34 @@ compileEvalIR ir = mkEvalCode (fst (compileWithState emptyState ir) [IHalt])
         BoundInternal p -> RHQualified p
 
 runEvalIRVM :: Context -> EvalIR -> LookupPreference -> IO (Context, Either EvalError XObj)
-runEvalIRVM ctx ir preference =
+runEvalIRVM = runEvalIRVMWithPhase PhaseExecute
+
+runEvalIRVMWithPhase :: EvalPhase -> Context -> EvalIR -> LookupPreference -> IO (Context, Either EvalError XObj)
+runEvalIRVMWithPhase phase ctx ir preference =
   case evalIRCacheKey ir of
-    Nothing -> runEvalCode ctx preference (compileEvalIR ir)
+    Nothing -> runEvalCodeWithPhase phase ctx preference (compileEvalIR ir)
     Just key -> do
       cache <- readIORef evalIRCodeCache
       case Map.lookup key cache of
-        Just cached -> runEvalCode ctx preference cached
+        Just cached -> runEvalCodeWithPhase phase ctx preference cached
         Nothing ->
           let compiled = compileEvalIR ir
            in do
                 writeIORef evalIRCodeCache (Map.insert key compiled cache)
-                runEvalCode ctx preference compiled
+                runEvalCodeWithPhase phase ctx preference compiled
 
 evalDynamicVM :: Context -> XObj -> IO (Context, Either EvalError XObj)
 evalDynamicVM ctx xobj =
   let ctx' = ensureDynamicUse ctx
-   in runEvalIRVM ctx' (lowerExpr ctx' xobj) PreferDynamic
+   in runEvalIRVMWithPhase PhaseExecute ctx' (lowerExpr ctx' xobj) PreferDynamic
+
+evalExpandVM :: Context -> XObj -> IO (Context, Either EvalError XObj)
+evalExpandVM ctx xobj =
+  let ctx' = ensureDynamicUse ctx
+   in runEvalIRVMWithPhase PhaseExpand ctx' (lowerExpr ctx' xobj) PreferDynamic
 
 macroExpandVM :: Context -> XObj -> IO (Context, Either EvalError XObj)
-macroExpandVM ctx xobj = expand MacroExpandOnly evalDynamicVM ctx xobj
+macroExpandVM ctx xobj = expand MacroExpandOnly evalExpandVM ctx xobj
 
 ensureDynamicUse :: Context -> Context
 ensureDynamicUse ctx =
@@ -407,7 +416,7 @@ annotateWithinContextVM ctx xobj = do
   case sig of
     Left err -> pure (ctx, Left err)
     Right okSig -> do
-      (_, expansionResult) <- expandAll evalDynamicVM ctxDyn xobj
+      (_, expansionResult) <- expandAll evalExpandVM ctxDyn xobj
       case expansionResult of
         Left err -> pure (ctx, Left err)
         Right expanded ->
@@ -560,8 +569,8 @@ primitiveDefmacroVM _ ctx (XObj (Sym (SymPath [] name) _) _ _) params body =
 primitiveDefmacroVM _ ctx notName _ _ =
   pure (throwErr (InvalidArgs "`defmacro` expected a name as first argument." [notName]) ctx (xobjInfo notName))
 
-specialCommandWithVM :: Context -> SymPath -> [EvalIR] -> IO (Context, Either EvalError XObj)
-specialCommandWithVM ctx path forms = do
+specialCommandWithVM :: EvalPhase -> Context -> SymPath -> [EvalIR] -> IO (Context, Either EvalError XObj)
+specialCommandWithVM phase ctx path forms = do
   let globalEnv = contextGlobalEnv ctx
       useThese = envUseModules globalEnv
       ctx' = replaceGlobalEnv ctx (globalEnv {envUseModules = Set.insert path useThese})
@@ -577,11 +586,11 @@ specialCommandWithVM ctx path forms = do
       case accRes of
         Left _ -> pure (accCtx, accRes)
         Right _ -> do
-          (nextCtx, evaled) <- runEvalIRVM accCtx form PreferDynamic
+          (nextCtx, evaled) <- runEvalIRVMWithPhase phase accCtx form PreferDynamic
           pure (nextCtx, evaled)
 
-specialCommandSetVM :: Context -> EvalIR -> EvalIR -> IO (Context, Either EvalError XObj)
-specialCommandSetVM ctx targetIR valueIR =
+specialCommandSetVM :: EvalPhase -> Context -> EvalIR -> EvalIR -> IO (Context, Either EvalError XObj)
+specialCommandSetVM phase ctx targetIR valueIR =
   case raiseExpr targetIR of
     orig@(XObj (Sym path@(SymPath _ _) _) _ _) ->
       let lookupInternal =
@@ -603,7 +612,7 @@ specialCommandSetVM ctx targetIR valueIR =
   where
     evalAndSet :: Binder -> (Context -> Env -> Either EvalError XObj -> Binder -> IO (Context, Either EvalError XObj)) -> Env -> IO (Context, Either EvalError XObj)
     evalAndSet binder setter env =
-      evalDynamicVM ctx (raiseExpr valueIR)
+      runEvalIRVMWithPhase phase ctx valueIR PreferDynamic
         >>= \(newCtx, result) ->
           case result of
             Right evald ->
@@ -634,15 +643,15 @@ setStaticOrDynamicVarVM path@(SymPath _ name) env binder value =
       fromRight env (E.replaceInPlace env name (Binder meta (XObj (Lst [lett, sym, value]) (xobjInfo value) t)))
     _ -> env
 
-execIRLetBC :: Context -> LookupPreference -> EvalIR -> EvalIR -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
-execIRLetBC ctx preference bindings body info _ =
+execIRLetBC :: EvalPhase -> Context -> LookupPreference -> EvalIR -> EvalIR -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
+execIRLetBC phase ctx preference bindings body info _ =
   case bindings of
     IRArray flatBindings _ _ ->
       let binds = unwrapLetBindsBC (pairwise flatBindings) []
           letNamesInOrder = collectBindingNamesInOrder (pairwise flatBindings)
           ni = Env Map.empty (contextInternalEnv ctx) Nothing Set.empty InternalEnv 0
        in do
-            eitherCtx <- foldrM (successiveEvalBindBC preference) (Right (replaceInternalEnv ctx ni)) binds
+            eitherCtx <- foldrM (successiveEvalBindBC phase preference) (Right (replaceInternalEnv ctx ni)) binds
             case eitherCtx of
               Left err -> pure (ctx, Left err)
               Right newCtx -> do
@@ -657,7 +666,7 @@ execIRLetBC ctx preference bindings body info _ =
                     localSlots = Map.union letSlots baseLocalSlots
                     localNameSlots = Map.union letNameSlots baseLocalNameSlots
                     localPref = PreferLocal localNamesSet localSlots localNameSlots localExecMode
-                (finalCtx, evaledBody) <- runEvalIRVM newCtx body localPref
+                (finalCtx, evaledBody) <- runEvalIRVMWithPhase phase newCtx body localPref
                 let e = fromMaybe E.empty $ contextInternalEnv finalCtx
                     parentEnv = envParent e
                 pure (replaceInternalEnvMaybe finalCtx parentEnv, evaledBody)
@@ -704,15 +713,15 @@ nextLocalSlot slots
   | null (Map.keys slots) = 0
   | otherwise = 1 + maximum (Map.keys slots)
 
-successiveEvalBindBC :: LookupPreference -> (String, EvalIR) -> Either EvalError Context -> IO (Either EvalError Context)
-successiveEvalBindBC _ _ err@(Left _) = pure err
-successiveEvalBindBC preference (name, valueIR) (Right ctx') = do
+successiveEvalBindBC :: EvalPhase -> LookupPreference -> (String, EvalIR) -> Either EvalError Context -> IO (Either EvalError Context)
+successiveEvalBindBC _ _ _ err@(Left _) = pure err
+successiveEvalBindBC phase preference (name, valueIR) (Right ctx') = do
   let valueXObj = raiseExpr valueIR
       origin = contextInternalEnv ctx'
       recFix = E.recursive origin (Just "let-rec-env") 0
       envWithSelf = fromRight recFix $ if isFn valueXObj then E.insertX recFix (SymPath [] name) valueXObj else Right recFix
       ctx'' = replaceInternalEnv ctx' envWithSelf
-  (newCtx, res) <- runEvalIRVM ctx'' valueIR preference
+  (newCtx, res) <- runEvalIRVMWithPhase phase ctx'' valueIR preference
   case res of
     Right okX ->
       pure $
@@ -742,34 +751,34 @@ execIRFnBC ctx preference args body info ty = do
     _ ->
       pure (throwErr (UnknownForm (raiseExpr (IRFn args body info ty))) ctx info)
 
-execIRWhileBC :: Context -> LookupPreference -> EvalIR -> EvalIR -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
-execIRWhileBC ctx preference cond body _ _ = loop ctx
+execIRWhileBC :: EvalPhase -> Context -> LookupPreference -> EvalIR -> EvalIR -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
+execIRWhileBC phase ctx preference cond body _ _ = loop ctx
   where
     loop loopCtx = do
-      (condCtx, condResult) <- runEvalIRVM loopCtx cond preference
+      (condCtx, condResult) <- runEvalIRVMWithPhase phase loopCtx cond preference
       case condResult of
         Left err -> pure (condCtx, Left err)
         Right condValue ->
           case xobjObj condValue of
             Bol False -> pure (condCtx, Right (XObj (Lst []) Nothing Nothing))
             Bol True -> do
-              (bodyCtx, bodyResult) <- runEvalIRVM condCtx body preference
+              (bodyCtx, bodyResult) <- runEvalIRVMWithPhase phase condCtx body preference
               case bodyResult of
                 Left err -> pure (bodyCtx, Left err)
                 Right _ -> loop bodyCtx
             _ -> pure (throwErr (IfContainsNonBool (raiseExpr cond)) ctx (irInfoBC cond))
 
-execIRWithBC :: Context -> EvalIR -> [EvalIR] -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
-execIRWithBC ctx sym forms info _ =
+execIRWithBC :: EvalPhase -> Context -> EvalIR -> [EvalIR] -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
+execIRWithBC phase ctx sym forms info _ =
   case symToPathBC sym of
-    Just path -> specialCommandWithVM ctx path forms
+    Just path -> specialCommandWithVM phase ctx path forms
     Nothing -> pure (throwErr (UnknownForm (raiseExpr (IRWith sym forms info Nothing))) ctx info)
 
-execIRSetBC :: Context -> EvalIR -> EvalIR -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
-execIRSetBC ctx target value _ _ = specialCommandSetVM ctx target value
+execIRSetBC :: EvalPhase -> Context -> EvalIR -> EvalIR -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
+execIRSetBC phase ctx target value _ _ = specialCommandSetVM phase ctx target value
 
-execIRCallBC :: Context -> LookupPreference -> EvalIR -> [EvalIR] -> [EvalCode] -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
-execIRCallBC appCtx preference fun args argCodes info ty =
+execIRCallBC :: EvalPhase -> Context -> LookupPreference -> EvalIR -> [EvalIR] -> [EvalCode] -> Maybe Info -> Maybe Ty -> IO (Context, Either EvalError XObj)
+execIRCallBC phase appCtx preference fun args argCodes info ty =
   let refDerefArityMessage name args' =
         let argXObjs = map raiseExpr args'
             count = length argXObjs
@@ -800,29 +809,29 @@ execIRCallBC appCtx preference fun args argCodes info ty =
               case keywordNameBC fun of
                 Just "if" ->
                   case args of
-                    [a, b, c] -> execIRIfBC appCtx preference a b c
+                    [a, b, c] -> execIRIfBC phase appCtx preference a b c
                     _ -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
                 Just "let" ->
                   case args of
-                    [a, b] -> execIRLetBC appCtx preference a b info ty
+                    [a, b] -> execIRLetBC phase appCtx preference a b info ty
                     _ -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
                 Just "fn" ->
                   case args of
                     [a, b] -> execIRFnBC appCtx preference a b info ty
                     _ -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
                 Just "do" ->
-                  execIRDoBC appCtx preference args
+                  execIRDoBC phase appCtx preference args
                 Just "while" ->
                   case args of
-                    [a, b] -> execIRWhileBC appCtx preference a b info ty
+                    [a, b] -> execIRWhileBC phase appCtx preference a b info ty
                     _ -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
                 Just "with" ->
                   case args of
-                    (sym : forms) -> execIRWithBC appCtx sym forms info ty
+                    (sym : forms) -> execIRWithBC phase appCtx sym forms info ty
                     _ -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
                 Just "set!" ->
                   case args of
-                    [a, b] -> execIRSetBC appCtx a b info ty
+                    [a, b] -> execIRSetBC phase appCtx a b info ty
                     _ -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
                 Just "def" -> specialCommandDefineVM appCtx (callXObjBC fun args info ty)
                 Just "defn" -> specialCommandDefineVM appCtx (callXObjBC fun args info ty)
@@ -840,10 +849,10 @@ execIRCallBC appCtx preference fun args argCodes info ty =
                     _ -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
                 Just "the" -> pure (evalError appCtx "EvalVM `the` is not implemented yet." info)
                 _ -> do
-                  (newCtx, fResult) <- runEvalIRVM appCtx fun preference
+                  (newCtx, fResult) <- runEvalIRVMWithPhase phase appCtx fun preference
                   case fResult of
                     Left err -> pure (newCtx, Left err)
-                    Right funXObj -> dispatchCallableBC newCtx preference fun args argCodes info ty funXObj
+                    Right funXObj -> dispatchCallableBC phase newCtx preference fun args argCodes info ty funXObj
   where
     inlineCallable =
       case raiseExpr fun of
@@ -871,8 +880,8 @@ paramsFromSpec proper rest =
         Nothing -> properParams
         Just restName -> properParams ++ [sym ":rest", sym restName]
 
-dispatchCallableBC :: Context -> LookupPreference -> EvalIR -> [EvalIR] -> [EvalCode] -> Maybe Info -> Maybe Ty -> XObj -> IO (Context, Either EvalError XObj)
-dispatchCallableBC appCtx preference fun args argCodes info ty funXObj =
+dispatchCallableBC :: EvalPhase -> Context -> LookupPreference -> EvalIR -> [EvalIR] -> [EvalCode] -> Maybe Info -> Maybe Ty -> XObj -> IO (Context, Either EvalError XObj)
+dispatchCallableBC phase appCtx preference fun args argCodes info ty funXObj =
   if isStaticDefinitionBC funXObj
     then pure (appCtx, Left (HasStaticCall (callXObjBC fun args info ty) info))
     else dispatchByClass (classifyCallableBC funXObj)
@@ -887,7 +896,7 @@ dispatchCallableBC appCtx preference fun args argCodes info ty funXObj =
             Just err -> pure err
             Nothing -> dispatchCompiledClosure mode capturedCtx cid proper rest
         InlineFn params body ->
-          runInlineFnCallBC appCtx preference funExpr params body args argCodes info
+          runInlineFnCallBC phase appCtx preference funExpr params body args argCodes info
         MacroDefForm ->
           dispatchMacroDef
         DynamicDefForm ->
@@ -895,24 +904,24 @@ dispatchCallableBC appCtx preference fun args argCodes info ty funXObj =
         DefDynamicForm ->
           dispatchDefdynamic
         CommandForm arity ->
-          runCommandCallBC appCtx preference arity args argCodes info
+          runCommandCallBC phase appCtx preference arity args argCodes info
         PrimitiveForm prim ->
           runPrimitiveCallBC appCtx funXObj prim args info
         UnknownCallable ->
           pure (evalError appCtx ("Unknown callable object in EvalVM: " ++ pretty funXObj ++ " in call " ++ pretty (callXObjBC fun args info ty)) info)
     resolveAndDispatch spath =
       case resolveSymbol appCtx spath info preference of
-        Just (resolvedCtx, Right resolvedFun) -> dispatchCallableBC resolvedCtx preference fun args argCodes info ty resolvedFun
+        Just (resolvedCtx, Right resolvedFun) -> dispatchCallableBC phase resolvedCtx preference fun args argCodes info ty resolvedFun
         Just (resolvedCtx, Left err) -> pure (resolvedCtx, Left err)
         Nothing -> pure (throwErr (UnknownForm (callXObjBC fun args info ty)) appCtx info)
     dispatchCompiledClosure mode capturedCtx cid proper rest =
       case mode of
         CallAsMacro ->
-          runCompiledMacroClosureCallBC appCtx capturedCtx cid proper rest args
+          runCompiledMacroClosureCallBC phase appCtx preference cid proper rest args
         CallAsDynamic ->
-          runCompiledDynamicClosureCallBC appCtx cid proper rest argCodes
+          runCompiledDynamicClosureCallBC phase appCtx cid proper rest argCodes
         CallAsFunction ->
-          runCompiledClosureCallBC appCtx preference capturedCtx cid proper rest argCodes
+          runCompiledClosureCallBC phase appCtx preference capturedCtx cid proper rest argCodes
     dispatchMacroDef =
       case map raiseExpr args of
         [name, params, body] -> primitiveDefmacroVM funXObj appCtx name params body
@@ -967,8 +976,8 @@ classifyCallableBC xobj =
       PrimitiveForm prim
     _ -> UnknownCallable
 
-runInlineFnCallBC :: Context -> LookupPreference -> XObj -> [XObj] -> XObj -> [EvalIR] -> [EvalCode] -> Maybe Info -> IO (Context, Either EvalError XObj)
-runInlineFnCallBC appCtx preference funExpr params body argsToCall argCodes info =
+runInlineFnCallBC :: EvalPhase -> Context -> LookupPreference -> XObj -> [XObj] -> XObj -> [EvalIR] -> [EvalCode] -> Maybe Info -> IO (Context, Either EvalError XObj)
+runInlineFnCallBC phase appCtx preference funExpr params body argsToCall argCodes info =
   case parseParamSpec params of
     Left err -> pure (appCtx, Left err)
     Right (proper, rest) -> do
@@ -981,59 +990,68 @@ runInlineFnCallBC appCtx preference funExpr params body argsToCall argCodes info
             Left cerr -> pure (ctxAfterCompile, Left cerr)
             Right code -> do
               cid <- registerVMClosureCode code
-              runCompiledClosureCallBC ctxAfterCompile preference ctxAfterCompile cid proper rest argCodes
+              runCompiledClosureCallBC phase ctxAfterCompile preference ctxAfterCompile cid proper rest argCodes
 
-runCompiledClosureCallBC :: Context -> LookupPreference -> Context -> Int -> [String] -> Maybe String -> [EvalCode] -> IO (Context, Either EvalError XObj)
-runCompiledClosureCallBC appCtx preference capturedCtx cid proper restName argCodes = do
-  (ctxWithArgs, evaledArgs) <- evalManyCodeBC appCtx preference argCodes
+runCompiledClosureCallBC :: EvalPhase -> Context -> LookupPreference -> Context -> Int -> [String] -> Maybe String -> [EvalCode] -> IO (Context, Either EvalError XObj)
+runCompiledClosureCallBC phase appCtx preference capturedCtx cid proper restName argCodes = do
+  (ctxWithArgs, evaledArgs) <- evalManyCodeBC phase appCtx preference argCodes
   case evaledArgs of
     Right okArgs -> do
       let callCtx = replaceInternalEnvMaybe ctxWithArgs (contextInternalEnv capturedCtx)
           compileMode = compileModeForPreference preference
-      (ctx', res) <- applyCompiledBC compileMode callCtx cid proper restName okArgs
+      (ctx', res) <- applyCompiledBC phase compileMode callCtx cid proper restName okArgs
       pure (replaceInternalEnvMaybe ctx' (contextInternalEnv ctxWithArgs), res)
     Left err -> pure (ctxWithArgs, Left err)
 
-runCompiledDynamicClosureCallBC :: Context -> Int -> [String] -> Maybe String -> [EvalCode] -> IO (Context, Either EvalError XObj)
-runCompiledDynamicClosureCallBC appCtx cid proper restName argCodes = do
-  (ctxWithArgs, evaledArgs) <- evalManyCodeBC appCtx PreferDynamic argCodes
+runCompiledDynamicClosureCallBC :: EvalPhase -> Context -> Int -> [String] -> Maybe String -> [EvalCode] -> IO (Context, Either EvalError XObj)
+runCompiledDynamicClosureCallBC phase appCtx cid proper restName argCodes = do
+  (ctxWithArgs, evaledArgs) <- evalManyCodeBC phase appCtx PreferDynamic argCodes
   case evaledArgs of
     Right okArgs -> do
-      (ctx', res) <- applyCompiledBC CompileModeDynamic ctxWithArgs cid proper restName okArgs
+      (ctx', res) <- applyCompiledBC phase CompileModeDynamic ctxWithArgs cid proper restName okArgs
       pure (replaceInternalEnvMaybe ctx' (contextInternalEnv ctxWithArgs), res)
     Left err -> pure (ctxWithArgs, Left err)
 
-runCompiledMacroClosureCallBC :: Context -> Context -> Int -> [String] -> Maybe String -> [EvalIR] -> IO (Context, Either EvalError XObj)
-runCompiledMacroClosureCallBC appCtx _ cid proper restName argsToCall = do
-  (ctx', res) <- applyCompiledBC CompileModeMacro appCtx cid proper restName (map raiseExpr argsToCall)
+runCompiledMacroClosureCallBC :: EvalPhase -> Context -> LookupPreference -> Int -> [String] -> Maybe String -> [EvalIR] -> IO (Context, Either EvalError XObj)
+runCompiledMacroClosureCallBC phase appCtx preference cid proper restName argsToCall = do
+  (ctx', res) <- applyCompiledBC phase CompileModeMacro appCtx cid proper restName (map raiseExpr argsToCall)
   case res of
-    Right xobj' -> macroExpandVM ctx' xobj'
+    Right xobj' -> do
+      (expandedCtx, expandedRes) <- macroExpandVM ctx' xobj'
+      case expandedRes of
+        Left err -> pure (expandedCtx, Left err)
+        Right expanded ->
+          case phase of
+            -- Expansion commands should observe macro output as data.
+            PhaseExpand -> pure (expandedCtx, Right expanded)
+            -- Normal evaluation should execute the expanded form immediately.
+            PhaseExecute -> runEvalIRVMWithPhase phase expandedCtx (lowerExpr expandedCtx expanded) preference
     Left _ -> pure (appCtx, res)
 
-runCommandCallBC :: Context -> LookupPreference -> CommandFunctionType -> [EvalIR] -> [EvalCode] -> Maybe Info -> IO (Context, Either EvalError XObj)
-runCommandCallBC appCtx preference arity callArgs argCodes callInfo =
+runCommandCallBC :: EvalPhase -> Context -> LookupPreference -> CommandFunctionType -> [EvalIR] -> [EvalCode] -> Maybe Info -> IO (Context, Either EvalError XObj)
+runCommandCallBC phase appCtx preference arity callArgs argCodes callInfo =
   case (arity, callArgs) of
     (NullaryCommandFunction nullary, []) -> nullary appCtx
     (UnaryCommandFunction unary, [_]) -> do
-      (c, evaledArgs) <- evalManyCodeBC appCtx preference (take 1 argCodes)
+      (c, evaledArgs) <- evalManyCodeBC phase appCtx preference (take 1 argCodes)
       case evaledArgs of
         Right [x'] -> unary c x'
         Left err -> pure (c, Left err)
         _ -> pure (throwErr (UnknownForm (raiseExpr (IRCall (IRLiteral (XObj (Lst []) Nothing Nothing)) callArgs callInfo Nothing))) c callInfo)
     (BinaryCommandFunction binary, [_, _]) -> do
-      (c, evaledArgs) <- evalManyCodeBC appCtx preference (take 2 argCodes)
+      (c, evaledArgs) <- evalManyCodeBC phase appCtx preference (take 2 argCodes)
       case evaledArgs of
         Right [x', y'] -> binary c x' y'
         Left err -> pure (c, Left err)
         _ -> pure (throwErr (UnknownForm (raiseExpr (IRCall (IRLiteral (XObj (Lst []) Nothing Nothing)) callArgs callInfo Nothing))) c callInfo)
     (TernaryCommandFunction ternary, [_, _, _]) -> do
-      (c, evaledArgs) <- evalManyCodeBC appCtx preference (take 3 argCodes)
+      (c, evaledArgs) <- evalManyCodeBC phase appCtx preference (take 3 argCodes)
       case evaledArgs of
         Right [x', y', z'] -> ternary c x' y' z'
         Left err -> pure (c, Left err)
         _ -> pure (throwErr (UnknownForm (raiseExpr (IRCall (IRLiteral (XObj (Lst []) Nothing Nothing)) callArgs callInfo Nothing))) c callInfo)
     (VariadicCommandFunction variadic, xs) -> do
-      (c, evaledArgs) <- evalManyCodeBC appCtx preference (take (length xs) argCodes)
+      (c, evaledArgs) <- evalManyCodeBC phase appCtx preference (take (length xs) argCodes)
       case evaledArgs of
         Right args' -> variadic c args'
         Left err -> pure (c, Left err)
@@ -1051,8 +1069,8 @@ runPrimitiveCallBC appCtx fun prim callArgs callInfo =
         (VariadicPrimitive variadic, xs) -> variadic fun appCtx xs
         _ -> pure (throwErr (UnknownForm (raiseExpr (IRCall (IRLiteral fun) callArgs callInfo Nothing))) appCtx callInfo)
 
-applyCompiledBC :: CompileMode -> Context -> Int -> [String] -> Maybe String -> [XObj] -> IO (Context, Either EvalError XObj)
-applyCompiledBC compileMode appCtx cid proper restName argVals = do
+applyCompiledBC :: EvalPhase -> CompileMode -> Context -> Int -> [String] -> Maybe String -> [XObj] -> IO (Context, Either EvalError XObj)
+applyCompiledBC phase compileMode appCtx cid proper restName argVals = do
   mpayload <- lookupVMClosurePayload cid
   case mpayload of
     Nothing ->
@@ -1102,11 +1120,11 @@ applyCompiledBC compileMode appCtx cid proper restName argVals = do
               CompileModeFunction -> ExecFunction
               CompileModeDynamic -> ExecDynamic
               CompileModeMacro -> ExecMacro
-      (finalCtx, result) <- runEvalCode localCtx (PreferLocal localNames localSlots localNameSlots localExecMode) code
+      (finalCtx, result) <- runEvalCodeWithPhase phase localCtx (PreferLocal localNames localSlots localNameSlots localExecMode) code
       pure (replaceInternalEnvMaybe finalCtx (contextInternalEnv compileCtx), result)
 
-evalManyCodeBC :: Context -> LookupPreference -> [EvalCode] -> IO (Context, Either EvalError [XObj])
-evalManyCodeBC startCtx preference xs = do
+evalManyCodeBC :: EvalPhase -> Context -> LookupPreference -> [EvalCode] -> IO (Context, Either EvalError [XObj])
+evalManyCodeBC phase startCtx preference xs = do
   (newCtx, evaled) <- foldlM successiveEval (startCtx, Right []) xs
   pure (newCtx, fmap reverse evaled)
   where
@@ -1114,29 +1132,29 @@ evalManyCodeBC startCtx preference xs = do
       case acc of
         Left _ -> pure (ctx', acc)
         Right l -> do
-          (nextCtx, evald) <- runEvalCode ctx' preference code
+          (nextCtx, evald) <- runEvalCodeWithPhase phase ctx' preference code
           pure $ case evald of
             Right res -> (nextCtx, Right (res : l))
             Left err -> (nextCtx, Left err)
 
-execIRDoBC :: Context -> LookupPreference -> [EvalIR] -> IO (Context, Either EvalError XObj)
-execIRDoBC ctx preference forms =
+execIRDoBC :: EvalPhase -> Context -> LookupPreference -> [EvalIR] -> IO (Context, Either EvalError XObj)
+execIRDoBC phase ctx preference forms =
   foldlM
     ( \(ctx', acc) next ->
         case acc of
           Left _ -> pure (ctx', acc)
-          Right _ -> runEvalIRVM ctx' next preference
+          Right _ -> runEvalIRVMWithPhase phase ctx' next preference
     )
     (ctx, Right (XObj (Lst []) Nothing Nothing))
     forms
 
-execIRIfBC :: Context -> LookupPreference -> EvalIR -> EvalIR -> EvalIR -> IO (Context, Either EvalError XObj)
-execIRIfBC ctx preference cond trueBranch falseBranch = do
-  (newCtx, evd) <- runEvalIRVM ctx cond preference
+execIRIfBC :: EvalPhase -> Context -> LookupPreference -> EvalIR -> EvalIR -> EvalIR -> IO (Context, Either EvalError XObj)
+execIRIfBC phase ctx preference cond trueBranch falseBranch = do
+  (newCtx, evd) <- runEvalIRVMWithPhase phase ctx cond preference
   case evd of
     Right cond' ->
       case xobjObj cond' of
-        Bol b -> runEvalIRVM newCtx (if b then trueBranch else falseBranch) preference
+        Bol b -> runEvalIRVMWithPhase phase newCtx (if b then trueBranch else falseBranch) preference
         _ -> pure (throwErr (IfContainsNonBool (raiseExpr cond)) ctx (irInfoBC cond))
     Left e -> pure (newCtx, Left e)
 
@@ -1194,7 +1212,10 @@ symToPathBC (IRSymbol ref _ _ _) = Just (refToSymPath ref)
 symToPathBC _ = Nothing
 
 runEvalCode :: Context -> LookupPreference -> EvalCode -> IO (Context, Either EvalError XObj)
-runEvalCode ctx preference code = go ctx preference 0 [] Map.empty Map.empty
+runEvalCode = runEvalCodeWithPhase PhaseExecute
+
+runEvalCodeWithPhase :: EvalPhase -> Context -> LookupPreference -> EvalCode -> IO (Context, Either EvalError XObj)
+runEvalCodeWithPhase phase ctx preference code = go ctx preference 0 [] Map.empty Map.empty
   where
     codeLen = evalCodeLen code
     codeArr = evalCodeArray code
@@ -1303,7 +1324,7 @@ runEvalCode ctx preference code = go ctx preference 0 [] Map.empty Map.empty
                       PreferLocal _ localSlots _ execMode ->
                         case Map.lookup slot localSlots of
                           Just funXObj -> do
-                            (nextCtx, result) <- dispatchCallableBC currentCtx currentPref funIR args argCodes i t funXObj
+                            (nextCtx, result) <- dispatchCallableBC phase currentCtx currentPref funIR args argCodes i t funXObj
                             case result of
                               Right value -> go nextCtx currentPref (pc + 1) (value : stack) symbolCache callableCache
                               Left err -> pure (nextCtx, Left err)
@@ -1322,7 +1343,7 @@ runEvalCode ctx preference code = go ctx preference 0 [] Map.empty Map.empty
                     ckey = cacheKey currentCtx sid
                     funIR = IRSymbol ref mode i t
                     dispatchWith funXObj = do
-                      (nextCtx, result) <- dispatchCallableBC currentCtx currentPref funIR args argCodes i t funXObj
+                      (nextCtx, result) <- dispatchCallableBC phase currentCtx currentPref funIR args argCodes i t funXObj
                       case result of
                         Right value ->
                           let callableCache' =
@@ -1341,7 +1362,7 @@ runEvalCode ctx preference code = go ctx preference 0 [] Map.empty Map.empty
                                   if refCacheable
                                     then Map.insert (cacheKey resolvedCtx sid) funXObj callableCache
                                     else callableCache
-                            (nextCtx, result) <- dispatchCallableBC resolvedCtx currentPref funIR args argCodes i t funXObj
+                            (nextCtx, result) <- dispatchCallableBC phase resolvedCtx currentPref funIR args argCodes i t funXObj
                             case result of
                               Right value -> go nextCtx currentPref (pc + 1) (value : stack) symbolCache callableCache'
                               Left err -> pure (nextCtx, Left err)
@@ -1358,12 +1379,12 @@ runEvalCode ctx preference code = go ctx preference 0 [] Map.empty Map.empty
               Right (items, rest) ->
                 go currentCtx currentPref (pc + 1) (XObj (StaticArr (reverse items)) i t : rest) symbolCache callableCache
           IExecCall fun args argCodes i t -> do
-            (nextCtx, result) <- execIRCallBC currentCtx currentPref fun args argCodes i t
+            (nextCtx, result) <- execIRCallBC phase currentCtx currentPref fun args argCodes i t
             case result of
               Right value -> go nextCtx currentPref (pc + 1) (value : stack) symbolCache callableCache
               Left err -> pure (nextCtx, Left err)
           IExecLet bindings body i t -> do
-            (nextCtx, result) <- execIRLetBC currentCtx currentPref bindings body i t
+            (nextCtx, result) <- execIRLetBC phase currentCtx currentPref bindings body i t
             case result of
               Right value -> go nextCtx currentPref (pc + 1) (value : stack) symbolCache callableCache
               Left err -> pure (nextCtx, Left err)
@@ -1373,17 +1394,17 @@ runEvalCode ctx preference code = go ctx preference 0 [] Map.empty Map.empty
               Right value -> go nextCtx currentPref (pc + 1) (value : stack) symbolCache callableCache
               Left err -> pure (nextCtx, Left err)
           IExecWhile cond body i t -> do
-            (nextCtx, result) <- execIRWhileBC currentCtx currentPref cond body i t
+            (nextCtx, result) <- execIRWhileBC phase currentCtx currentPref cond body i t
             case result of
               Right value -> go nextCtx currentPref (pc + 1) (value : stack) symbolCache callableCache
               Left err -> pure (nextCtx, Left err)
           IExecWith sym forms i t -> do
-            (nextCtx, result) <- execIRWithBC currentCtx sym forms i t
+            (nextCtx, result) <- execIRWithBC phase currentCtx sym forms i t
             case result of
               Right value -> go nextCtx currentPref (pc + 1) (value : stack) symbolCache callableCache
               Left err -> pure (nextCtx, Left err)
           IExecSet target value i t -> do
-            (nextCtx, result) <- execIRSetBC currentCtx target value i t
+            (nextCtx, result) <- execIRSetBC phase currentCtx target value i t
             case result of
               Right value' ->
                 let pref' = syncLocalSlotAfterSet nextCtx currentPref target

--- a/test/TestEvalVM.hs
+++ b/test/TestEvalVM.hs
@@ -17,7 +17,9 @@ testEvalVM =
     vmIfFalse,
     vmDoLastValue,
     vmArrayBuild,
-    vmUnsupportedCallTraps
+    vmUnsupportedCallTraps,
+    vmMacroExecutesExpandedCode,
+    vmExpandPhaseReturnsExpandedMacroForm
   ]
 
 vmLiteral :: Test
@@ -60,6 +62,26 @@ vmUnsupportedCallTraps =
       Left _ -> pure ()
       Right ok -> assertFailure ("unsupported call should trap, got: " ++ show ok)
 
+vmMacroExecutesExpandedCode :: Test
+vmMacroExecutesExpandedCode =
+  TestCase $ do
+    let expr = macroProgram
+    (_, result) <- runEvalIRVM testContext (lowerExpr testContext expr) PreferDynamic
+    assertEqual "execution phase should evaluate expanded macro code" (Right (int 3)) result
+
+vmExpandPhaseReturnsExpandedMacroForm :: Test
+vmExpandPhaseReturnsExpandedMacroForm =
+  TestCase $ do
+    let expr = macroProgram
+    (_, result) <- runEvalIRVMWithPhase PhaseExpand testContext (lowerExpr testContext expr) PreferDynamic
+    case result of
+      Right (XObj (Lst (XObj (Sym (SymPath [] "+") _) _ _ : _)) _ _) ->
+        pure ()
+      Right other ->
+        assertFailure ("expand phase should return expanded macro form, got: " ++ show other)
+      Left err ->
+        assertFailure ("expand phase should succeed, got error: " ++ show err)
+
 testContext :: Context
 testContext =
   Context
@@ -78,3 +100,25 @@ sym name = XObj (Sym (SymPath [] name) Symbol) Nothing Nothing
 
 int :: Int -> XObj
 int n = XObj (Num IntTy (Integral n)) Nothing (Just IntTy)
+
+macroProgram :: XObj
+macroProgram =
+  lst
+    [ sym "do",
+      lst
+        [ sym "defmacro",
+          sym "m",
+          arr [sym "x"],
+          lst [sym "list", quoteSym "+", sym "x", int 1]
+        ],
+      lst [sym "m", int 2]
+    ]
+
+quoteSym :: String -> XObj
+quoteSym name = lst [sym "quote", sym name]
+
+lst :: [XObj] -> XObj
+lst xs = XObj (Lst xs) Nothing Nothing
+
+arr :: [XObj] -> XObj
+arr xs = XObj (Arr xs) Nothing Nothing


### PR DESCRIPTION
This PR splits eval into phases (expand and execute) to reduce the amount of `eval` we need in macros and also fix the REPL such that `(println* "hi")` will now actually print and not just expand. You can still expand using `macro-expand`.

Cheers