### PR TITLE
fix: Make guessing game example work again (trim input).

### DIFF
--- a/examples/guessing_game.carp
+++ b/examples/guessing_game.carp
@@ -42,7 +42,7 @@
       (Random.seed-from (Double.from-int (System.time)))
       (start-new-game!)
       (while guessing
-          (let [user-input (String.trim &(get-line))
+        (let [user-input (String.trim &(get-line))
               guessed-num (from-string &user-input)]
           (if (= &user-input "q\n")
             (exit!)

--- a/examples/guessing_game.carp
+++ b/examples/guessing_game.carp
@@ -42,7 +42,7 @@
       (Random.seed-from (Double.from-int (System.time)))
       (start-new-game!)
       (while guessing
-        (let [user-input (get-line)
+          (let [user-input (String.trim &(get-line))
               guessed-num (from-string &user-input)]
           (if (= &user-input "q\n")
             (exit!)


### PR DESCRIPTION
I tried running the examples and the guessing game didn't work properly, here's a fix.