### PR TITLE
feat(stdlib): add trim, blank?, and repeat-char to String module

### DIFF
--- a/core/String.carp
+++ b/core/String.carp
@@ -240,6 +240,43 @@
   (doc lines "splits a string into lines.")
   (defn lines [s]
     (split-by s &[\newline]))
+
+  (doc trim-left "Trims whitespace from the beginning of a string.")
+  (defn trim-left [s]
+    (let [cs (chars s)
+          len (Array.length &cs)
+          i 0]
+      (do
+        (while (and (< i len) (Char.whitespace? @(Array.unsafe-nth &cs i)))
+          (set! i (Int.inc i)))
+        (if (= i len)
+          @""
+          (from-chars &(Array.suffix &cs i))))))
+
+  (doc trim-right "Trims whitespace from the end of a string.")
+  (defn trim-right [s]
+    (let [cs (chars s)
+          len (Array.length &cs)
+          i (Int.dec len)]
+      (do
+        (while (and (>= i 0) (Char.whitespace? @(Array.unsafe-nth &cs i)))
+          (set! i (Int.dec i)))
+        (if (< i 0)
+          @""
+          (from-chars &(Array.prefix &cs (Int.inc i)))))))
+
+  (doc trim "Trims whitespace from the beginning and end of a string.")
+  (defn trim [s]
+    (trim-left &(trim-right s)))
+
+  (doc blank? "Checks whether the string is empty or contains only whitespace.")
+  (defn blank? [s]
+    (let [cs (chars s)]
+      (Array.all? &(fn [c] (Char.whitespace? @c)) &cs)))
+
+  (doc repeat-char "Returns a new string which is the character `c` repeated `n` times.")
+  (defn repeat-char [n c]
+    (from-chars &(Array.replicate n &c)))
 )
 
 (defmodule StringCopy

--- a/test/string.carp
+++ b/test/string.carp
@@ -400,4 +400,24 @@
                 3
                 (Dynamic.length (Dynamic.String.to-array "abc"))
                 "Dynamic.String.to-array works as expected (check length)")
+
+  (assert-equal test
+                "hello"
+                &(trim-left "   hello")
+                "trim-left works as expected")
+  (assert-equal test
+                "hello"
+                &(trim-right "hello   ")
+                "trim-right works as expected")
+  (assert-equal test
+                "hello"
+                &(trim "   hello   ")
+                "trim works as expected")
+  (assert-true test
+               (blank? "   \n\t ")
+               "blank? works as expected")
+  (assert-equal test
+                "aaaaa"
+                &(repeat-char 5 \a)
+                "repeat-char works as expected")
 )


### PR DESCRIPTION
This PR introduces several common string utilities to the Carp standard library.

### Changes:
- **Trim Functions:** Added `trim-left`, `trim-right`, and `trim` for removing leading/trailing whitespace.
- **Predicates:** Added `blank?` to check if a string is empty or contains only whitespace.
- **Utilities:** Added `repeat-char` for efficient character repetition.
- **Tests:** Integrated new test cases into `test/string.carp`.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp standard library consistency.