### PR TITLE
refactor(compiler): resolve original variable names in borrow checker errors

### DIFF
--- a/src/Memory.hs
+++ b/src/Memory.hs
@@ -23,7 +23,8 @@ data MemState = MemState
   { memStateDeleters :: Set.Set Deleter,
     memStateDeps :: Set.Set Ty,
     memStateLifetimes :: Map.Map String LifetimeMode,
-    memStateParamDeleters :: Set.Set Deleter
+    memStateParamDeleters :: Set.Set Deleter,
+    memStateNames :: Map.Map String String
   }
   deriving (Show)
 
@@ -39,7 +40,7 @@ data LifetimeMode
 -- | the code emitter can access them and insert calls to destructors.
 manageMemory :: TypeEnv -> Env -> XObj -> Either TypeError (XObj, Set.Set Ty)
 manageMemory typeEnv globalEnv root =
-  let (finalObj, finalState) = runState (visit root) (MemState Set.empty Set.empty Map.empty Set.empty)
+  let (finalObj, finalState) = runState (visit root) (MemState Set.empty Set.empty Map.empty Set.empty Map.empty)
       deleteThese = memStateDeleters finalState
       deps = memStateDeps finalState
    in -- (trace ("Delete these: " ++ joinWithComma (map show (Set.toList deleteThese)))) $
@@ -54,7 +55,7 @@ manageMemory typeEnv globalEnv root =
               -- considered alive, and returnRefTargetIsAlive so only return-
               -- type lifetimes are checked (not the function type's own
               -- lifetime, which may have had internal temporaries merged in).
-              case evalState (returnRefTargetIsAlive ok) (MemState (memStateParamDeleters finalState) Set.empty (memStateLifetimes finalState) Set.empty) of
+              case evalState (returnRefTargetIsAlive ok) (MemState (memStateParamDeleters finalState) Set.empty (memStateLifetimes finalState) Set.empty (memStateNames finalState)) of
                 Left err -> Left err
                 Right _ -> Right (ok {xobjInfo = newInfo}, deps)
   where
@@ -124,13 +125,14 @@ manageMemory typeEnv globalEnv root =
                 -- Add the captured variables (if any, only happens in lifted lambdas) as fake deleters
                 -- TODO: Use another kind of Deleter for this case since it's pretty special?
                 mapM_
-                  ( ( \cap ->
-                        modify
-                          ( \memState ->
-                              memState {memStateDeleters = Set.insert (FakeDeleter cap) (memStateDeleters memState)}
-                          )
-                    )
-                      . getName
+                  ( \cap ->
+                      modify
+                        ( \memState ->
+                            let var = varOfXObj cap
+                                name = getName cap
+                                newNames = Map.insert var name (memStateNames memState)
+                             in memState {memStateDeleters = Set.insert (FakeDeleter var) (memStateDeleters memState), memStateNames = newNames}
+                        )
                   )
                   captures
                 mapM_ (addToLifetimesMappingsIfRef False) argList
@@ -507,7 +509,8 @@ manage typeEnv globalEnv xobj =
         let newDeleters = Set.insert deleter (memStateDeleters m)
             t = fromMaybe (error "memory: can't manage xobj without type") $ xobjTy xobj
             newDeps = Set.insert t (memStateDeps m)
-        put $ m {memStateDeleters = newDeleters, memStateDeps = newDeps}
+            newNames = Map.insert (varOfXObj xobj) (getName xobj) (memStateNames m)
+        put $ m {memStateDeleters = newDeleters, memStateDeps = newDeps, memStateNames = newNames}
       Nothing -> pure ()
 
 -- | Remove `xobj` from the set of alive variables, in need of deletion at end of scope.
@@ -625,11 +628,12 @@ refTargetIsAlive xobj =
              in case Set.toList deadVars of
                   [] -> pure (Right xobj)
                   (deadName : _) ->
-                    pure
-                      ( case xobjObj xobj of
-                          (Lst (LetPat _ _ body)) -> Left (UsingDeadReference body deadName)
-                          _ -> Left (UsingDeadReference xobj deadName)
-                      )
+                    let original = Map.lookup deadName (memStateNames m)
+                     in pure
+                          ( case xobjObj xobj of
+                              (Lst (LetPat _ _ body)) -> Left (UsingDeadReference body deadName original)
+                              _ -> Left (UsingDeadReference xobj deadName original)
+                          )
           Just LifetimeOutsideFunction ->
             pure (Right xobj)
           Just (LifetimeMixed _) ->
@@ -673,10 +677,11 @@ returnRefTargetIsAlive xobj =
        in case Set.toList deadVars of
             [] -> pure (Right xobj)
             (deadName : _) ->
-              let reportOn = case xobjObj fnBody of
+              let original = Map.lookup deadName (memStateNames m)
+                  reportOn = case xobjObj fnBody of
                     Lst (LetPat _ _ body) -> body
                     _ -> fnBody
-               in pure (Left (UsingDeadReference reportOn deadName))
+               in pure (Left (UsingDeadReference reportOn deadName original))
 
 -- | Map from lifetime variables (of refs) to a `LifetimeMode`
 -- | (usually containing the name of the XObj that the lifetime is tied to).

--- a/src/TypeError.hs
+++ b/src/TypeError.hs
@@ -58,7 +58,7 @@ data TypeError
   | InvalidLetBinding [XObj] (XObj, XObj)
   | DuplicateBinding XObj
   | DefinitionsMustBeAtToplevel XObj
-  | UsingDeadReference XObj String
+  | UsingDeadReference XObj String (Maybe String)
   | UninhabitedConstructor Ty XObj Int Int
   | InconsistentKinds String [XObj]
   | FailedToAddLambdaStructToTyEnv SymPath XObj
@@ -323,8 +323,8 @@ instance Show TypeError where
     "I encountered a duplicate binding `" ++ pretty xobj ++ "` inside the `let` at " ++ prettyInfoFromXObj xobj ++ "."
   show (DefinitionsMustBeAtToplevel xobj) =
     "I encountered a definition that was not at top level: `" ++ pretty xobj ++ "`"
-  show (UsingDeadReference xobj dependsOn) =
-    "The reference '" ++ pretty xobj ++ "' (depending on the variable '" ++ dependsOn ++ "') isn't alive at " ++ prettyInfoFromXObj xobj ++ "."
+  show (UsingDeadReference xobj dependsOn originalName) =
+    "The reference '" ++ pretty xobj ++ "' (depending on the variable '" ++ (fromMaybe dependsOn originalName) ++ "') isn't alive at " ++ prettyInfoFromXObj xobj ++ "."
   show (UninhabitedConstructor ty xobj got wanted) =
     "Can't use a struct or sumtype constructor without arguments as a member type at " ++ prettyInfoFromXObj xobj ++ ". The type constructor " ++ show ty ++ " expects " ++ show wanted ++ " arguments but got " ++ show got
   show (InconsistentKinds varName xobjs) =
@@ -453,7 +453,7 @@ machineReadableErrorStrings fppl err =
       [machineReadableInfoFromXObj fppl xobj ++ " Duplicate binding `" ++ pretty xobj ++ "` inside `let`."]
     (DefinitionsMustBeAtToplevel xobj) ->
       [machineReadableInfoFromXObj fppl xobj ++ " Definition not at top level: `" ++ pretty xobj ++ "`"]
-    (UsingDeadReference xobj _) ->
+    (UsingDeadReference xobj _ _) ->
       [machineReadableInfoFromXObj fppl xobj ++ " The reference '" ++ pretty xobj ++ "' isn't alive."]
     (UninhabitedConstructor ty xobj got wanted) ->
       [machineReadableInfoFromXObj fppl xobj ++ "Can't use a struct or sumtype constructor without arguments as a member type at " ++ prettyInfoFromXObj xobj ++ ". The type constructor " ++ show ty ++ " expects " ++ show wanted ++ " arguments but got " ++ show got]


### PR DESCRIPTION
This PR significantly improves the clarity of borrow checker error messages by mapping internal compiler-generated names (like `_16`) back to the original variable names defined by the user.

### Changes:
- **Internal Mapping:** Added a `memStateNames` map to the borrow checker's state (`MemState`) to track the relationship between internal expression IDs and user-defined names.
- **Metadata Capture:** Updated the `manage` and lambda-capture logic in `Memory.hs` to populate this map whenever a new variable is encountered.
- **Error Enhancement:** Modified the `UsingDeadReference` error in `TypeError.hs` to prioritize the original name if available.
- **UX Improvement:** Errors now read `The reference 'r' (depending on the variable 'my-important-string') isn't alive` instead of referring to cryptic internal IDs.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp compiler's diagnostics.