### PR TITLE
feat(stdlib): add find-last, take/drop, split-by-predicate, and variadic zip-n to Array

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -116,6 +116,30 @@ If it doesn’t find an index, `Nothing` will be returned.")
             (break))))
       ret))
 
+  (doc find-last "finds the last element in `a` that matches the function `f` and wraps it in a `Just`.
+
+If it doesn’t find an element, `Nothing` will be returned.")
+  (defn find-last [f a]
+    (let-do [res (Maybe.Nothing)]
+      (for [i (Int.dec (length a)) -1 -1]
+        (when (~f (unsafe-nth a i))
+          (do
+            (set! res (Maybe.Just @(unsafe-nth a i)))
+            (break))))
+      res))
+
+  (doc find-last-index "finds the index of the last element in `a` that matches the function `f` and wraps it in a `Just`.
+
+If it doesn’t find an index, `Nothing` will be returned.")
+  (defn find-last-index [f a]
+    (let-do [ret (Maybe.Nothing)]
+      (for [i (Int.dec (length a)) -1 -1]
+        (when (~f (unsafe-nth a i))
+          (do
+            (set! ret (Maybe.Just i))
+            (break))))
+      ret))
+
   (doc unsafe-first "takes the first element of an array.
 
 Generates a runtime error if the array is empty.")
@@ -595,6 +619,19 @@ Example:
               (set! result (Array.push-back result @&sep))
               (set! result (Array.push-back result @(Array.unsafe-nth xs i)))))))
       result))
+
+  (doc split-by-predicate
+    "splits an array `a` into two arrays: those that satisfy the predicate `f` and those that do not.
+Returns a `Pair` of arrays.")
+  (defn split-by-predicate [f a]
+    (let-do [matching []
+             not-matching []]
+      (for [i 0 (length a)]
+        (let [x (unsafe-nth a i)]
+          (if (~f x)
+            (set! matching (push-back matching @x))
+            (set! not-matching (push-back not-matching @x)))))
+      (Pair.init matching not-matching)))
 )
 
 (defmacro doall [f xs]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -230,6 +230,14 @@ If the array is empty, returns `Nothing`")
   (defn suffix [xs start-index]
     (slice xs start-index (length xs)))
 
+  (doc take "takes the first `n` elements from an array.")
+  (defn take [n xs]
+    (slice xs 0 n))
+
+  (doc drop "drops the first `n` elements from an array.")
+  (defn drop [n xs]
+    (slice xs n (length xs)))
+
   (doc rest "gets all but the first element from the array.")
   (defn rest [xs]
     (suffix xs 1))
@@ -632,7 +640,38 @@ Returns a `Pair` of arrays.")
             (set! matching (push-back matching @x))
             (set! not-matching (push-back not-matching @x)))))
       (Pair.init matching not-matching)))
+
+  (doc zip-n "takes a function `f` and any number of arrays, and zips them into a new array.
+The length of the resulting array is the length of the shortest input array.")
+  (defmacro zip-n [f :rest arrays]
+    (let [res (gensym-with 'res)
+          i (gensym-with 'i)
+          min-len (gensym-with 'min-len)
+          func (gensym-with 'func)]
+      `(let [%min-len %(min-all-list (map-length-list arrays))
+             %res (Array.allocate %min-len)
+             %func %f]
+         (do
+           (for [%i 0 %min-len]
+             (Array.aset-uninitialized! &%res %i
+               (~%func %@(map-nth-list arrays i))))
+           %res))))
 )
+
+(defndynamic map-length-list [arrs]
+  (if (empty? arrs)
+    '()
+    (cons `(Array.length %(car arrs)) (map-length-list (cdr arrs)))))
+
+(defndynamic min-all-list [xs]
+  (if (= (length xs) 1)
+    (car xs)
+    (list 'Int.min (car xs) (min-all-list (cdr xs)))))
+
+(defndynamic map-nth-list [arrs i]
+  (if (empty? arrs)
+    '()
+    (cons `(Array.unsafe-nth %(car arrs) %i) (map-nth-list (cdr arrs) i))))
 
 (defmacro doall [f xs]
   `(for [i 0 (Array.length &%xs)]

--- a/core/Array.carp
+++ b/core/Array.carp
@@ -637,8 +637,8 @@ Returns a `Pair` of arrays.")
       (for [i 0 (length a)]
         (let [x (unsafe-nth a i)]
           (if (~f x)
-            (set! matching (push-back matching @x))
-            (set! not-matching (push-back not-matching @x)))))
+            (push-back! &matching @x)
+            (push-back! &not-matching @x))))
       (Pair.init matching not-matching)))
 
   (doc zip-n "takes a function `f` and any number of arrays, and zips them into a new array.

--- a/test/array.carp
+++ b/test/array.carp
@@ -435,4 +435,31 @@
                 42
                 (unsafe-nth-value &[42 43] 0)
                 "unsafe-nth-value works as expected")
+
+  (assert-equal test
+                &(Maybe.Just 2)
+                &(find-last &(fn [x] (= @x 2)) &[1 2 3 2 1])
+                "find-last works as expected")
+  (assert-equal test
+                &(Maybe.Just 3)
+                &(find-last-index &(fn [x] (= @x 2)) &[1 2 3 2 1])
+                "find-last-index works as expected")
+  (assert-equal test
+                &(Maybe.Nothing)
+                &(find-last &(fn [x] (= @x 5)) &[1 2 3 2 1])
+                "find-last returns Nothing when not found")
+
+  (let [arr &[1 2 3 4 5]
+        p (split-by-predicate &(fn [x] (Int.even? @x)) arr)]
+    (assert-ref-equal test
+                      [2 4]
+                      @(Pair.a &p)
+                      "split-by-predicate matching part is correct"))
+
+  (let [arr &[1 2 3 4 5]
+        p (split-by-predicate &(fn [x] (Int.even? @x)) arr)]
+    (assert-ref-equal test
+                      [1 3 5]
+                      @(Pair.b &p)
+                      "split-by-predicate non-matching part is correct"))
 )

--- a/test/array.carp
+++ b/test/array.carp
@@ -462,4 +462,24 @@
                       [1 3 5]
                       @(Pair.b &p)
                       "split-by-predicate non-matching part is correct"))
+
+  (let [arr &[1 2 3 4 5]]
+    (assert-equal test
+                  &[1 2 3]
+                  &(take 3 arr)
+                  "take works as expected"))
+
+  (let [arr &[1 2 3 4 5]]
+    (assert-equal test
+                  &[4 5]
+                  &(drop 3 arr)
+                  "drop works as expected"))
+
+  (let [a &[1 2 3]
+        b &[10 20 30]
+        c &[100 200 300 400]]
+    (assert-equal test
+                  &[111 222 333]
+                  &(zip-n &(fn [x y z] (+ @x (+ @y @z))) a b c)
+                  "zip-n works as expected with 3 arrays"))
 )

--- a/test/array.carp
+++ b/test/array.carp
@@ -437,16 +437,16 @@
                 "unsafe-nth-value works as expected")
 
   (assert-equal test
-                &(Maybe.Just 2)
-                &(find-last &(fn [x] (= @x 2)) &[1 2 3 2 1])
+                &(Maybe.Just 4)
+                &(find-last &(fn [x] (Int.even? @x)) &[1 2 3 4 5])
                 "find-last works as expected")
   (assert-equal test
                 &(Maybe.Just 3)
-                &(find-last-index &(fn [x] (= @x 2)) &[1 2 3 2 1])
+                &(find-last-index &(fn [x] (Int.even? @x)) &[1 2 3 4 5])
                 "find-last-index works as expected")
   (assert-equal test
                 &(Maybe.Nothing)
-                &(find-last &(fn [x] (= @x 5)) &[1 2 3 2 1])
+                &(find-last &(fn [x] (> @x 10)) &[1 2 3 4 5])
                 "find-last returns Nothing when not found")
 
   (let [arr &[1 2 3 4 5]


### PR DESCRIPTION
This PR introduces several common functional and search utilities to the `Array` module, bringing it closer to parity with other functional standard libraries.

### Changes:
- **Reverse Searching:** Added `find-last` and `find-last-index` for searching from the end of an array.
- **Slicing Helpers:** Added `take` and `drop` for simple index-based array truncation.
- **Partitioning:** Added `split-by-predicate` to divide an array into matching and non-matching elements (returns a `Pair`).
- **Variadic Zipping:** Added a powerful `zip-n` macro that allows zipping an arbitrary number of arrays with a multi-argument function.
- **Tests:** Integrated 8 new test cases into `test/array.carp`.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp standard library consistency.