### PR TITLE
feat(stdlib): add Array.flatten

### DIFF
--- a/core/Array.carp
+++ b/core/Array.carp
@@ -363,6 +363,10 @@ The trailing elements of the longer array will be discarded.")
           (set! j (+ j len))))
       result))
 
+  (doc flatten "collapses a nested array of arrays into a single array. (Alias for [`concat`](#concat)).")
+  (defn flatten [xs]
+    (concat xs))
+
   (doc enumerated "creates a new array of `Pair`s where the first position is the index and the second position is the element from the original array `xs`.")
   (defn enumerated [xs]
     (let-do [arr (allocate (length xs))]

--- a/test/array.carp
+++ b/test/array.carp
@@ -187,6 +187,10 @@
                     (concat &[[1] [2 3] [4 5 6] [7 8]])
                     "concat works as expected")
   (assert-ref-equal test
+                    [1 2 3 4 5 6 7 8]
+                    (flatten &[[1] [2 3] [4 5 6] [7 8]])
+                    "flatten works as expected")
+  (assert-ref-equal test
                     [11 22 33]
                     (zip &add-ref &[1 2 3 4 5 6 7] &[10 20 30])
                     "zip works as expected")


### PR DESCRIPTION
This PR adds `Array.flatten` to the standard library as a descriptive alias for `Array.concat`.

### Changes:
- **Flattening:** Added `Array.flatten` to collapse nested arrays.
- **Tests:** Integrated a new test case into `test/array.carp`.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp standard library consistency.