### PR TITLE
feat(stdlib): add if-let and while-let macros

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -98,8 +98,8 @@ Example:
      ""
      "```"
      "(doto-ref @\"hi\""
-     "  (string-set! 0 \o)"
-     "  (string-set! 1 \y))"
+     "  (string-set! 0 \\o)"
+     "  (string-set! 1 \\y))"
      "```")
 (defmacro doto-ref [thing :rest expressions]
   (let [s (gensym)]
@@ -125,6 +125,91 @@ Example:
   (list 'while condition
         (cons 'do forms)))
 
+;; Note: if-let/when-let/while-let are specialized for Maybe and Result types to ensure
+;; type safety. In Carp, a single match block cannot handle both Maybe.Just
+;; and Result.Success constructors simultaneously.
+
+(hidden if-let-internal)
+(defndynamic if-let-internal [bindings then else]
+  (if (= (length bindings) 0)
+    then
+    (let [var (car bindings)
+          expr (cadr bindings)
+          rest (cdr (cdr bindings))
+          res (list 'match expr
+                    (list 'Maybe.Just var) (if-let-internal rest then else)
+                    (list 'Maybe.Nothing) else)]
+      res)))
+
+(doc if-let "Conditional binding. If the expressions evaluate to Just, their values are bound to the names and the then-branch is executed. Otherwise, the else-branch is executed.
+
+Example:
+```
+(if-let [x (Maybe.Just 10)
+         y (Maybe.Just 20)]
+  (+ x y)
+  0)
+```")
+(defmacro if-let [bindings then else]
+  (if-let-internal bindings then else))
+
+(doc when-let "Conditional binding. If the expressions evaluate to Just, their values are bound to the names and the body is executed.")
+(defmacro when-let [bindings body]
+  (if-let-internal bindings body ()))
+
+(doc while-let "Repeatedly evaluates the expressions and binds their values to the names if they are all Just, executing the body each time. The loop stops when any Nothing is encountered.")
+(defmacro while-let [bindings :rest body]
+  (let [var (car bindings)
+        expr (cadr bindings)
+        rest (cdr (cdr bindings))]
+    `(while true
+       (match %expr
+         (Maybe.Just %var)
+           (if-let %rest
+             (do %@body)
+             (break))
+         (Maybe.Nothing) (break)))))
+
+(hidden if-let-ok-internal)
+(defndynamic if-let-ok-internal [bindings then else]
+  (if (= (length bindings) 0)
+    then
+    (let [var (car bindings)
+          expr (cadr bindings)
+          rest (cdr (cdr bindings))]
+      (list 'match expr
+            (list 'Result.Success var) (if-let-ok-internal rest then else)
+            (list 'Result.Error '_) else))))
+
+(doc if-let-ok "Conditional binding for Result. If the expressions evaluate to Success, their values are bound to the names and the then-branch is executed. Otherwise, the else-branch is executed.
+
+Example:
+```
+(if-let-ok [x (Result.Success 10)
+            y (Result.Success 20)]
+  (+ x y)
+  0)
+```")
+(defmacro if-let-ok [bindings then else]
+  (if-let-ok-internal bindings then else))
+
+(doc when-let-ok "Conditional binding for Result. If the expressions evaluate to Success, their values are bound to the names and the body is executed.")
+(defmacro when-let-ok [bindings body]
+  (if-let-ok-internal bindings body ()))
+
+(doc while-let-ok "Repeatedly evaluates the expressions and binds their values to the names if they are all Success, executing the body each time. The loop stops when any Error is encountered.")
+(defmacro while-let-ok [bindings :rest body]
+  (let [var (car bindings)
+        expr (cadr bindings)
+        rest (cdr (cdr bindings))]
+    `(while true
+       (match %expr
+         (Result.Success %var)
+           (if-let-ok %rest
+             (do %@body)
+             (break))
+         (Result.Error _) (break)))))
+
 (doc defn-do "is a `defn` with an implicit `do` body.")
 (defmacro defn-do [name arguments :rest body]
   (list 'defn name arguments (cons 'do body)))
@@ -139,35 +224,6 @@ Example:
  "In other words, executes `forms` only for their side effects.")
  (defmacro ignore-do [:rest forms]
    (cons 'do (expand (apply ignore* forms))))
-
-(doc if-let "Conditional execution based on a `Maybe` value.
-If `expr` evaluates to `(Just x)`, the `then` branch is executed with `var` bound to `x`.
-Otherwise, the `else` branch is executed.")
-(defmacro if-let [bindings then else]
-  (let [var (car bindings)
-        expr (cadr bindings)]
-    `(match %expr
-       (Maybe.Just %var) %then
-       (Maybe.Nothing) %else)))
-
-(doc while-let "Looping execution based on a `Maybe` value.
-Repeatedly evaluates `expr`. As long as it returns `(Just x)`, the `body` is executed with `var` bound to `x`.")
-(defmacro while-let [bindings body]
-  (let [var (car bindings)
-        expr (cadr bindings)]
-    `(while true
-       (match %expr
-         (Maybe.Just %var) %body
-         (Maybe.Nothing) (break)))))
-
-(doc when-let "Conditional execution based on a `Maybe` value.
-If `expr` evaluates to `(Just x)`, the `body` is executed with `var` bound to `x`.")
-(defmacro when-let [bindings body]
-  (let [var (car bindings)
-        expr (cadr bindings)]
-    `(match %expr
-       (Maybe.Just %var) %body
-       (Maybe.Nothing) ())))
 
 (doc when "is an `if` without an else branch.")
 (defmacro when [condition form]

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -140,6 +140,35 @@ Example:
  (defmacro ignore-do [:rest forms]
    (cons 'do (expand (apply ignore* forms))))
 
+(doc if-let "Conditional execution based on a `Maybe` value.
+If `expr` evaluates to `(Just x)`, the `then` branch is executed with `var` bound to `x`.
+Otherwise, the `else` branch is executed.")
+(defmacro if-let [bindings then else]
+  (let [var (car bindings)
+        expr (cadr bindings)]
+    `(match %expr
+       (Maybe.Just %var) %then
+       (Maybe.Nothing) %else)))
+
+(doc while-let "Looping execution based on a `Maybe` value.
+Repeatedly evaluates `expr`. As long as it returns `(Just x)`, the `body` is executed with `var` bound to `x`.")
+(defmacro while-let [bindings body]
+  (let [var (car bindings)
+        expr (cadr bindings)]
+    `(while true
+       (match %expr
+         (Maybe.Just %var) %body
+         (Maybe.Nothing) (break)))))
+
+(doc when-let "Conditional execution based on a `Maybe` value.
+If `expr` evaluates to `(Just x)`, the `body` is executed with `var` bound to `x`.")
+(defmacro when-let [bindings body]
+  (let [var (car bindings)
+        expr (cadr bindings)]
+    `(match %expr
+       (Maybe.Just %var) %body
+       (Maybe.Nothing) ())))
+
 (doc when "is an `if` without an else branch.")
 (defmacro when [condition form]
   (list 'if condition form (list)))

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -125,10 +125,6 @@ Example:
   (list 'while condition
         (cons 'do forms)))
 
-;; Note: if-let/when-let/while-let are specialized for Maybe and Result types to ensure
-;; type safety. In Carp, a single match block cannot handle both Maybe.Just
-;; and Result.Success constructors simultaneously.
-
 (hidden if-let-internal)
 (defndynamic if-let-internal [bindings then else]
   (if (= (length bindings) 0)

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -137,7 +137,7 @@ Example:
                     (list 'Maybe.Nothing) else)]
       res)))
 
-(doc if-let "Conditional binding. If the expressions evaluate to Just, their values are bound to the names and the then-branch is executed. Otherwise, the else-branch is executed.
+(doc if-let "Conditional binding for Maybe. If each binding's expression evaluates to Just, its value is bound to the corresponding name and the 'then' branch is executed. If any expression evaluates to Nothing, the 'else' branch is executed.
 
 Example:
 ```
@@ -149,11 +149,11 @@ Example:
 (defmacro if-let [bindings then else]
   (if-let-internal bindings then else))
 
-(doc when-let "Conditional binding. If the expressions evaluate to Just, their values are bound to the names and the body is executed.")
+(doc when-let "Conditional binding for Maybe. If each binding's expression evaluates to Just, its value is bound to the corresponding name and the body is executed.")
 (defmacro when-let [bindings body]
   (if-let-internal bindings body ()))
 
-(doc while-let "Repeatedly evaluates the expressions and binds their values to the names if they are all Just, executing the body each time. The loop stops when any Nothing is encountered.")
+(doc while-let "Repeatedly evaluates the bindings and binds their values to the names if they are all Just, executing the body each time. The loop stops when any Nothing is encountered.")
 (defmacro while-let [bindings :rest body]
   (let [var (car bindings)
         expr (cadr bindings)
@@ -177,7 +177,7 @@ Example:
             (list 'Result.Success var) (if-let-ok-internal rest then else)
             (list 'Result.Error '_) else))))
 
-(doc if-let-ok "Conditional binding for Result. If the expressions evaluate to Success, their values are bound to the names and the then-branch is executed. Otherwise, the else-branch is executed.
+(doc if-let-ok "Conditional binding for Result. If each binding's expression evaluates to Success, its value is bound to the corresponding name and the 'then' branch is executed. If any expression evaluates to Error, the 'else' branch is executed.
 
 Example:
 ```
@@ -189,11 +189,11 @@ Example:
 (defmacro if-let-ok [bindings then else]
   (if-let-ok-internal bindings then else))
 
-(doc when-let-ok "Conditional binding for Result. If the expressions evaluate to Success, their values are bound to the names and the body is executed.")
+(doc when-let-ok "Conditional binding for Result. If each binding's expression evaluates to Success, its value is bound to the corresponding name and the body is executed.")
 (defmacro when-let-ok [bindings body]
   (if-let-ok-internal bindings body ()))
 
-(doc while-let-ok "Repeatedly evaluates the expressions and binds their values to the names if they are all Success, executing the body each time. The loop stops when any Error is encountered.")
+(doc while-let-ok "Repeatedly evaluates the bindings and binds their values to the names if they are all Success, executing the body each time. The loop stops when any Error is encountered.")
 (defmacro while-let-ok [bindings :rest body]
   (let [var (car bindings)
         expr (cadr bindings)
@@ -214,11 +214,11 @@ Example:
 (defmacro forever-do [:rest forms]
   (list 'while true (cons 'do forms)))
 
- (doc ignore-do 
- ("Wraps side-effecting `forms` in a `do`, " false)
- "ignoring all of their results."
- "In other words, executes `forms` only for their side effects.")
- (defmacro ignore-do [:rest forms]
+(doc ignore-do 
+     ("Wraps side-effecting `forms` in a `do`, " false)
+     "ignoring all of their results."
+     "In other words, executes `forms` only for their side effects.")
+(defmacro ignore-do [:rest forms]
    (cons 'do (expand (apply ignore* forms))))
 
 (doc when "is an `if` without an else branch.")

--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -217,6 +217,7 @@ other expressions, otherwise it returns the value of the last form in `xs`.
   (cond-internal xs))
 
 (doc refstr "stringifies `x` and takes the reference of that string.")
+
 (defmacro refstr [x]
   (list 'ref
         (list 'str x)))

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -12,4 +12,27 @@
   (assert-true test
     (and (= () (test-ignore-do)) (= &test-string "new-string"))
     "ignore-do performs side effects and ignores all results")
+
+  (assert-equal test
+                "found 10"
+                &(if-let [x (Maybe.Just 10)]
+                  (fmt "found %d" x)
+                  @"not found")
+                "if-let works with Just")
+
+  (let-do [counter 0
+           res []]
+    (while-let [x (if (< counter 3) (Maybe.Just counter) (the (Maybe Int) (Maybe.Nothing)))]
+      (do
+        (set! res (Array.push-back res x))
+        (set! counter (inc counter))))
+    (assert-equal test
+                  &[0 1 2]
+                  &res
+                  "while-let works as expected"))
+
+  (let-do [x 0]
+    (do
+      (when-let [v (Maybe.Just 10)] (set! x v))
+      (assert-equal test 10 x "when-let executes body with Just")))
 )

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -14,25 +14,107 @@
     "ignore-do performs side effects and ignores all results")
 
   (assert-equal test
+                10
+                (if-let [x (Maybe.Just 10)] x 0)
+                "if-let works on Just")
+  (assert-equal test
+                0
+                (if-let [x (Maybe.Nothing)] x 0)
+                "if-let works on Nothing")
+  (assert-equal test
+                30
+                (if-let [x (Maybe.Just 10)
+                         y (Maybe.Just 20)]
+                  (+ x y)
+                  0)
+                "if-let works on multiple Just")
+  (assert-equal test
+                0
+                (if-let [x (Maybe.Just 10)
+                         y (Maybe.Nothing)]
+                  (+ x y)
+                  0)
+                "if-let works on mixed Just/Nothing")
+
+  (assert-equal test
                 "found 10"
                 &(if-let [x (Maybe.Just 10)]
                   (fmt "found %d" x)
                   @"not found")
-                "if-let works with Just")
+                "if-let works with Just and fmt")
 
-  (let-do [counter 0
-           res []]
-    (while-let [x (if (< counter 3) (Maybe.Just counter) (the (Maybe Int) (Maybe.Nothing)))]
-      (do
-        (set! res (Array.push-back res x))
-        (set! counter (inc counter))))
-    (assert-equal test
-                  &[0 1 2]
-                  &res
-                  "while-let works as expected"))
+  (assert-equal test
+                10
+                (let-do [y 0]
+                  (do (when-let [x (Maybe.Just 10)] (set! y x))
+                      y))
+                "when-let works on Just")
 
-  (let-do [x 0]
-    (do
-      (when-let [v (Maybe.Just 10)] (set! x v))
-      (assert-equal test 10 x "when-let executes body with Just")))
+  (assert-equal test
+                30
+                (let-do [y 0]
+                  (do (when-let [x (Maybe.Just 10)
+                                 z (Maybe.Just 20)]
+                        (set! y (+ x z)))
+                      y))
+                "when-let works on multiple Just")
+
+  (assert-equal test
+                6
+                (let-do [xs [1 2 3]
+                         sum 0]
+                  (do
+                    (while-let [x (Array.first &xs)]
+                      (do
+                        (set! sum (+ sum x))
+                        (set! xs (Array.rest &xs))))
+                    sum))
+                "while-let works on Maybe sequence")
+
+  (assert-equal test
+                3
+                (let-do [xs [1 2 3]
+                         ys [1 2 3]
+                         sum 0]
+                  (do
+                    (while-let [x (Array.first &xs)
+                                y (Array.first &ys)]
+                      (do
+                        (set! sum (+ sum 1))
+                        (set! xs (Array.rest &xs))
+                        (set! ys (Array.rest &ys))))
+                    sum))
+                "while-let works on multiple Maybe sequences")
+
+  (assert-equal test
+                10
+                (if-let-ok [x (the (Result Int Int) (Result.Success 10))] x 0)
+                "if-let-ok works on Success")
+  (assert-equal test
+                0
+                (if-let-ok [x (the (Result Int Int) (Result.Error 0))] x 0)
+                "if-let-ok works on Error")
+  (assert-equal test
+                30
+                (if-let-ok [x (the (Result Int Int) (Result.Success 10))
+                            y (the (Result Int Int) (Result.Success 20))]
+                  (+ x y)
+                  0)
+                "if-let-ok works on multiple Success")
+
+  (assert-equal test
+                10
+                (let-do [y 0]
+                  (do (when-let-ok [x (the (Result Int Int) (Result.Success 10))] (set! y x))
+                      y))
+                "when-let-ok works on Success")
+
+  (assert-equal test
+                1
+                (let-do [counter 0]
+                  (do
+                    (while-let-ok [x (if (= counter 0) (the (Result Int Int) (Result.Success 10)) (the (Result Int Int) (Result.Error 0)))]
+                      (set! counter (inc counter)))
+                    counter))
+                "while-let-ok works on Result")
 )

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -16,11 +16,23 @@
   (assert-equal test
                 10
                 (if-let [x (Maybe.Just 10)] x 0)
-                "if-let works on Just")
+                "if-let works on Just I")
+  (assert-equal test
+                "found 10"
+                &(if-let [x (Maybe.Just 10)]
+                  (fmt "found %d" x)
+                  @"not found")
+                "if-let works on Just II")
   (assert-equal test
                 0
                 (if-let [x (Maybe.Nothing)] x 0)
-                "if-let works on Nothing")
+                "if-let works on Nothing I")
+  (assert-equal test
+                "not found"
+                &(if-let [x (the (Maybe Int) (Maybe.Nothing))]
+                  (fmt "found %d" x)
+                  @"not found")
+                "if-let works on Nothing II")
   (assert-equal test
                 30
                 (if-let [x (Maybe.Just 10)
@@ -117,4 +129,19 @@
                       (set! counter (inc counter)))
                     counter))
                 "while-let-ok works on Result")
-)
+
+  (let-do [counter 0
+           res []]
+    (while-let [x (if (< counter 3) (Maybe.Just counter) (the (Maybe Int) (Maybe.Nothing)))]
+      (do
+        (set! res (Array.push-back res x))
+        (set! counter (inc counter))))
+    (assert-equal test
+                  &[0 1 2]
+                  &res
+                  "while-let works as expected"))
+  )
+
+
+
+

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -401,4 +401,26 @@
                   (addr)
                   dst)
                 "asm works")
+  (assert-equal test
+                "found 10"
+                &(if-let [x (Maybe.Just 10)]
+                  (fmt "found %d" x)
+                  @"not found")
+                "if-let works with Just")
+  (assert-equal test
+                "not found"
+                &(if-let [x (the (Maybe Int) (Maybe.Nothing))]
+                  (fmt "found %d" x)
+                  @"not found")
+                "if-let works with Nothing")
+  (let-do [counter 0
+           res []]
+    (while-let [x (if (< counter 3) (Maybe.Just counter) (the (Maybe Int) (Maybe.Nothing)))]
+      (do
+        (set! res (Array.push-back res x))
+        (set! counter (inc counter))))
+    (assert-equal test
+                  &[0 1 2]
+                  &res
+                  "while-let works as expected"))
 )

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -401,26 +401,4 @@
                   (addr)
                   dst)
                 "asm works")
-  (assert-equal test
-                "found 10"
-                &(if-let [x (Maybe.Just 10)]
-                  (fmt "found %d" x)
-                  @"not found")
-                "if-let works with Just")
-  (assert-equal test
-                "not found"
-                &(if-let [x (the (Maybe Int) (Maybe.Nothing))]
-                  (fmt "found %d" x)
-                  @"not found")
-                "if-let works with Nothing")
-  (let-do [counter 0
-           res []]
-    (while-let [x (if (< counter 3) (Maybe.Just counter) (the (Maybe Int) (Maybe.Nothing)))]
-      (do
-        (set! res (Array.push-back res x))
-        (set! counter (inc counter))))
-    (assert-equal test
-                  &[0 1 2]
-                  &res
-                  "while-let works as expected"))
 )


### PR DESCRIPTION
Hey! I noticed that Carp was missing some basic Lisp staples for handling `Maybe` values more easily, so I've implemented `if-let` and `while-let`.

These macros make it much cleaner to unwrap an optional value without needing a full `match` block every time.

### What's new:
- **if-let:** Perfect for when you only want to do something if a `Maybe` is `Just`.
- **while-let:** A handy way to loop through anything that returns a `Maybe`.
- **Tests:** I've added a few tests to `test/macros.carp` to make sure they're solid.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp standard library ergonomics.