### PR TITLE
feat(stdlib): add when-do and unless-do macros

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -146,7 +146,7 @@ Example:
 
 (doc when-do "is a `when` with an implicit `do` body.")
 (defmacro when-do [condition :rest forms]
-  (list 'if condition (cons 'do forms) (list)))
+  (list 'when condition (cons 'do forms)))
 
 (doc unless "is an `if` without a then branch.")
 (defmacro unless [condition form]

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -154,7 +154,7 @@ Example:
 
 (doc unless-do "is a `unless` with an implicit `do` body.")
 (defmacro unless-do [condition :rest forms]
-  (list 'if condition (list) (cons 'do forms)))
+  (list 'unless condition (cons 'do forms)))
 
 (hidden treat-case-handler)
 (defndynamic treat-case-handler [name handler]

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -144,9 +144,17 @@ Example:
 (defmacro when [condition form]
   (list 'if condition form (list)))
 
+(doc when-do "is a `when` with an implicit `do` body.")
+(defmacro when-do [condition :rest forms]
+  (list 'if condition (cons 'do forms) (list)))
+
 (doc unless "is an `if` without a then branch.")
 (defmacro unless [condition form]
   (list 'if condition (list) form))
+
+(doc unless-do "is a `unless` with an implicit `do` body.")
+(defmacro unless-do [condition :rest forms]
+  (list 'if condition (list) (cons 'do forms)))
 
 (hidden treat-case-handler)
 (defndynamic treat-case-handler [name handler]

--- a/test/macros.carp
+++ b/test/macros.carp
@@ -401,4 +401,12 @@
                   (addr)
                   dst)
                 "asm works")
+  (let-do [x 0]
+    (do
+      (when-do true (set! x 1) (set! x (inc x)))
+      (assert-equal test 2 x "when-do executes multi-form body when true")))
+  (let-do [x 0]
+    (do
+      (unless-do false (set! x 1) (set! x (inc x)))
+      (assert-equal test 2 x "unless-do executes multi-form body when false")))
 )


### PR DESCRIPTION
This PR adds the `when-do` and `unless-do` macros to the standard library, providing a convenient way to execute multiple forms conditionally.

### Changes:
- **when-do:** Executes multiple forms if the condition is true.
- **unless-do:** Executes multiple forms if the condition is false.
- **Tests:** Integrated new test cases into `test/macros.carp`.

These complement the existing `when` and `unless` macros which only handle a single form.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp standard library ergonomics.