### PR TITLE
feat(stdlib): add threading, conditional, and monadic macros

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -60,6 +60,19 @@ Example:
 (defmacro --> [:rest forms]
   (thread-last-internal forms))
 
+(hidden as->-internal)
+(defndynamic as->-internal [name forms]
+  (if (= 0 (length forms))
+    name
+    `(let [%name %(car forms)]
+       %(as->-internal name (cdr forms)))))
+
+(doc as-> "Threading macro with an explicit name.
+Binds `value` to `name` and then threads it through each of the `forms`, re-binding the result to `name` at each step.")
+(defmacro as-> [value name :rest forms]
+  `(let [%name %value]
+     %(as->-internal name forms)))
+
 (hidden comp-internal)
 (defndynamic comp-internal [sym fns]
   (if (= (length fns) 0)
@@ -185,6 +198,26 @@ Example:
   (let [name (gensym)]
     (list 'let [name form]
       (case-internal name branches))))
+
+(hidden cond-let-internal)
+(defndynamic cond-let-internal [xs]
+  (if (= (length xs) 0)
+    (list)
+    (if (= (length xs) 1)
+      (car xs)
+      (let [binding (car xs)
+            var (car binding)
+            expr (cadr binding)]
+        `(match %expr
+           (Maybe.Just %var) %(cadr xs)
+           (Maybe.Nothing) %(cond-let-internal (cddr xs)))))))
+
+(doc cond-let "Multibranch conditional with Maybe bindings.
+Each branch is a `[var expr]` binding and a body.
+If `expr` evaluates to `(Just x)`, `body` is executed with `var` bound to `x`.
+The final argument is an optional else branch.")
+(defmacro cond-let [:rest xs]
+  (cond-let-internal xs))
 
 (defmodule Dynamic
   (doc flip

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -73,6 +73,97 @@ Binds `value` to `name` and then threads it through each of the `forms`, re-bind
   `(let [%name %value]
      %(as->-internal name forms)))
 
+(hidden as->>-internal)
+(defndynamic as->>-internal [name forms]
+  (if (= 0 (length forms))
+    name
+    `(let [%name %(cons-last name (car forms))]
+       %(as->>-internal name (cdr forms)))))
+
+(doc as->> "Threading macro with an explicit name (last).
+Binds `value` to `name` and then threads it through each of the `forms` as the last argument, re-binding the result to `name` at each step.")
+(defmacro as->> [value name :rest forms]
+  `(let [%name %value]
+     %(as->>-internal name forms)))
+
+(hidden cond-first-internal)
+(defndynamic cond-first-internal [acc steps]
+  (if (= 0 (length steps))
+    acc
+    (let [test (car steps)
+          form (cadr steps)
+          new-acc `(if %test (-> %acc %form) %acc)]
+      (cond-first-internal new-acc (cddr steps)))))
+
+(doc cond-> "Conditional threading macro (first).
+Threads `val` through each `form` in `steps` only if the corresponding `test` is true.")
+(defmacro cond-> [val :rest steps]
+  (cond-first-internal val steps))
+
+(hidden cond-last-internal)
+(defndynamic cond-last-internal [acc steps]
+  (if (= 0 (length steps))
+    acc
+    (let [test (car steps)
+          form (cadr steps)
+          new-acc `(if %test (--> %acc %form) %acc)]
+      (cond-last-internal new-acc (cddr steps)))))
+
+(doc cond->> "Conditional threading macro (last).
+Threads `val` through each `form` in `steps` only if the corresponding `test` is true.")
+(defmacro cond->> [val :rest steps]
+  (cond-last-internal val steps))
+
+(doc some-> "Monadic threading macro (first).
+Threads the unwrapped value of `val` (a Maybe) through each `form` in `steps`.
+Wraps the final result in a `Maybe.Just`. If `val` is `Nothing`, returns `Nothing`.
+Each form in `steps` must return a value, not a Maybe.")
+(defmacro some-> [val :rest steps]
+  `(match %val
+     (Maybe.Just x) (Maybe.Just (-> x %@steps))
+     (Maybe.Nothing) (Maybe.Nothing)))
+
+(doc some->> "Monadic threading macro (last).
+Threads the unwrapped value of `val` (a Maybe) through each `form` in `steps`.
+Wraps the final result in a `Maybe.Just`. If `val` is `Nothing`, returns `Nothing`.
+Each form in `steps` must return a value, not a Maybe.")
+(defmacro some->> [val :rest steps]
+  `(match %val
+     (Maybe.Just x) (Maybe.Just (--> x %@steps))
+     (Maybe.Nothing) (Maybe.Nothing)))
+
+(hidden maybe-and-then-internal)
+(defndynamic maybe-and-then-internal [acc steps]
+  (if (empty? steps)
+    acc
+    (maybe-and-then-internal
+      `(match %acc
+         (Maybe.Just x) (-> x %(car steps))
+         (Maybe.Nothing) (Maybe.Nothing))
+      (cdr steps))))
+
+(doc maybe-and-then-> "Monadic threading macro for Maybe (first).
+Threads a `Maybe` value through each `form` in `steps`.
+Each form must return a `Maybe`. If any step evaluates to `Nothing`, the entire expression results in `Nothing`.")
+(defmacro maybe-and-then-> [val :rest steps]
+  (maybe-and-then-internal val steps))
+
+(hidden result-and-then-internal)
+(defndynamic result-and-then-internal [acc steps]
+  (if (empty? steps)
+    acc
+    (result-and-then-internal
+      `(match %acc
+         (Result.Success x) (-> x %(car steps))
+         (Result.Error e) (Result.Error e))
+      (cdr steps))))
+
+(doc result-and-then-> "Monadic threading macro for Result (first).
+Threads a `Result` value through each `form` in `steps`.
+Each form must return a `Result`. If any step evaluates to `Error`, the entire expression results in the error.")
+(defmacro result-and-then-> [val :rest steps]
+  (result-and-then-internal val steps))
+
 (hidden comp-internal)
 (defndynamic comp-internal [sym fns]
   (if (= (length fns) 0)

--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -98,7 +98,9 @@ Binds `value` to `name` and then threads it through each of the `forms` as the l
 (doc cond-> "Conditional threading macro (first).
 Threads `val` through each `form` in `steps` only if the corresponding `test` is true.")
 (defmacro cond-> [val :rest steps]
-  (cond-first-internal val steps))
+  (if (= (mod (length steps) 2) 0)
+    (cond-first-internal val steps)
+    (macro-error "cond-> requires an even number of forms (test form pairs)")))
 
 (hidden cond-last-internal)
 (defndynamic cond-last-internal [acc steps]
@@ -112,35 +114,20 @@ Threads `val` through each `form` in `steps` only if the corresponding `test` is
 (doc cond->> "Conditional threading macro (last).
 Threads `val` through each `form` in `steps` only if the corresponding `test` is true.")
 (defmacro cond->> [val :rest steps]
-  (cond-last-internal val steps))
-
-(doc some-> "Monadic threading macro (first).
-Threads the unwrapped value of `val` (a Maybe) through each `form` in `steps`.
-Wraps the final result in a `Maybe.Just`. If `val` is `Nothing`, returns `Nothing`.
-Each form in `steps` must return a value, not a Maybe.")
-(defmacro some-> [val :rest steps]
-  `(match %val
-     (Maybe.Just x) (Maybe.Just (-> x %@steps))
-     (Maybe.Nothing) (Maybe.Nothing)))
-
-(doc some->> "Monadic threading macro (last).
-Threads the unwrapped value of `val` (a Maybe) through each `form` in `steps`.
-Wraps the final result in a `Maybe.Just`. If `val` is `Nothing`, returns `Nothing`.
-Each form in `steps` must return a value, not a Maybe.")
-(defmacro some->> [val :rest steps]
-  `(match %val
-     (Maybe.Just x) (Maybe.Just (--> x %@steps))
-     (Maybe.Nothing) (Maybe.Nothing)))
+  (if (= (mod (length steps) 2) 0)
+    (cond-last-internal val steps)
+    (macro-error "cond->> requires an even number of forms (test form pairs)")))
 
 (hidden maybe-and-then-internal)
 (defndynamic maybe-and-then-internal [acc steps]
   (if (empty? steps)
     acc
-    (maybe-and-then-internal
-      `(match %acc
-         (Maybe.Just x) (-> x %(car steps))
-         (Maybe.Nothing) (Maybe.Nothing))
-      (cdr steps))))
+    (let [x (gensym-with 'x)]
+      (maybe-and-then-internal
+        `(match %acc
+           (Maybe.Just %x) (-> %x %(car steps))
+           (Maybe.Nothing) (Maybe.Nothing))
+        (cdr steps)))))
 
 (doc maybe-and-then-> "Monadic threading macro for Maybe (first).
 Threads a `Maybe` value through each `form` in `steps`.
@@ -152,11 +139,13 @@ Each form must return a `Maybe`. If any step evaluates to `Nothing`, the entire 
 (defndynamic result-and-then-internal [acc steps]
   (if (empty? steps)
     acc
-    (result-and-then-internal
-      `(match %acc
-         (Result.Success x) (-> x %(car steps))
-         (Result.Error e) (Result.Error e))
-      (cdr steps))))
+    (let [x (gensym-with 'x)
+          e (gensym-with 'e)]
+      (result-and-then-internal
+        `(match %acc
+           (Result.Success %x) (-> %x %(car steps))
+           (Result.Error %e) (Result.Error %e))
+        (cdr steps)))))
 
 (doc result-and-then-> "Monadic threading macro for Result (first).
 Threads a `Result` value through each `form` in `steps`.
@@ -293,7 +282,7 @@ Example:
 (hidden cond-let-internal)
 (defndynamic cond-let-internal [xs]
   (if (= (length xs) 0)
-    (list)
+    `(Maybe.Nothing)
     (if (= (length xs) 1)
       (car xs)
       (let [binding (car xs)

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -12,4 +12,27 @@
   (assert-true test
     (and (= () (test-ignore-do)) (= &test-string "new-string"))
     "ignore-do performs side effects and ignores all results")
+
+  (assert-equal test
+                "first"
+                &(cond-let
+                   [x (Maybe.Just @"first")] (copy &x)
+                   [x (Maybe.Just @"second")] @"wrong"
+                   @"else")
+                "cond-let picks first Just")
+
+  (assert-equal test
+                "second"
+                &(cond-let
+                   [x (the (Maybe String) (Maybe.Nothing))] @"wrong"
+                   [x (Maybe.Just @"second")] (copy &x)
+                   @"else")
+                "cond-let picks second Just")
+
+  (assert-equal test
+                20
+                (as-> 5 x
+                  (+ x 5)
+                  (* x 2))
+                "as-> threads correctly through operations")
 )

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -8,6 +8,12 @@
              (set! test-string @"new-string") ;; ignored, but side-effect performed
              (- 4 4)))
 
+(defn inc-maybe [x] (Maybe.Just (inc x)))
+(defn const-nothing [_] (the (Maybe Int) (Maybe.Nothing)))
+
+(defn inc-success [x] (Result.Success (inc x)))
+(defn const-error [_] (the (Result Int Int) (Result.Error 0)))
+
 (deftest test
   (assert-true test
     (and (= () (test-ignore-do)) (= &test-string "new-string"))
@@ -35,4 +41,57 @@
                   (+ x 5)
                   (* x 2))
                 "as-> threads correctly through operations")
+
+  (assert-equal test
+                30
+                (as->> 5 x
+                  (+ 5)    ;; (+ 5 5) -> 10
+                  (* 3))   ;; (* 3 10) -> 30
+                "as->> threads correctly through operations (last)")
+
+  (assert-equal test
+                15
+                (cond-> 5
+                  true (+ 5)
+                  false (+ 100)
+                  true (+ 5))
+                "cond-> threads correctly through true conditions")
+
+  (assert-equal test
+                30
+                (cond->> 5
+                  true (+ 5)
+                  false (+ 100)
+                  true (* 3))
+                "cond->> threads correctly through true conditions")
+
+  (assert-equal test
+                &(Maybe.Just 11)
+                &(some-> (Maybe.Just 10) inc)
+                "some-> threads through Just (value return)")
+
+  (assert-equal test
+                &(the (Maybe Int) (Maybe.Nothing))
+                &(some-> (the (Maybe Int) (Maybe.Nothing)) inc)
+                "some-> threads through Nothing")
+
+  (assert-equal test
+                &(Maybe.Just 11)
+                &(maybe-and-then-> (Maybe.Just 10) inc-maybe)
+                "maybe-and-then-> threads through Just (maybe return)")
+
+  (assert-equal test
+                &(the (Maybe Int) (Maybe.Nothing))
+                &(maybe-and-then-> (Maybe.Just 10) const-nothing)
+                "maybe-and-then-> short-circuits on Nothing return")
+
+  (assert-equal test
+                &(the (Result Int Int) (Result.Success 11))
+                &(result-and-then-> (the (Result Int Int) (Result.Success 10)) inc-success)
+                "result-and-then-> threads through Success")
+
+  (assert-equal test
+                &(the (Result Int Int) (Result.Error 0))
+                &(result-and-then-> (the (Result Int Int) (Result.Success 10)) const-error)
+                "result-and-then-> short-circuits on Error return")
 )

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -36,6 +36,14 @@
                 "cond-let picks second Just")
 
   (assert-equal test
+                "else"
+                &(cond-let
+                   [x (the (Maybe String) (Maybe.Nothing))] @"wrong"
+                   [x (the (Maybe String) (Maybe.Nothing))] @"also-wrong"
+                   @"else")
+                "cond-let falls through to else when all Nothing")
+
+  (assert-equal test
                 20
                 (as-> 5 x
                   (+ x 5)
@@ -64,16 +72,6 @@
                   false (+ 100)
                   true (* 3))
                 "cond->> threads correctly through true conditions")
-
-  (assert-equal test
-                &(Maybe.Just 11)
-                &(some-> (Maybe.Just 10) inc)
-                "some-> threads through Just (value return)")
-
-  (assert-equal test
-                &(the (Maybe Int) (Maybe.Nothing))
-                &(some-> (the (Maybe Int) (Maybe.Nothing)) inc)
-                "some-> threads through Nothing")
 
   (assert-equal test
                 &(Maybe.Just 11)


### PR DESCRIPTION
This PR introduces a suite of powerful control-flow macros to the Carp standard library, enhancing ergonomics for data threading, conditional logic, and monadic operations.

### Changes:
- **as-> / as->>:** Flexible threading macros that name the value, enabling its use in any argument position.
- **cond-let:** A multibranch conditional for `Maybe` bindings, providing clean unwrapping for multiple options.
- **cond-> / cond->>:** Conditional threading macros that apply transformations only when their corresponding tests are true.
- **maybe-and-then-> / result-and-then->:** Advanced monadic chaining macros for steps that themselves return `Maybe` or `Result`.
- **Tests:** Integrated 11 new test cases into `test/control_macros.carp`.

These macros significantly improve the ergonomics of complex data pipelines and conditional logic.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp standard library ergonomics.