### PR TITLE
feat(stdlib): add Maybe and Result ergonomic helpers

### DIFF
--- a/core/Maybe.carp
+++ b/core/Maybe.carp
@@ -104,6 +104,39 @@ It is the inverse of [`and-then`](#and-then).")
       (Nothing) (Nothing)
       (Just x) (if (~f &x) (Just x) (Nothing))))
 
+  (doc flatten "flattens a nested `Maybe` value.")
+  (defn flatten [a]
+    (match a
+      (Nothing) (Nothing)
+      (Just x) x))
+
+  (doc expect "unwraps a `Maybe` value, or aborts with `msg` if it is `Nothing`.")
+  ;; Note: This is a macro to avoid a circular dependency with the IO module.
+  (defmacro expect [a msg]
+    `(match %a
+       (Maybe.Just x) x
+       (Maybe.Nothing) (do (IO.errorln %msg) (System.abort) (bottom))))
+
+  (doc inspect "applies a side-effecting function `f` to the value inside `a` if it is a `Just`, and returns `a` unchanged.")
+  (defn inspect [a f]
+    (do
+      (match-ref &a
+        (Nothing) ()
+        (Just x) (~f x))
+      a))
+
+  (doc map-or "applies a function `f` to the value inside `a` if it is a `Just`, otherwise returns `dflt`.")
+  (defn map-or [a dflt f]
+    (match a
+      (Nothing) dflt
+      (Just x) (~f x)))
+
+  (doc map-or-else "applies a function `f` to the value inside `a` if it is a `Just`, otherwise returns the result of `dflt-f`.")
+  (defn map-or-else [a dflt-f f]
+    (match a
+      (Nothing) (~dflt-f)
+      (Just x) (~f x)))
+
   (doc zero "returns `Nothing`.")
   (defn zero [] (Nothing))
   (implements zero Maybe.zero)

--- a/core/Result.carp
+++ b/core/Result.carp
@@ -99,6 +99,47 @@ It is the inverse of [`success?`](#success?).")
       (Error _) true
       (Success _) false))
 
+  (doc flatten "flattens a nested `Result` value.")
+  (defn flatten [a]
+    (match a
+      (Success x) x
+      (Error e) (Error e)))
+
+  (doc expect "unwraps a `Result` success value, or aborts with `msg` if it is an `Error`.")
+  ;; Note: This is a macro to avoid a circular dependency with the IO module.
+  (defmacro expect [a msg]
+    `(match %a
+       (Result.Success x) x
+       (Result.Error _) (do (IO.errorln %msg) (System.abort) (bottom))))
+
+  (doc inspect "applies a side-effecting function `f` to the value inside `a` if it is a `Success`, and returns `a` unchanged.")
+  (defn inspect [a f]
+    (do
+      (match-ref &a
+        (Success x) (~f x)
+        (Error _) ())
+      a))
+
+  (doc inspect-error "applies a side-effecting function `f` to the error inside `a` if it is an `Error`, and returns `a` unchanged.")
+  (defn inspect-error [a f]
+    (do
+      (match-ref &a
+        (Success _) ()
+        (Error e) (~f e))
+      a))
+
+  (doc map-or "applies a function `f` to the value inside `a` if it is a `Success`, otherwise returns `dflt`.")
+  (defn map-or [a dflt f]
+    (match a
+      (Success x) (~f x)
+      (Error _) dflt))
+
+  (doc map-or-else "applies a function `f` to the value inside `a` if it is a `Success`, otherwise returns the result of `dflt-f`.")
+  (defn map-or-else [a dflt-f f]
+    (match a
+      (Success x) (~f x)
+      (Error _) (~dflt-f)))
+
   (doc = "equality is defined as the equality of both the constructor and the contained value, i.e. `(Success 1)` and `(Success 1)` are the same, but `(Success 1)` and `(Success 2)` are not.")
   (defn = [a b]
     (match-ref a

--- a/test/maybe.carp
+++ b/test/maybe.carp
@@ -165,4 +165,41 @@
                 &(the (Maybe Int) (Nothing))
                 &(filter (the (Maybe Int) (Nothing)) &(fn [x] (Int.even? @x)))
                 "filter works on Nothing")
+
+  (assert-equal test
+                &(Just 10)
+                &(flatten (Just (Just 10)))
+                "flatten works on Just Just")
+  (assert-equal test
+                &(the (Maybe Int) (Nothing))
+                &(flatten (the (Maybe (Maybe Int)) (Just (Nothing))))
+                "flatten works on Just Nothing")
+
+  (assert-equal test
+                10
+                (expect (Just 10) "should not fail")
+                "expect works on Just")
+
+  (let-do [x 0]
+    (do
+      (ignore (inspect (Just 10) &(fn [v] (set! x @v))))
+      (assert-equal test 10 x "inspect works on Just")))
+
+  (assert-equal test
+                20
+                (map-or (Just 10) 0 &(fn [v] (* v 2)))
+                "map-or works on Just")
+  (assert-equal test
+                0
+                (map-or (the (Maybe Int) (Nothing)) 0 &(fn [v] (* v 2)))
+                "map-or works on Nothing")
+
+  (assert-equal test
+                20
+                (map-or-else (Just 10) &(fn [] 0) &(fn [v] (* v 2)))
+                "map-or-else works on Just")
+  (assert-equal test
+                0
+                (map-or-else (the (Maybe Int) (Nothing)) &(fn [] 0) &(fn [v] (* v 2)))
+                "map-or-else works on Nothing")
 )

--- a/test/maybe.carp
+++ b/test/maybe.carp
@@ -1,6 +1,8 @@
 (load "Test.carp")
 (use-all Maybe Test)
 
+(def test-inspect-val 0)
+
 (deftest test
   (assert-true test
                (nothing? &(the (Maybe Int) (Nothing)))
@@ -180,10 +182,9 @@
                 (expect (Just 10) "should not fail")
                 "expect works on Just")
 
-  (let-do [x 0]
-    (do
-      (ignore (inspect (Just 10) &(fn [v] (set! x @v))))
-      (assert-equal test 10 x "inspect works on Just")))
+  (do
+    (ignore (inspect (Just 10) &(fn [v] (set! test-inspect-val @v))))
+    (assert-equal test 10 test-inspect-val "inspect works on Just"))
 
   (assert-equal test
                 20

--- a/test/result.carp
+++ b/test/result.carp
@@ -139,4 +139,46 @@
                   (Success (Success x)) x)
                 "matching on nested results"
   )
+
+  (assert-equal test
+                &(Result.Success 10)
+                &(flatten (Success (the (Result Int Int) (Success 10))))
+                "flatten works with Success Success")
+  (assert-equal test
+                &(the (Result Int Int) (Error 0))
+                &(flatten (the (Result (Result Int Int) Int) (Success (Error 0))))
+                "flatten works with Success Error")
+
+  (assert-equal test
+                10
+                (expect (the (Result Int Int) (Success 10)) "should not fail")
+                "expect works with Success")
+
+  (let-do [x 0]
+    (do
+      (ignore (inspect (Success 10) &(fn [v] (set! x @v))))
+      (assert-equal test 10 x "inspect works with Success")))
+
+  (let-do [x 0]
+    (do
+      (ignore (inspect-error (the (Result Int Int) (Error 10)) &(fn [v] (set! x @v))))
+      (assert-equal test 10 x "inspect-error works with Error")))
+
+  (assert-equal test
+                20
+                (map-or (the (Result Int Int) (Success 10)) 0 &(fn [v] (* v 2)))
+                "map-or works with Success")
+  (assert-equal test
+                0
+                (map-or (the (Result Int Int) (Error 10)) 0 &(fn [v] (* v 2)))
+                "map-or works with Error")
+
+  (assert-equal test
+                20
+                (map-or-else (the (Result Int Int) (Success 10)) &(fn [] 0) &(fn [v] (* v 2)))
+                "map-or-else works with Success")
+  (assert-equal test
+                0
+                (map-or-else (the (Result Int Int) (Error 10)) &(fn [] 0) &(fn [v] (* v 2)))
+                "map-or-else works with Error")
 )

--- a/test/result.carp
+++ b/test/result.carp
@@ -2,6 +2,8 @@
 
 (use-all Test Result)
 
+(def test-inspect-val 0)
+
 (deftest test
   (assert-true test
                (success? &(the (Result Int String) (Success 1)))
@@ -154,15 +156,13 @@
                 (expect (the (Result Int Int) (Success 10)) "should not fail")
                 "expect works with Success")
 
-  (let-do [x 0]
-    (do
-      (ignore (inspect (Success 10) &(fn [v] (set! x @v))))
-      (assert-equal test 10 x "inspect works with Success")))
+  (do
+    (ignore (inspect (the (Result Int Int) (Success 10)) &(fn [v] (set! test-inspect-val @v))))
+    (assert-equal test 10 test-inspect-val "inspect works with Success"))
 
-  (let-do [x 0]
-    (do
-      (ignore (inspect-error (the (Result Int Int) (Error 10)) &(fn [v] (set! x @v))))
-      (assert-equal test 10 x "inspect-error works with Error")))
+  (do
+    (ignore (inspect-error (the (Result Int Int) (Error 10)) &(fn [v] (set! test-inspect-val @v))))
+    (assert-equal test 10 test-inspect-val "inspect-error works with Error"))
 
   (assert-equal test
                 20


### PR DESCRIPTION
This PR adds several common functional and ergonomic helpers to the `Maybe` and `Result` modules.

### Changes:
- **Flattening:** Added `flatten` to both modules to handle nested optionality/errors.
- **Unwrapping:** Added `expect` (as a macro to avoid circular `IO` dependencies) for unwrapping with a custom panic message.
- **Inspection:** Added `inspect` (and `inspect-error` for Result) for performing side-effects without consuming the value.
- **Conditional Mapping:** Added `map-or` and `map-or-else` for more concise transformation-with-default patterns.
- **Tests:** Integrated 14 new test cases across `test/maybe.carp` and `test/result.carp`.

---
**Disclaimer:** This PR was built with the assistance of Gemini (an AI assistant) working in collaboration with @sqrew to improve the Carp standard library ergonomics.