### PR TITLE
fix: ensure closure move semantics are clean and route through the captured vars

### DIFF
--- a/src/Concretize.hs
+++ b/src/Concretize.hs
@@ -26,8 +26,8 @@ where
 import AssignTypes
 import Constraints
 import Control.Applicative
-import Control.Monad.State
 import Control.Monad (foldM, unless)
+import Control.Monad.State
 import Data.Either (fromRight)
 import Data.List (foldl')
 import Data.Maybe (fromMaybe)
@@ -309,7 +309,19 @@ mkLambda visited allowAmbig _ tenv env root@(ListPat (FnPat fn arr@(ArrPat args)
           )
           (xobjInfo root)
           (Just TypeTy)
-      pairs = memberXObjsToPairs structMemberPairs
+      -- Build the (name, Ty) pairs directly from capturedVars rather than
+      -- routing through structMemberPairs. The reify/xobjToTy round-trip
+      -- mangles function-type lifetimes (StaticLifetimeTy → reified as the
+      -- Sym "<StaticLifetime>" → re-parsed as a phantom struct), which makes
+      -- isManaged wrongly return False for FuncTy fields and leaks captured
+      -- closure envs.
+      pairs =
+        map
+          ( \x -> case x of
+              (XObj (Sym (SymPath _ memberName) _) _ (Just memberTy)) -> (mangle memberName, memberTy)
+              _ -> error "concretize: struct member pair is a non symbol"
+          )
+          capturedVars
       deleteFnTy = typesDeleterFunctionType (PointerTy environmentStructTy)
       deleteFnTemplate = concreteDeleteTakePtr tenv env pairs
       (deleteFn, deleterDeps) = instantiateTemplate (SymPath [] (environmentTypeName ++ "_delete")) deleteFnTy deleteFnTemplate

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -12,8 +12,8 @@ module Emit
   )
 where
 
+import Control.Monad (unless, when, zipWithM_)
 import Control.Monad.State
-import Control.Monad (when, zipWithM_, unless)
 import Data.Char (ord)
 import Data.Functor ((<&>))
 import Data.Graph (SCC (..), stronglyConnComp)
@@ -326,16 +326,27 @@ toC toCMode emitLines mutualGroup (Binder meta root) = renderEmitterState (execS
                   ( \xobj ->
                       case xobj of
                         (XObj (Sym path lookupMode) _ _) ->
-                          appendToSrc
-                            ( addIndent indent ++ lambdaEnvName ++ "->"
-                                ++ pathToC path
-                                ++ " = "
-                                ++ ( case lookupMode of
-                                       LookupLocal (Capture _) -> "_env->" ++ pathToC path
-                                       _ -> pathToC path
-                                   )
-                                ++ ";\n"
-                            )
+                          let dstField = lambdaEnvName ++ "->" ++ pathToC path
+                              srcExpr = case lookupMode of
+                                LookupLocal (Capture _) -> "_env->" ++ pathToC path
+                                _ -> pathToC path
+                           in do
+                                appendToSrc
+                                  (addIndent indent ++ dstField ++ " = " ++ srcExpr ++ ";\n")
+                                -- For captures sourced from an outer closure's env, the
+                                -- assignment above is a move (struct copy without a copy
+                                -- function call). Zero the source so the outer env's
+                                -- delete is a no-op for this field — otherwise both envs
+                                -- would try to free the same heap data on teardown.
+                                case lookupMode of
+                                  LookupLocal (Capture _) ->
+                                    appendToSrc
+                                      ( addIndent indent ++ "memset(&" ++ srcExpr
+                                          ++ ", 0, sizeof("
+                                          ++ srcExpr
+                                          ++ "));\n"
+                                      )
+                                  _ -> pure ()
                         _ -> appendToSrc ""
                   )
                   (remove (isUnit . forceTy) capturedVars)


### PR DESCRIPTION
**Disclaimer:** Claude helped me diagnose this issue and write a reproducible.

This PR fixes an issue where complex closure use cases (passed in structs, handed around and deleted much later) actually leaked.

Reproducible:

```clojure
(defn wrap [f]
  (fn [x] (f x)))

(defn main []
  (let-do [acc 0]
    (for [i 0 10000000]
      (let [s (Int.str i)
            inner (fn [n] (Int.+ (String.length &s) n))
            outer (wrap inner)]
        (set! acc (Int.+ acc (outer i)))))
    (IO.println &(fmt "done acc=%d" acc))))
```

Running with `time -l` (`time -v` on Linux), I see peak RSS on 10m iterations: 162.6 MB without the fix, 1.4 MB with the fix.

Cheers