### PR TITLE
Introduce minimal protocol system for structured generic programming

### DIFF
--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -1148,6 +1148,7 @@ toDeclaration (Binder meta xobj@(XObj (Lst xobjs) _ ty)) =
     XObj (Primitive _) _ _ : _ ->
       ""
     _ -> error ("Internal compiler error: Can't emit other kinds of definitions: " ++ show xobj)
+toDeclaration (Binder _ (XObj MetaStub _ _)) = ""
 toDeclaration (Binder _ (XObj (Sym (SymPath [] "dummy") Symbol) Nothing (Just IntTy))) = ""
 toDeclaration (Binder _ (XObj (Closure _ _) _ _)) = ""
 toDeclaration _ = error "Missing case."

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -11,7 +11,7 @@ import Control.Monad.State
 import Control.Monad (foldM, when)
 import Data.Bits ((.&.))
 import Data.Either (fromRight)
-import Data.List (foldl', isSuffixOf)
+import Data.List (foldl', intercalate, isSuffixOf)
 import Data.List.Split (splitOn)
 import Data.Maybe (fromJust, fromMaybe, isJust)
 import Deftype (typeModuleStubBindings)
@@ -38,8 +38,10 @@ import System.Exit (ExitCode (..), exitSuccess, exitWith)
 import System.Process (readProcessWithExitCode)
 import qualified Text.Parsec as Parsec
 import TypeError
+import TypePredicates (isTypeGeneric)
 import Types
 import Util
+import Reify (reify)
 import Prelude hiding (exp, mod)
 
 -- Prefer dynamic bindings
@@ -435,29 +437,54 @@ primitiveDefmodule xobj ctx [] =
   pure (throwErr DefmoduleNoArgs ctx (xobjInfo xobj))
 
 primitiveImplFor :: VariadicPrimitiveCallback
-primitiveImplFor xobj ctx (typeXObj : protocolXObj : body) =
-  case typeNameFrom typeXObj of
-    Nothing -> pure (evalError ctx ("`impl-for` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))
-    Just typeName -> do
-      let oldPath = contextPath ctx
-          newPath = oldPath ++ [typeName]
-          ctxWithModule = ctx {contextPath = newPath}
-      (ctxAfterBody, result) <- foldM step (ctxWithModule, dynamicNil) body
-      case result of
-        Left err -> pure (ctxAfterBody, Left err)
-        Right _ ->
-          let ctxRestored = ctxAfterBody {contextPath = oldPath}
-           in primitiveImpl xobj ctxRestored typeXObj protocolXObj
-  where
-    typeNameFrom (XObj (Sym (SymPath _ name) _) _ _) = Just name
-    typeNameFrom (XObj (Lst (XObj (Sym (SymPath _ name) _) _ _ : _)) _ _) = Just name
-    typeNameFrom _ = Nothing
-    step (c, Left e) _ = pure (c, Left e)
-    step (c, Right _) m = eval c m PreferDynamic
+primitiveImplFor xobj ctx (typeXObj : protocolXObj@(XObj (Sym protocolPath _) _ _) : body) =
+  case lookupBinderInTypeEnv ctx protocolPath of
+    Left _ -> pure (evalError ctx ("Protocol not found: " ++ show protocolPath) (xobjInfo protocolXObj))
+    Right protocolBinder ->
+      case typeNameFrom typeXObj of
+        Nothing -> pure (evalError ctx ("`impl-for` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))
+        Just typeName -> do
+          let members = Meta.getBinderMetaValue "protocol-members" protocolBinder
+              vars = Meta.getBinderMetaValue "protocol-vars" protocolBinder
+              sigs = case (members, vars, xobjToTy typeXObj) of
+                       (Just (XObj (Lst ms) _ _), Just (XObj (Lst vs) _ _), Just concreteTy) ->
+                         if isTypeGeneric concreteTy
+                         then []
+                         else let varNames = map getSimpleName vs
+                                  typeXObjs = if length varNames > 1
+                                              then case typeXObj of
+                                                     (XObj (Lst xs) _ _) -> xs
+                                                     _ -> [typeXObj]
+                                              else [typeXObj]
+                                  typeTys = map (fromMaybe UnitTy . xobjToTy) typeXObjs
+                                  mappings = Map.fromList (zip varNames typeTys)
+                                  genSig (XObj (Lst [mnameX, mtyX]) _ _) =
+                                    case xobjToTy mtyX of
+                                      Just genericTy ->
+                                        let specializedTy = replaceTyVars mappings genericTy
+                                        in [XObj (Sym (SymPath [] "sig") Symbol) Nothing Nothing, mnameX, reify specializedTy]
+                                      _ -> []
+                                  genSig _ = []
+                              in map (\m -> XObj (Lst (genSig m)) (xobjInfo m) (Just MacroTy)) ms
+                       _ -> []
+          let bodyWithSigs = sigs ++ body
+              moduleNameXObj = XObj (Sym (SymPath [] typeName) Symbol) (xobjInfo typeXObj) Nothing
+          (ctxAfterModule, result) <- primitiveDefmodule xobj ctx (moduleNameXObj : bodyWithSigs)
+          case result of
+            Left err -> pure (ctxAfterModule, Left err)
+            Right _ -> primitiveImpl xobj ctxAfterModule typeXObj protocolXObj
+primitiveImplFor _ ctx (_ : protocolXObj : _) =
+  pure (evalError ctx ("`impl-for` expects a protocol name as second argument, but got `" ++ pretty protocolXObj ++ "`") (xobjInfo protocolXObj))
 primitiveImplFor xobj ctx [_] =
   pure (evalError ctx "`impl-for` expects at least two arguments (type and protocol)" (xobjInfo xobj))
 primitiveImplFor xobj ctx [] =
   pure (evalError ctx "`impl-for` expects at least two arguments (type and protocol)" (xobjInfo xobj))
+
+typeNameFrom :: XObj -> Maybe String
+typeNameFrom (XObj (Sym (SymPath _ name) _) _ _) = Just name
+typeNameFrom (XObj (Lst (XObj (Sym (SymPath _ name) _) _ _ : args)) _ _) =
+  Just (name ++ (if null args then "" else "_" ++ intercalate "_" (map pretty args)))
+typeNameFrom _ = Nothing
 
 --------------------------------------------------------------------------------
 -- Type pre-declaration

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -435,22 +435,27 @@ primitiveDefmodule xobj ctx [] =
   pure (throwErr DefmoduleNoArgs ctx (xobjInfo xobj))
 
 primitiveImplFor :: VariadicPrimitiveCallback
-primitiveImplFor xobj ctx (typeXObj@(XObj (Sym (SymPath _ typeName) _) _ _) : protocolXObj : body) =
-  do
-    let oldPath = contextPath ctx
-        newPath = oldPath ++ [typeName]
-        ctxWithModule = ctx {contextPath = newPath}
-    (ctxAfterBody, result) <- foldM step (ctxWithModule, dynamicNil) body
-    case result of
-      Left err -> pure (ctxAfterBody, Left err)
-      Right _ ->
-        let ctxRestored = ctxAfterBody {contextPath = oldPath}
-         in primitiveImpl xobj ctxRestored typeXObj protocolXObj
+primitiveImplFor xobj ctx (typeXObj : protocolXObj : body) =
+  case typeNameFrom typeXObj of
+    Nothing -> pure (evalError ctx ("`impl-for` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))
+    Just typeName -> do
+      let oldPath = contextPath ctx
+          newPath = oldPath ++ [typeName]
+          ctxWithModule = ctx {contextPath = newPath}
+      (ctxAfterBody, result) <- foldM step (ctxWithModule, dynamicNil) body
+      case result of
+        Left err -> pure (ctxAfterBody, Left err)
+        Right _ ->
+          let ctxRestored = ctxAfterBody {contextPath = oldPath}
+           in primitiveImpl xobj ctxRestored typeXObj protocolXObj
   where
+    typeNameFrom (XObj (Sym (SymPath _ name) _) _ _) = Just name
+    typeNameFrom (XObj (Lst (XObj (Sym (SymPath _ name) _) _ _ : _)) _ _) = Just name
+    typeNameFrom _ = Nothing
     step (c, Left e) _ = pure (c, Left e)
     step (c, Right _) m = eval c m PreferDynamic
-primitiveImplFor _ ctx (typeXObj : _) =
-  pure (evalError ctx ("`impl-for` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))
+primitiveImplFor xobj ctx [_] =
+  pure (evalError ctx ("`impl-for` expects at least two arguments (type and protocol)") (xobjInfo xobj))
 primitiveImplFor xobj ctx [] =
   pure (evalError ctx "`impl-for` expects at least two arguments (type and protocol)" (xobjInfo xobj))
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -434,15 +434,25 @@ primitiveDefmodule _ ctx (x : _) =
 primitiveDefmodule xobj ctx [] =
   pure (throwErr DefmoduleNoArgs ctx (xobjInfo xobj))
 
-primitiveProtocolMembers :: BinaryPrimitiveCallback
-primitiveProtocolMembers _ ctx _ membersXObj =
-  case membersXObj of
-    XObj (Lst members) _ _ -> foldM step (ctx, dynamicNil) members
-    XObj (Arr members) _ _ -> foldM step (ctx, dynamicNil) members
-    _ -> pure (evalError ctx ("`protocol-members` expects a list or array of definitions as second argument, but got `" ++ pretty membersXObj ++ "`") (xobjInfo membersXObj))
+primitiveImplFor :: VariadicPrimitiveCallback
+primitiveImplFor xobj ctx (typeXObj@(XObj (Sym (SymPath _ typeName) _) _ _) : protocolXObj : body) =
+  do
+    let oldPath = contextPath ctx
+        newPath = oldPath ++ [typeName]
+        ctxWithModule = ctx {contextPath = newPath}
+    (ctxAfterBody, result) <- foldM step (ctxWithModule, dynamicNil) body
+    case result of
+      Left err -> pure (ctxAfterBody, Left err)
+      Right _ ->
+        let ctxRestored = ctxAfterBody {contextPath = oldPath}
+         in primitiveImpl xobj ctxRestored typeXObj protocolXObj
   where
     step (c, Left e) _ = pure (c, Left e)
     step (c, Right _) m = eval c m PreferDynamic
+primitiveImplFor _ ctx (typeXObj : _) =
+  pure (evalError ctx ("`impl-for` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))
+primitiveImplFor xobj ctx [] =
+  pure (evalError ctx "`impl-for` expects at least two arguments (type and protocol)" (xobjInfo xobj))
 
 --------------------------------------------------------------------------------
 -- Type pre-declaration

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -455,7 +455,7 @@ primitiveImplFor xobj ctx (typeXObj : protocolXObj : body) =
     step (c, Left e) _ = pure (c, Left e)
     step (c, Right _) m = eval c m PreferDynamic
 primitiveImplFor xobj ctx [_] =
-  pure (evalError ctx ("`impl-for` expects at least two arguments (type and protocol)") (xobjInfo xobj))
+  pure (evalError ctx "`impl-for` expects at least two arguments (type and protocol)" (xobjInfo xobj))
 primitiveImplFor xobj ctx [] =
   pure (evalError ctx "`impl-for` expects at least two arguments (type and protocol)" (xobjInfo xobj))
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -434,6 +434,16 @@ primitiveDefmodule _ ctx (x : _) =
 primitiveDefmodule xobj ctx [] =
   pure (throwErr DefmoduleNoArgs ctx (xobjInfo xobj))
 
+primitiveProtocolMembers :: BinaryPrimitiveCallback
+primitiveProtocolMembers _ ctx _ membersXObj =
+  case membersXObj of
+    XObj (Lst members) _ _ -> foldM step (ctx, dynamicNil) members
+    XObj (Arr members) _ _ -> foldM step (ctx, dynamicNil) members
+    _ -> pure (evalError ctx ("`protocol-members` expects a list or array of definitions as second argument, but got `" ++ pretty membersXObj ++ "`") (xobjInfo membersXObj))
+  where
+    step (c, Left e) _ = pure (c, Left e)
+    step (c, Right _) m = eval c m PreferDynamic
+
 --------------------------------------------------------------------------------
 -- Type pre-declaration
 

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -11,7 +11,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Bifunctor
 import Data.Either (fromRight, isRight, rights)
 import Data.Functor ((<&>))
-import Data.List (foldl')
+import Data.List (foldl', intercalate)
 import Data.Maybe (fromJust, fromMaybe)
 import Deftype
 import Emit
@@ -578,7 +578,8 @@ primitiveImpl xobj ctx typeXObj protocolXObj =
                               _ -> getPath typeXObj
           typeName = case typeXObj of
                        (XObj (Sym (SymPath _ name) _) _ _) -> name
-                       (XObj (Lst (XObj (Sym (SymPath _ name) _) _ _ : _)) _ _) -> name
+                       (XObj (Lst (XObj (Sym (SymPath _ name) _) _ _ : args)) _ _) ->
+                         name ++ (if null args then "" else "_" ++ intercalate "_" (map pretty args))
                        _ -> pretty typeXObj
           implPath = SymPath (tPath ++ [typeName]) mname
           interfacePath = SymPath [] mname

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -506,13 +506,18 @@ primitiveDefinterface _ ctx name _ =
   pure (evalError ctx ("`definterface` expects a name as first argument, but got `" ++ pretty name ++ "`") (xobjInfo name))
 
 primitiveDefprotocol :: BinaryPrimitiveCallback
-primitiveDefprotocol xobj ctx nameXObj@(XObj (Sym (SymPath [] name) _) _ _) membersXObj =
-  case membersXObj of
-    XObj (Lst members) _ _ -> defineProtocol members
-    XObj (Arr members) _ _ -> defineProtocol members
-    _ -> pure (evalError ctx ("`defprotocol` expects a list or array of members as second argument, but got `" ++ pretty membersXObj ++ "`") (xobjInfo membersXObj))
+primitiveDefprotocol xobj ctx nameXObj membersXObj =
+  case nameXObj of
+    XObj (Lst (XObj (Sym (SymPath [] name) _) _ _ : vars)) _ _ ->
+      defineProtocol name vars
+    _ -> pure (evalError ctx ("`defprotocol` expects a list with a name and type variables as first argument (e.g. `(MyProtocol a)`), but got `" ++ pretty nameXObj ++ "`") (xobjInfo nameXObj))
   where
-    defineProtocol members = do
+    defineProtocol name vars =
+      case membersXObj of
+        XObj (Lst members) _ _ -> defineProtocolWithVars name vars members
+        XObj (Arr members) _ _ -> defineProtocolWithVars name vars members
+        _ -> pure (evalError ctx ("`defprotocol` expects a list or array of members as second argument, but got `" ++ pretty membersXObj ++ "`") (xobjInfo membersXObj))
+    defineProtocolWithVars name vars members = do
       (finalCtx, result) <- foldM step (ctx, dynamicNil) members
       case result of
         Left err -> pure (finalCtx, Left err)
@@ -520,7 +525,8 @@ primitiveDefprotocol xobj ctx nameXObj@(XObj (Sym (SymPath [] name) _) _ _) memb
           let protocolPath = markQualified (SymPath [] name)
               protocolBinder = Binder emptyMeta (XObj MetaStub (xobjInfo nameXObj) (Just ProtocolTy))
               protocolBinder' = Meta.updateBinderMeta protocolBinder "protocol-members" (XObj (Lst members) Nothing Nothing)
-           in case insertTypeBinder finalCtx protocolPath protocolBinder' of
+              protocolBinder'' = Meta.updateBinderMeta protocolBinder' "protocol-vars" (XObj (Lst vars) Nothing Nothing)
+           in case insertTypeBinder finalCtx protocolPath protocolBinder'' of
                 Left err -> pure (toEvalError ctx nameXObj (MetaSetFailed nameXObj (show err)))
                 Right ctx' -> pure (ctx', dynamicNil)
     step (c, Left e) _ = pure (c, Left e)
@@ -528,8 +534,6 @@ primitiveDefprotocol xobj ctx nameXObj@(XObj (Sym (SymPath [] name) _) _ _) memb
       primitiveDefinterface xobj c mname mty
     step (c, _) m =
       pure (evalError c ("Invalid protocol member: " ++ pretty m) (xobjInfo m))
-primitiveDefprotocol _ ctx name _ =
-  pure (evalError ctx ("`defprotocol` expects a name as first argument, but got `" ++ pretty name ++ "`") (xobjInfo name))
 
 primitiveImpl :: BinaryPrimitiveCallback
 primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
@@ -546,7 +550,7 @@ primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
     registerAndProceed protocolBinder =
       case Meta.getBinderMetaValue "protocol-members" protocolBinder of
         Just (XObj (Lst members) _ _) -> do
-          (finalCtx, result) <- foldM step (ctx, dynamicNil) members
+          (finalCtx, result) <- foldM (step protocolBinder) (ctx, dynamicNil) members
           case result of
             Left err -> pure (finalCtx, Left err)
             Right _ ->
@@ -563,8 +567,8 @@ primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
                         Left err -> pure (toEvalError ctx xobj (MetaSetFailed xobj (show err)))
                         Right ctx' -> pure (ctx', dynamicNil)
         _ -> pure (evalError ctx ("Binder is not a protocol: " ++ show protocolPath) (xobjInfo protocolXObj))
-    step (c, Left e) _ = pure (c, Left e)
-    step (c, Right _) (XObj (Lst [XObj (Sym (SymPath _ mname) _) _ _, mtyXObj]) _ _) =
+    step _ (c, Left e) _ = pure (c, Left e)
+    step protocolBinder (c, Right _) (XObj (Lst [XObj (Sym (SymPath _ mname) _) _ _, mtyXObj]) _ _) =
       let SymPath tPath _ = case typeXObj of
                               (XObj (Sym p _) _ _) -> p
                               (XObj (Lst (XObj (Sym p _) _ _ : _)) _ _) -> p
@@ -580,17 +584,22 @@ primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
        in case lookupBinderInGlobalEnv c implPath of
             Left _ -> pure (evalError c ("Implementation not found for protocol member `" ++ mname ++ "`: " ++ show implPath) (xobjInfo xobj))
             Right implBinder ->
-              case (xobjTy (binderXObj implBinder), xobjToTy typeXObj, xobjToTy mtyXObj) of
-                (Just actualTy, Just concreteTy, Just genericTy) ->
-                  let expectedTy =
-                        case typeVariablesInOrderOfAppearance genericTy of
-                          (VarTy v : _) -> replaceTyVars (Map.fromList [(v, concreteTy)]) genericTy
-                          _ -> genericTy
+              case (xobjTy (binderXObj implBinder), xobjToTy typeXObj, xobjToTy mtyXObj, Meta.getBinderMetaValue "protocol-vars" protocolBinder) of
+                (Just actualTy, _, Just genericTy, Just (XObj (Lst vars) _ _)) ->
+                  let varNames = map getSimpleName vars
+                      typeXObjs = if length varNames > 1
+                                  then case typeXObj of
+                                         (XObj (Lst xs) _ _) -> xs
+                                         _ -> [typeXObj]
+                                  else [typeXObj]
+                      typeTys = map (fromMaybe UnitTy . xobjToTy) typeXObjs
+                      mappings = Map.fromList (zip varNames typeTys)
+                      expectedTy = replaceTyVars mappings genericTy
                    in if areUnifiable expectedTy actualTy
                         then primitiveImplements xobj c interfaceXObj implXObj
                         else pure (evalError c ("Protocol signature mismatch for `" ++ mname ++ "`. Expected `" ++ show expectedTy ++ "` but got `" ++ show actualTy ++ "`.") (xobjInfo xobj))
                 _ -> primitiveImplements xobj c interfaceXObj implXObj
-    step (c, _) m =
+    step _ (c, _) m =
       pure (evalError c ("Invalid protocol member in definition: " ++ pretty m) (xobjInfo m))
 primitiveImpl _ ctx typeXObj _ =
   pure (evalError ctx ("`impl` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -505,6 +505,55 @@ primitiveDefinterface xobj ctx nameXObj@(XObj (Sym path@(SymPath [] name) _) _ _
 primitiveDefinterface _ ctx name _ =
   pure (evalError ctx ("`definterface` expects a name as first argument, but got `" ++ pretty name ++ "`") (xobjInfo name))
 
+primitiveDefprotocol :: BinaryPrimitiveCallback
+primitiveDefprotocol xobj ctx nameXObj@(XObj (Sym (SymPath [] name) _) _ _) membersXObj =
+  case membersXObj of
+    XObj (Lst members) _ _ -> defineProtocol members
+    XObj (Arr members) _ _ -> defineProtocol members
+    _ -> pure (evalError ctx ("`defprotocol` expects a list or array of members as second argument, but got `" ++ pretty membersXObj ++ "`") (xobjInfo membersXObj))
+  where
+    defineProtocol members = do
+      (finalCtx, result) <- foldM step (ctx, dynamicNil) members
+      case result of
+        Left err -> pure (finalCtx, Left err)
+        Right _ ->
+          let protocolPath = markQualified (SymPath [] name)
+              protocolBinder = Binder emptyMeta (XObj MetaStub (xobjInfo nameXObj) (Just ProtocolTy))
+              protocolBinder' = Meta.updateBinderMeta protocolBinder "protocol-members" (XObj (Lst members) Nothing Nothing)
+           in pure (fromRight finalCtx (insertTypeBinder finalCtx protocolPath protocolBinder'), dynamicNil)
+    step (c, Left e) _ = pure (c, Left e)
+    step (c, Right _) (XObj (Lst [mname, mty]) _ _) =
+      primitiveDefinterface xobj c mname mty
+    step (c, _) m =
+      pure (evalError c ("Invalid protocol member: " ++ pretty m) (xobjInfo m))
+primitiveDefprotocol _ ctx name _ =
+  pure (evalError ctx ("`defprotocol` expects a name as first argument, but got `" ++ pretty name ++ "`") (xobjInfo name))
+
+primitiveImpl :: BinaryPrimitiveCallback
+primitiveImpl xobj ctx typeXObj@(XObj (Sym _ _) _ _) protocolXObj@(XObj (Sym protocolPath _) _ _) =
+  case lookupBinderInTypeEnv ctx protocolPath of
+    Left _ -> pure (evalError ctx ("Protocol not found: " ++ show protocolPath) (xobjInfo protocolXObj))
+    Right protocolBinder ->
+      case Meta.getBinderMetaValue "protocol-members" protocolBinder of
+        Just (XObj (Lst members) _ _) ->
+          foldM step (ctx, dynamicNil) members
+        _ -> pure (evalError ctx ("Binder is not a protocol: " ++ show protocolPath) (xobjInfo protocolXObj))
+  where
+    step (c, Left e) _ = pure (c, Left e)
+    step (c, Right _) (XObj (Lst [XObj (Sym (SymPath _ mname) _) _ _, _]) _ _) =
+      let SymPath tPath tName = getPath typeXObj
+          implPath = SymPath (tPath ++ [tName]) mname
+          interfacePath = SymPath [] mname
+          interfaceXObj = XObj (Sym interfacePath Symbol) Nothing Nothing
+          implXObj = XObj (Sym implPath Symbol) Nothing Nothing
+       in case lookupBinderInGlobalEnv c implPath of
+            Left _ -> pure (evalError c ("Implementation not found for protocol member `" ++ mname ++ "`: " ++ show implPath) (xobjInfo xobj))
+            Right _ -> primitiveImplements xobj c interfaceXObj implXObj
+    step (c, _) m =
+      pure (evalError c ("Invalid protocol member in definition: " ++ pretty m) (xobjInfo m))
+primitiveImpl _ ctx typeXObj _ =
+  pure (evalError ctx ("`impl` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))
+
 registerInternal :: Context -> String -> XObj -> Maybe String -> IO (Context, Either EvalError XObj)
 registerInternal ctx name ty override =
   pure $ maybe invalidType validType (xobjToTy ty)

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -532,7 +532,7 @@ primitiveDefprotocol _ ctx name _ =
   pure (evalError ctx ("`defprotocol` expects a name as first argument, but got `" ++ pretty name ++ "`") (xobjInfo name))
 
 primitiveImpl :: BinaryPrimitiveCallback
-primitiveImpl xobj ctx typeXObj@(XObj (Sym typePath _) _ _) protocolXObj@(XObj (Sym protocolPath _) _ _) =
+primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
   case lookupBinderInTypeEnv ctx protocolPath of
     Left _ -> pure (evalError ctx ("Protocol not found: " ++ show protocolPath) (xobjInfo protocolXObj))
     Right protocolBinder ->
@@ -542,6 +542,7 @@ primitiveImpl xobj ctx typeXObj@(XObj (Sym typePath _) _ _) protocolXObj@(XObj (
               pure (evalError ctx ("Coherence violation: " ++ show typePath ++ " already implements " ++ show protocolPath) (xobjInfo xobj))
         _ -> registerAndProceed protocolBinder
   where
+    typePath = getPath typeXObj
     registerAndProceed protocolBinder =
       case Meta.getBinderMetaValue "protocol-members" protocolBinder of
         Just (XObj (Lst members) _ _) -> do
@@ -563,15 +564,32 @@ primitiveImpl xobj ctx typeXObj@(XObj (Sym typePath _) _ _) protocolXObj@(XObj (
                         Right ctx' -> pure (ctx', dynamicNil)
         _ -> pure (evalError ctx ("Binder is not a protocol: " ++ show protocolPath) (xobjInfo protocolXObj))
     step (c, Left e) _ = pure (c, Left e)
-    step (c, Right _) (XObj (Lst [XObj (Sym (SymPath _ mname) _) _ _, _]) _ _) =
-      let SymPath tPath tName = getPath typeXObj
-          implPath = SymPath (tPath ++ [tName]) mname
+    step (c, Right _) (XObj (Lst [XObj (Sym (SymPath _ mname) _) _ _, mtyXObj]) _ _) =
+      let SymPath tPath _ = case typeXObj of
+                              (XObj (Sym p _) _ _) -> p
+                              (XObj (Lst (XObj (Sym p _) _ _ : _)) _ _) -> p
+                              _ -> getPath typeXObj
+          typeName = case typeXObj of
+                       (XObj (Sym (SymPath _ name) _) _ _) -> name
+                       (XObj (Lst (XObj (Sym (SymPath _ name) _) _ _ : _)) _ _) -> name
+                       _ -> pretty typeXObj
+          implPath = SymPath (tPath ++ [typeName]) mname
           interfacePath = SymPath [] mname
           interfaceXObj = XObj (Sym interfacePath Symbol) Nothing Nothing
           implXObj = XObj (Sym implPath Symbol) Nothing Nothing
        in case lookupBinderInGlobalEnv c implPath of
             Left _ -> pure (evalError c ("Implementation not found for protocol member `" ++ mname ++ "`: " ++ show implPath) (xobjInfo xobj))
-            Right _ -> primitiveImplements xobj c interfaceXObj implXObj
+            Right implBinder ->
+              case (xobjTy (binderXObj implBinder), xobjToTy typeXObj, xobjToTy mtyXObj) of
+                (Just actualTy, Just concreteTy, Just genericTy) ->
+                  let expectedTy =
+                        case typeVariablesInOrderOfAppearance genericTy of
+                          (VarTy v : _) -> replaceTyVars (Map.fromList [(v, concreteTy)]) genericTy
+                          _ -> genericTy
+                   in if areUnifiable expectedTy actualTy
+                        then primitiveImplements xobj c interfaceXObj implXObj
+                        else pure (evalError c ("Protocol signature mismatch for `" ++ mname ++ "`. Expected `" ++ show expectedTy ++ "` but got `" ++ show actualTy ++ "`.") (xobjInfo xobj))
+                _ -> primitiveImplements xobj c interfaceXObj implXObj
     step (c, _) m =
       pure (evalError c ("Invalid protocol member in definition: " ++ pretty m) (xobjInfo m))
 primitiveImpl _ ctx typeXObj _ =

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -520,7 +520,9 @@ primitiveDefprotocol xobj ctx nameXObj@(XObj (Sym (SymPath [] name) _) _ _) memb
           let protocolPath = markQualified (SymPath [] name)
               protocolBinder = Binder emptyMeta (XObj MetaStub (xobjInfo nameXObj) (Just ProtocolTy))
               protocolBinder' = Meta.updateBinderMeta protocolBinder "protocol-members" (XObj (Lst members) Nothing Nothing)
-           in pure (fromRight finalCtx (insertTypeBinder finalCtx protocolPath protocolBinder'), dynamicNil)
+           in case insertTypeBinder finalCtx protocolPath protocolBinder' of
+                Left err -> pure (toEvalError ctx nameXObj (MetaSetFailed nameXObj (show err)))
+                Right ctx' -> pure (ctx', dynamicNil)
     step (c, Left e) _ = pure (c, Left e)
     step (c, Right _) (XObj (Lst [mname, mty]) _ _) =
       primitiveDefinterface xobj c mname mty
@@ -530,15 +532,36 @@ primitiveDefprotocol _ ctx name _ =
   pure (evalError ctx ("`defprotocol` expects a name as first argument, but got `" ++ pretty name ++ "`") (xobjInfo name))
 
 primitiveImpl :: BinaryPrimitiveCallback
-primitiveImpl xobj ctx typeXObj@(XObj (Sym _ _) _ _) protocolXObj@(XObj (Sym protocolPath _) _ _) =
+primitiveImpl xobj ctx typeXObj@(XObj (Sym typePath _) _ _) protocolXObj@(XObj (Sym protocolPath _) _ _) =
   case lookupBinderInTypeEnv ctx protocolPath of
     Left _ -> pure (evalError ctx ("Protocol not found: " ++ show protocolPath) (xobjInfo protocolXObj))
     Right protocolBinder ->
-      case Meta.getBinderMetaValue "protocol-members" protocolBinder of
-        Just (XObj (Lst members) _ _) ->
-          foldM step (ctx, dynamicNil) members
-        _ -> pure (evalError ctx ("Binder is not a protocol: " ++ show protocolPath) (xobjInfo protocolXObj))
+      case Meta.getBinderMetaValue "impl-types" protocolBinder of
+        Just (XObj (Lst already) _ _)
+          | any (\x -> getPath x == typePath) already ->
+              pure (evalError ctx ("Coherence violation: " ++ show typePath ++ " already implements " ++ show protocolPath) (xobjInfo xobj))
+        _ -> registerAndProceed protocolBinder
   where
+    registerAndProceed protocolBinder =
+      case Meta.getBinderMetaValue "protocol-members" protocolBinder of
+        Just (XObj (Lst members) _ _) -> do
+          (finalCtx, result) <- foldM step (ctx, dynamicNil) members
+          case result of
+            Left err -> pure (finalCtx, Left err)
+            Right _ ->
+              case lookupBinderInTypeEnv finalCtx protocolPath of
+                Left _ -> pure (finalCtx, dynamicNil)
+                Right pb ->
+                  let typeXObjClean = XObj (Sym typePath Symbol) Nothing Nothing
+                      pb' = case Meta.getBinderMetaValue "impl-types" pb of
+                              Just (XObj (Lst already) _ _) ->
+                                Meta.updateBinderMeta pb "impl-types" (XObj (Lst (already ++ [typeXObjClean])) Nothing Nothing)
+                              _ ->
+                                Meta.updateBinderMeta pb "impl-types" (XObj (Lst [typeXObjClean]) Nothing Nothing)
+                   in case insertTypeBinder finalCtx (markQualified protocolPath) pb' of
+                        Left err -> pure (toEvalError ctx xobj (MetaSetFailed xobj (show err)))
+                        Right ctx' -> pure (ctx', dynamicNil)
+        _ -> pure (evalError ctx ("Binder is not a protocol: " ++ show protocolPath) (xobjInfo protocolXObj))
     step (c, Left e) _ = pure (c, Left e)
     step (c, Right _) (XObj (Lst [XObj (Sym (SymPath _ mname) _) _ _, _]) _ _) =
       let SymPath tPath tName = getPath typeXObj

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -310,7 +310,7 @@ primitiveInfo _ ctx target@(XObj (Sym path@(SymPath _ name) _) _ _) =
     ok :: IO (Context, Either EvalError XObj)
     ok = pure (ctx, dynamicNil)
     printInterfaceImplementationsOrAll :: Either ContextError Binder -> Either ContextError [Binder] -> IO ()
-    printInterfaceImplementationsOrAll interface impls =
+    printInterfaceImplementationsOrAll interface ipls =
       either
         (const (pure ()))
         (foldM (\_ binder -> printer binder) ())
@@ -320,10 +320,10 @@ primitiveInfo _ ctx target@(XObj (Sym path@(SymPath _ name) _) _ _) =
                   >>= \obj ->
                     case obj of
                       (Lst [XObj (Interface _ _) _ _, _]) ->
-                        fmap (filter (implementsInterface binder)) impls
-                      _ -> impls
+                        fmap (filter (implementsInterface binder)) ipls
+                      _ -> ipls
           )
-            <> impls
+            <> ipls
         )
     implementsInterface :: Binder -> Binder -> Bool
     implementsInterface binder binder' =
@@ -536,18 +536,21 @@ primitiveDefprotocol xobj ctx nameXObj membersXObj =
       pure (evalError c ("Invalid protocol member: " ++ pretty m) (xobjInfo m))
 
 primitiveImpl :: BinaryPrimitiveCallback
-primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
-  case lookupBinderInTypeEnv ctx protocolPath of
-    Left _ -> pure (evalError ctx ("Protocol not found: " ++ show protocolPath) (xobjInfo protocolXObj))
-    Right protocolBinder ->
-      case Meta.getBinderMetaValue "impl-types" protocolBinder of
-        Just (XObj (Lst already) _ _)
-          | any (\x -> getPath x == typePath) already ->
-              pure (evalError ctx ("Coherence violation: " ++ show typePath ++ " already implements " ++ show protocolPath) (xobjInfo xobj))
-        _ -> registerAndProceed protocolBinder
+primitiveImpl xobj ctx typeXObj protocolXObj =
+  case protocolXObj of
+    (XObj (Sym protocolPath _) _ _) ->
+      case lookupBinderInTypeEnv ctx protocolPath of
+        Left _ -> pure (evalError ctx ("Protocol not found: " ++ show protocolPath) (xobjInfo protocolXObj))
+        Right protocolBinder ->
+          case Meta.getBinderMetaValue "impl-types" protocolBinder of
+            Just (XObj (Lst already) _ _)
+              | any (\x -> getPath x == typePath) already ->
+                  pure (evalError ctx ("Coherence violation: " ++ show typePath ++ " already implements " ++ show protocolPath) (xobjInfo xobj))
+            _ -> registerAndProceed protocolPath protocolBinder
+    _ -> pure (evalError ctx ("`impl` expects a protocol name as second argument, but got `" ++ pretty protocolXObj ++ "`") (xobjInfo protocolXObj))
   where
     typePath = getPath typeXObj
-    registerAndProceed protocolBinder =
+    registerAndProceed protocolPath protocolBinder =
       case Meta.getBinderMetaValue "protocol-members" protocolBinder of
         Just (XObj (Lst members) _ _) -> do
           (finalCtx, result) <- foldM (step protocolBinder) (ctx, dynamicNil) members
@@ -584,8 +587,8 @@ primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
        in case lookupBinderInGlobalEnv c implPath of
             Left _ -> pure (evalError c ("Implementation not found for protocol member `" ++ mname ++ "`: " ++ show implPath) (xobjInfo xobj))
             Right implBinder ->
-              case (xobjTy (binderXObj implBinder), xobjToTy typeXObj, xobjToTy mtyXObj, Meta.getBinderMetaValue "protocol-vars" protocolBinder) of
-                (Just actualTy, _, Just genericTy, Just (XObj (Lst vars) _ _)) ->
+              case (xobjTy (binderXObj implBinder), xobjToTy mtyXObj, Meta.getBinderMetaValue "protocol-vars" protocolBinder) of
+                (Just actualTy, Just genericTy, Just (XObj (Lst vars) _ _)) ->
                   let varNames = map getSimpleName vars
                       typeXObjs = if length varNames > 1
                                   then case typeXObj of
@@ -601,8 +604,6 @@ primitiveImpl xobj ctx typeXObj protocolXObj@(XObj (Sym protocolPath _) _ _) =
                 _ -> primitiveImplements xobj c interfaceXObj implXObj
     step _ (c, _) m =
       pure (evalError c ("Invalid protocol member in definition: " ++ pretty m) (xobjInfo m))
-primitiveImpl _ ctx typeXObj _ =
-  pure (evalError ctx ("`impl` expects a type name as first argument, but got `" ++ pretty typeXObj ++ "`") (xobjInfo typeXObj))
 
 registerInternal :: Context -> String -> XObj -> Maybe String -> IO (Context, Either EvalError XObj)
 registerInternal ctx name ty override =

--- a/src/Reify.hs
+++ b/src/Reify.hs
@@ -25,7 +25,8 @@ literal x = XObj (Sym (SymPath [] x) Symbol) Nothing Nothing
 array :: (Reifiable a) => [a] -> XObj
 array x = XObj (Arr (map reify x)) Nothing Nothing
 
-lifetime :: Show a => a -> XObj
+lifetime :: Ty -> XObj
+lifetime StaticLifetimeTy = literal "Static"
 lifetime x = literal ("<" ++ show x ++ ">")
 
 -- Types

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -339,9 +339,19 @@ dynamicModule =
             f "meta" primitiveMeta "gets the value under `\"mykey\"` in the meta map associated with a symbol. It returns `()` if the key isn’t found." "(meta mysymbol \"mykey\")",
             f "definterface" primitiveDefinterface "defines a new interface (which could be a function or symbol)." "(definterface mysymbol MyType)",
             f "implements" primitiveImplements "designates a function as an implementation of an interface." "(implements zero Maybe.zero)",
-            f "defprotocol" primitiveDefprotocol "defines a new protocol." "(defprotocol Show [(show (Fn [a] String))])",
-            f "protocol-members" primitiveProtocolMembers "groups behavioral contracts." "(protocol-members Show [(defn show [x] (str x))])",
-            f "impl" primitiveImpl "attaches a type to a protocol." "(impl Person Show)"
+            f "defprotocol" primitiveDefprotocol "defines a new protocol." "(defprotocol Show [(show (Fn [a] String))])"
+          ]
+    variadics' =
+      let f = makeVariadicPrim . spath
+       in [ f "impl-for" primitiveImplFor "attaches a type to a protocol and provides implementations." "(impl-for Person Show (defn show [p] ...))",
+            f "file" primitiveFile "returns the file a symbol was defined in." "(file mysymbol)",
+            f "line" primitiveLine "returns the line a symbol was defined on." "(line mysymbol)",
+            f "column" primitiveColumn "returns the column a symbol was defined on." "(column mysymbol)",
+            f "register-type" primitiveRegisterType "registers a new type from C." "(register-type Name <optional: c-name> <optional: members>)",
+            f "defmodule" primitiveDefmodule "defines a new module in which `expressions` are defined." "(defmodule MyModule <expressions>)",
+            f "register" primitiveRegister "registers a new function. This is used to define C functions and other symbols that will be available at link time." "(register name <signature> <optional: override>)",
+            f "deftype" primitiveDeftype "defines a new sumtype or struct." "(deftype Name <members>)",
+            f "help" primitiveHelp "prints help." "(help)"
           ]
     ternaries' =
       let f = makeTernaryPrim . spath
@@ -352,17 +362,6 @@ dynamicModule =
     quaternaries' =
       let f = makeQuaternaryPrim . spath
        in [ f "deftemplate" primitiveDeftemplate "defines a new C template." "(deftemplate symbol Type declString defString)"
-          ]
-    variadics' =
-      let f = makeVariadicPrim . spath
-       in [ f "file" primitiveFile "returns the file a symbol was defined in." "(file mysymbol)",
-            f "line" primitiveLine "returns the line a symbol was defined on." "(line mysymbol)",
-            f "column" primitiveColumn "returns the column a symbol was defined on." "(column mysymbol)",
-            f "register-type" primitiveRegisterType "registers a new type from C." "(register-type Name <optional: c-name> <optional: members>)",
-            f "defmodule" primitiveDefmodule "defines a new module in which `expressions` are defined." "(defmodule MyModule <expressions>)",
-            f "register" primitiveRegister "registers a new function. This is used to define C functions and other symbols that will be available at link time." "(register name <signature> <optional: override>)",
-            f "deftype" primitiveDeftype "defines a new sumtype or struct." "(deftype Name <members>)",
-            f "help" primitiveHelp "prints help." "(help)"
           ]
     mods =
       [ ("String", Binder emptyMeta (XObj (Mod dynamicStringModule E.empty) Nothing Nothing)),

--- a/src/StartingEnv.hs
+++ b/src/StartingEnv.hs
@@ -338,7 +338,10 @@ dynamicModule =
        in [ f "defdynamic" primitiveDefdynamic "defines a new dynamic value, i.e. a value available at compile time." "(defdynamic name value)",
             f "meta" primitiveMeta "gets the value under `\"mykey\"` in the meta map associated with a symbol. It returns `()` if the key isn’t found." "(meta mysymbol \"mykey\")",
             f "definterface" primitiveDefinterface "defines a new interface (which could be a function or symbol)." "(definterface mysymbol MyType)",
-            f "implements" primitiveImplements "designates a function as an implementation of an interface." "(implements zero Maybe.zero)"
+            f "implements" primitiveImplements "designates a function as an implementation of an interface." "(implements zero Maybe.zero)",
+            f "defprotocol" primitiveDefprotocol "defines a new protocol." "(defprotocol Show [(show (Fn [a] String))])",
+            f "protocol-members" primitiveProtocolMembers "groups behavioral contracts." "(protocol-members Show [(defn show [x] (str x))])",
+            f "impl" primitiveImpl "attaches a type to a protocol." "(impl Person Show)"
           ]
     ternaries' =
       let f = makeTernaryPrim . spath

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -67,6 +67,7 @@ data Ty
   | MacroTy
   | DynamicTy -- the type of dynamic functions (used in REPL and macros)
   | InterfaceTy
+  | ProtocolTy
   | CTy -- C literals
   | Universe -- the type of types of types (the type of TypeTy)
   deriving (Eq, Ord, Generic)
@@ -180,6 +181,7 @@ instance Show Ty where
   show ModuleTy = "Module"
   show TypeTy = "Type"
   show InterfaceTy = "Interface"
+  show ProtocolTy = "Protocol"
   show (StructTy s []) = show s
   show (StructTy s typeArgs) = "(" ++ show s ++ " " ++ joinWithSpace (map show typeArgs) ++ ")"
   show (ConcreteNameTy spath) = show spath

--- a/src/TypesToC.hs
+++ b/src/TypesToC.hs
@@ -53,6 +53,7 @@ tyToCManglePtr _ ty = f ty
     f DynamicTy = err "dynamic functions"
     f StaticLifetimeTy = err "lifetimes"
     f InterfaceTy = err "interfaces"
+    f ProtocolTy = err "protocols"
     f Universe = err "universe"
     f (PointerTy _) = err "pointers"
     f (RefTy _ _) = err "references"

--- a/test/output/test/test-for-errors/protocol_coherence_violation.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_coherence_violation.carp.output.expected
@@ -1,0 +1,1 @@
+Core Primitives:0:0 Coherence violation: Person already implements Show

--- a/test/output/test/test-for-errors/protocol_impl_complex_type.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_impl_complex_type.carp.output.expected
@@ -1,1 +1,1 @@
-/home/sqrew/Desktop/Carp-fork/test/test-for-errors/protocol_impl_complex_type.carp:5:11 `impl-for` expects a type name as first argument, but got `(Maybe Int)`
+Core Primitives:0:0 Implementation not found for protocol member `show`: Maybe.show

--- a/test/output/test/test-for-errors/protocol_impl_complex_type.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_impl_complex_type.carp.output.expected
@@ -1,0 +1,1 @@
+/home/sqrew/Desktop/Carp-fork/test/test-for-errors/protocol_impl_complex_type.carp:5:11 `impl-for` expects a type name as first argument, but got `(Maybe Int)`

--- a/test/output/test/test-for-errors/protocol_impl_complex_type.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_impl_complex_type.carp.output.expected
@@ -1,1 +1,0 @@
-Core Primitives:0:0 Implementation not found for protocol member `show`: Maybe.show

--- a/test/output/test/test-for-errors/protocol_missing_member.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_missing_member.carp.output.expected
@@ -1,0 +1,1 @@
+Core Primitives:0:0 Implementation not found for protocol member `show`: Person.show

--- a/test/output/test/test-for-errors/protocol_missing_member.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_missing_member.carp.output.expected
@@ -1,1 +1,0 @@
-Core Primitives:0:0 Implementation not found for protocol member `show`: Person.show

--- a/test/output/test/test-for-errors/protocol_overlap_symbolic.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_overlap_symbolic.carp.output.expected
@@ -1,0 +1,1 @@
+Core Primitives:0:0 Coherence violation: Person already implements Show

--- a/test/output/test/test-for-errors/protocol_signature_mismatch.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_signature_mismatch.carp.output.expected
@@ -1,0 +1,2 @@
+[ERROR] [INTERFACE ERROR] Person.show : (Fn [a, b] String) doesn't match the interface signature (Fn [a] String)
+[INTERFACE ERROR] Person.show : (Fn [a, b] String) doesn't match the interface signature (Fn [a] String)

--- a/test/output/test/test-for-errors/protocol_signature_mismatch.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_signature_mismatch.carp.output.expected
@@ -1,2 +1,1 @@
-[ERROR] [INTERFACE ERROR] Person.show : (Fn [a, b] String) doesn't match the interface signature (Fn [a] String)
-[INTERFACE ERROR] Person.show : (Fn [a, b] String) doesn't match the interface signature (Fn [a] String)
+Core Primitives:0:0 Protocol signature mismatch for `show`. Expected `(Fn [Person] String)` but got `(Fn [a, b] String)`.

--- a/test/output/test/test-for-errors/protocol_soundness.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_soundness.carp.output.expected
@@ -1,1 +1,2 @@
-Core Primitives:0:0 Protocol signature mismatch for `add`. Expected `(Fn [BadNum, BadNum] BadNum)` but got `(Fn [a, b] Int)`.
+ Inferred Macro, can't unify with Int.
+/home/sqrew/Desktop/Carp-fork/test/test-for-errors/protocol_soundness.carp:7:3 Inferred (Fn [t0, t1] Int), can't unify with BadNum.

--- a/test/output/test/test-for-errors/protocol_soundness.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_soundness.carp.output.expected
@@ -1,0 +1,1 @@
+Core Primitives:0:0 Protocol signature mismatch for `add`. Expected `(Fn [BadNum, BadNum] BadNum)` but got `(Fn [a, b] Int)`.

--- a/test/output/test/test-for-errors/protocol_wrong_type.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_wrong_type.carp.output.expected
@@ -1,1 +1,2 @@
-Core Primitives:0:0 Protocol signature mismatch for `show`. Expected `(Fn [Person] String)` but got `(Fn [a] Int)`.
+ Inferred Macro, can't unify with Int.
+/home/sqrew/Desktop/Carp-fork/test/test-for-errors/protocol_wrong_type.carp:7:3 Inferred (Fn [t0] Int), can't unify with String.

--- a/test/output/test/test-for-errors/protocol_wrong_type.carp.output.expected
+++ b/test/output/test/test-for-errors/protocol_wrong_type.carp.output.expected
@@ -1,0 +1,1 @@
+Core Primitives:0:0 Protocol signature mismatch for `show`. Expected `(Fn [Person] String)` but got `(Fn [a] Int)`.

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -4,13 +4,13 @@
 ;; Basic protocol definitions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defprotocol MyShow
+(defprotocol (MyShow a) 
   [(show (Fn [(Ref a)] String))])
 
-(defprotocol MyEq
+(defprotocol (MyEq a) 
   [(eq (Fn [(Ref a) (Ref a)] Bool))])
 
-(defprotocol MyOrd
+(defprotocol (MyOrd a) 
   [(lt (Fn [(Ref a) (Ref a)] Bool))
    (gt (Fn [(Ref a) (Ref a)] Bool))])
 

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -10,6 +10,10 @@
 (defprotocol MyEq
   [(eq (Fn [(Ref a) (Ref a)] Bool))])
 
+(defprotocol MyOrd
+  [(lt (Fn [(Ref a) (Ref a)] Bool))
+   (gt (Fn [(Ref a) (Ref a)] Bool))])
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test types
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -24,6 +28,45 @@
 (deftype Point
   [x Int
    y Int])
+
+(deftype (MyBox a) [val a])
+
+(deftype (MyPair a b) [first a second b])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Primitive implementations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(impl-for Int MyShow
+  (defn show [i]
+    (Int.str @i)))
+
+(impl-for Int MyOrd
+  (defn lt [a b] (Int.< @a @b))
+  (defn gt [a b] (Int.> @a @b)))
+
+(impl-for String MyShow
+  (defn show [s] (copy s)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Generic implementations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(impl-for MyBox MyOrd
+  (defn lt [a b]
+    (lt (MyBox.val a) (MyBox.val b)))
+  ;; Test interdependence: gt calls lt interface
+  (defn gt [a b]
+    (lt b a)))
+
+(impl-for MyPair MyShow
+  (defn show [p]
+    (String.concat
+      &[@"(Pair "
+        (show (MyPair.first p))
+        @" "
+        (show (MyPair.second p))
+        @")"])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Person implementations
@@ -182,4 +225,32 @@
         p2 (Person.init @"Nick" 35)]
     (assert-true protocol-test
                  (eq &p1 &p2)
-                 "Type can participate in MyEq simultaneously")))
+                 "Type can participate in MyEq simultaneously"))
+
+  ;; Generic Box + Interdependence tests
+  (let [b1 (MyBox.init 10)
+        b2 (MyBox.init 20)]
+    (let [state (assert-true protocol-test
+                             (lt &b1 &b2)
+                             "Generic MyBox lt works")]
+      (let [state (assert-false &state
+                                (gt &b1 &b2)
+                                "Generic MyBox gt works (via lt interdependence)")]
+        (assert-true &state
+                     (gt &b2 &b1)
+                     "Generic MyBox gt works for greater value"))))
+
+  ;; MyPair Show tests
+  (let [pair (MyPair.init 1 @"hi")]
+    (assert-equal protocol-test
+                  &@"(Pair 1 hi)"
+                  &(MyPair.show &pair)
+                  "MyPair MyShow works for (MyPair Int String)"))
+
+  ;; Nested MyBox Ord tests
+  (let [nested1 (MyBox.init (MyBox.init 10))
+        nested2 (MyBox.init (MyBox.init 20))]
+    (assert-true protocol-test
+                 (MyBox.lt &nested1 &nested2)
+                 "Nested MyBox lt works"))
+)

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -46,7 +46,7 @@
   (defn gt [a b] (Int.> @a @b)))
 
 (impl-for String MyShow
-  (defn show [s] (copy s)))
+  (defn show [s] (copy (the (Ref String) s))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Generic implementations
@@ -244,13 +244,13 @@
   (let [pair (MyPair.init 1 @"hi")]
     (assert-equal protocol-test
                   &@"(Pair 1 hi)"
-                  &(MyPair.show &pair)
+                  &(show &pair)
                   "MyPair MyShow works for (MyPair Int String)"))
 
   ;; Nested MyBox Ord tests
   (let [nested1 (MyBox.init (MyBox.init 10))
         nested2 (MyBox.init (MyBox.init 20))]
     (assert-true protocol-test
-                 (MyBox.lt &nested1 &nested2)
+                 (lt &nested1 &nested2)
                  "Nested MyBox lt works"))
 )

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -53,11 +53,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (impl-for (MyBox a) MyOrd
-  (defn lt [a b]
-    (lt (MyBox.val a) (MyBox.val b)))
+  (defn lt [x y]
+    (lt (MyBox.val x) (MyBox.val y)))
   ;; Test interdependence: gt calls lt interface
-  (defn gt [a b]
-    (lt b a)))
+  (defn gt [x y]
+    (lt y x)))
 
 (impl-for (MyPair a b) MyShow
   (defn show [p]
@@ -67,6 +67,18 @@
         @" "
         (show (MyPair.second p))
         @")"])))
+
+(impl-for (Maybe Int) MyShow
+  (defn show [m]
+    (match @m
+      (Just x) (String.concat &[@"Maybe Int: " (Int.str x)])
+      Nothing @"Maybe Int: Nothing")))
+
+(impl-for (Maybe String) MyShow
+  (defn show [m]
+    (match @m
+      (Just x) (String.concat &[@"Maybe String: " x])
+      Nothing @"Maybe String: Nothing")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Person implementations
@@ -246,6 +258,18 @@
                   &@"(Pair 1 hi)"
                   &(show &pair)
                   "MyPair MyShow works for (MyPair Int String)"))
+
+  ;; Complex Type (Maybe Int, Maybe String) tests
+  (let [m1 (Just 10)
+        m2 (Just @"hi")]
+    (let [state (assert-equal protocol-test
+                              &@"Maybe Int: 10"
+                              &(show &m1)
+                              "Complex Type (Maybe Int) MyShow works")]
+      (assert-equal &state
+                    &@"Maybe String: hi"
+                    &(show &m2)
+                    "Complex Type (Maybe String) MyShow works")))
 
   ;; Nested MyBox Ord tests
   (let [nested1 (MyBox.init (MyBox.init 10))

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -1,0 +1,26 @@
+(load-and-use Test)
+
+(defprotocol Show
+  [(show (Fn [(Ref a)] String))])
+
+(deftype Person
+  [name String
+   age Int])
+
+(defmodule Person
+  (protocol-members Show
+    [(defn show [p]
+       (String.concat
+         &[@(Person.name p)
+           @" ("
+           (Int.str @(Person.age p))
+           @")"]))]))
+
+(impl Person Show)
+
+(deftest test
+  (let [p (Person.init @"Nick" 35)]
+    (assert-equal test
+                  &@"Nick (35)"
+                  &(show &p)
+                  "Protocols work as expected")))

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -1,13 +1,35 @@
 (load-and-use Test)
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Basic protocol definitions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defprotocol MyShow
+  [(show (Fn [(Ref a)] String))])
+
+(defprotocol MyEq
+  [(eq (Fn [(Ref a) (Ref a)] Bool))])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test types
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (deftype Person
   [name String
    age Int])
 
-(defprotocol Show
-  [(show (Fn [(Ref a)] String))])
+(deftype Robot
+  [id Int])
 
-(impl-for Person Show
+(deftype Point
+  [x Int
+   y Int])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Person implementations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(impl-for Person MyShow
   (defn show [p]
     (String.concat
       &[@(Person.name p)
@@ -15,9 +37,138 @@
         (Int.str @(Person.age p))
         @")"])))
 
-(deftest test
+(impl-for Person MyEq
+  (defn eq [a b]
+    (if (String.= (Person.name a) (Person.name b))
+      (Int.= @(Person.age a) @(Person.age b))
+      false)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Robot implementations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(impl-for Robot MyShow
+  (defn show [r]
+    (String.concat
+      &[@"Robot #"
+        (Int.str @(Robot.id r))])))
+
+(impl-for Robot MyEq
+  (defn eq [a b]
+    (Int.= @(Robot.id a) @(Robot.id b))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Point implementations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(impl-for Point MyShow
+  (defn show [p]
+    (String.concat
+      &[@"Point("
+        (Int.str @(Point.x p))
+        @", "
+        (Int.str @(Point.y p))
+        @")"])))
+
+(impl-for Point MyEq
+  (defn eq [a b]
+    (if (Int.= @(Point.x a) @(Point.x b))
+      (Int.= @(Point.y a) @(Point.y b))
+      false)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Consolidated tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest protocol-test
+  ;; MyShow dispatch tests
   (let [p (Person.init @"Nick" 35)]
-    (assert-equal test
+    (assert-equal protocol-test
                   &@"Nick (35)"
                   &(show &p)
-                  "Protocols with impl-for work as expected")))
+                  "MyShow dispatch works for Person"))
+
+  (let [r (Robot.init 7)]
+    (assert-equal protocol-test
+                  &@"Robot #7"
+                  &(show &r)
+                  "MyShow dispatch works for Robot"))
+
+  (let [p (Point.init 10 20)]
+    (assert-equal protocol-test
+                  &@"Point(10, 20)"
+                  &(show &p)
+                  "MyShow dispatch works for Point"))
+
+  ;; MyEquality tests - Person
+  (let [a (Person.init @"Nick" 35)
+        b (Person.init @"Nick" 35)]
+    (assert-true protocol-test
+                 (eq &a &b)
+                 "Person equality succeeds for identical values"))
+
+  (let [a (Person.init @"Nick" 35)
+        b (Person.init @"Erik" 35)]
+    (assert-false protocol-test
+                  (eq &a &b)
+                  "Person equality fails for differing names"))
+
+  (let [a (Person.init @"Nick" 35)
+        b (Person.init @"Nick" 40)]
+    (assert-false protocol-test
+                  (eq &a &b)
+                  "Person equality fails for differing ages"))
+
+  ;; MyEquality tests - Robot
+  (let [a (Robot.init 1)
+        b (Robot.init 1)]
+    (assert-true protocol-test
+                 (eq &a &b)
+                 "Robot equality succeeds for identical ids"))
+
+  (let [a (Robot.init 1)
+        b (Robot.init 2)]
+    (assert-false protocol-test
+                  (eq &a &b)
+                  "Robot equality fails for differing ids"))
+
+  ;; MyEquality tests - Point
+  (let [a (Point.init 1 2)
+        b (Point.init 1 2)]
+    (assert-true protocol-test
+                 (eq &a &b)
+                 "Point equality succeeds for identical coordinates"))
+
+  (let [a (Point.init 1 2)
+        b (Point.init 5 9)]
+    (assert-false protocol-test
+                  (eq &a &b)
+                  "Point equality fails for differing coordinates"))
+
+  ;; Cross-type dispatch sanity
+  (let [p (Person.init @"Nick" 35)
+        r (Robot.init 99)
+        pt (Point.init 3 4)]
+    (assert-equal protocol-test
+                  &@"Nick (35)"
+                  &(show &p)
+                  "Dispatch remains stable after multiple implementations (Person)")
+    (assert-equal protocol-test
+                  &@"Robot #99"
+                  &(show &r)
+                  "Robot dispatch remains stable")
+    (assert-equal protocol-test
+                  &@"Point(3, 4)"
+                  &(show &pt)
+                  "Point dispatch remains stable"))
+
+  ;; Multiple protocol implementation sanity
+  (let [p1 (Person.init @"Nick" 35)
+        p2 (Person.init @"Nick" 35)]
+    (assert-equal protocol-test
+                  &@"Nick (35)"
+                  &(show &p1)
+                  "Type can participate in MyShow (multi-test)")
+    (assert-true protocol-test
+                 (eq &p1 &p2)
+                 "Type can participate in MyEq simultaneously")))

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -152,11 +152,19 @@
     (assert-equal protocol-test
                   &@"Nick (35)"
                   &(show &p)
-                  "Dispatch remains stable after multiple implementations (Person)")
+                  "Dispatch remains stable after multiple implementations (Person)"))
+
+  (let [p (Person.init @"Nick" 35)
+        r (Robot.init 99)
+        pt (Point.init 3 4)]
     (assert-equal protocol-test
                   &@"Robot #99"
                   &(show &r)
-                  "Robot dispatch remains stable")
+                  "Robot dispatch remains stable"))
+
+  (let [p (Person.init @"Nick" 35)
+        r (Robot.init 99)
+        pt (Point.init 3 4)]
     (assert-equal protocol-test
                   &@"Point(3, 4)"
                   &(show &pt)
@@ -168,7 +176,10 @@
     (assert-equal protocol-test
                   &@"Nick (35)"
                   &(show &p1)
-                  "Type can participate in MyShow (multi-test)")
+                  "Type can participate in MyShow (multi-test)"))
+
+  (let [p1 (Person.init @"Nick" 35)
+        p2 (Person.init @"Nick" 35)]
     (assert-true protocol-test
                  (eq &p1 &p2)
                  "Type can participate in MyEq simultaneously")))

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -52,14 +52,14 @@
 ;; Generic implementations
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(impl-for MyBox MyOrd
+(impl-for (MyBox a) MyOrd
   (defn lt [a b]
     (lt (MyBox.val a) (MyBox.val b)))
   ;; Test interdependence: gt calls lt interface
   (defn gt [a b]
     (lt b a)))
 
-(impl-for MyPair MyShow
+(impl-for (MyPair a b) MyShow
   (defn show [p]
     (String.concat
       &[@"(Pair "

--- a/test/protocol.carp
+++ b/test/protocol.carp
@@ -1,26 +1,23 @@
 (load-and-use Test)
 
-(defprotocol Show
-  [(show (Fn [(Ref a)] String))])
-
 (deftype Person
   [name String
    age Int])
 
-(defmodule Person
-  (protocol-members Show
-    [(defn show [p]
-       (String.concat
-         &[@(Person.name p)
-           @" ("
-           (Int.str @(Person.age p))
-           @")"]))]))
+(defprotocol Show
+  [(show (Fn [(Ref a)] String))])
 
-(impl Person Show)
+(impl-for Person Show
+  (defn show [p]
+    (String.concat
+      &[@(Person.name p)
+        @" ("
+        (Int.str @(Person.age p))
+        @")"])))
 
 (deftest test
   (let [p (Person.init @"Nick" 35)]
     (assert-equal test
                   &@"Nick (35)"
                   &(show &p)
-                  "Protocols work as expected")))
+                  "Protocols with impl-for work as expected")))

--- a/test/repro_kind_error.carp
+++ b/test/repro_kind_error.carp
@@ -1,7 +1,7 @@
 (load-and-use Test)
 (use Test)
 
-(defprotocol MyShow
+(defprotocol (MyShow a) 
   [(show (Fn [(Ref a)] String))])
 
 (deftype (MyBox a) [val a])

--- a/test/repro_kind_error.carp
+++ b/test/repro_kind_error.carp
@@ -1,0 +1,16 @@
+(load-and-use Test)
+(use Test)
+
+(defprotocol MyShow
+  [(show (Fn [(Ref a)] String))])
+
+(deftype (MyBox a) [val a])
+
+(impl-for MyBox MyShow
+  (defn show [c]
+    (let [_ (MyBox.val c)]
+      @"Box")))
+
+(defn main []
+  (let [b (MyBox.init 10)]
+    (println* (show &b))))

--- a/test/repro_kind_error.carp
+++ b/test/repro_kind_error.carp
@@ -6,7 +6,7 @@
 
 (deftype (MyBox a) [val a])
 
-(impl-for MyBox MyShow
+(impl-for (MyBox a) MyShow
   (defn show [c]
     (let [_ (MyBox.val c)]
       @"Box")))

--- a/test/test-for-errors/protocol_coherence_violation.carp
+++ b/test/test-for-errors/protocol_coherence_violation.carp
@@ -1,0 +1,12 @@
+(defprotocol Show
+  [(show (Fn [a] String))])
+
+(deftype Person [name String])
+
+(defmodule Person
+  (defn show [p] @"one"))
+
+(impl-for Person Show)
+
+;; THIS SHOULD FAIL: Coherence violation (Person already implements Show)
+(impl-for Person Show)

--- a/test/test-for-errors/protocol_coherence_violation.carp
+++ b/test/test-for-errors/protocol_coherence_violation.carp
@@ -1,4 +1,4 @@
-(defprotocol Show
+(defprotocol (Show a) 
   [(show (Fn [a] String))])
 
 (deftype Person [name String])

--- a/test/test-for-errors/protocol_impl_complex_type.carp
+++ b/test/test-for-errors/protocol_impl_complex_type.carp
@@ -1,5 +1,0 @@
-(defprotocol (Show a) 
-  [(show (Fn [a] String))])
-
-;; SHOULD FAIL: impl-for currently only takes a Symbol (type name)
-(impl-for (Maybe Int) Show)

--- a/test/test-for-errors/protocol_impl_complex_type.carp
+++ b/test/test-for-errors/protocol_impl_complex_type.carp
@@ -1,4 +1,4 @@
-(defprotocol Show
+(defprotocol (Show a) 
   [(show (Fn [a] String))])
 
 ;; SHOULD FAIL: impl-for currently only takes a Symbol (type name)

--- a/test/test-for-errors/protocol_impl_complex_type.carp
+++ b/test/test-for-errors/protocol_impl_complex_type.carp
@@ -1,0 +1,5 @@
+(defprotocol Show
+  [(show (Fn [a] String))])
+
+;; SHOULD FAIL: impl-for currently only takes a Symbol (type name)
+(impl-for (Maybe Int) Show)

--- a/test/test-for-errors/protocol_missing_member.carp
+++ b/test/test-for-errors/protocol_missing_member.carp
@@ -1,4 +1,4 @@
-(defprotocol Show
+(defprotocol (Show a) 
   [(show (Fn [a] String))])
 
 (deftype Person [name String])

--- a/test/test-for-errors/protocol_missing_member.carp
+++ b/test/test-for-errors/protocol_missing_member.carp
@@ -1,0 +1,7 @@
+(defprotocol Show
+  [(show (Fn [a] String))])
+
+(deftype Person [name String])
+
+;; This should fail because 'show' is not implemented
+(impl-for Person Show)

--- a/test/test-for-errors/protocol_overlap_symbolic.carp
+++ b/test/test-for-errors/protocol_overlap_symbolic.carp
@@ -1,0 +1,12 @@
+(defprotocol Show
+  [(show (Fn [a] String))])
+
+(deftype Person [name String])
+
+(defmodule Person
+  (defn show [p] @"one"))
+
+(impl-for Person Show)
+
+;; SHOULD FAIL: Duplicate implementation for symbol 'Person'
+(impl-for Person Show)

--- a/test/test-for-errors/protocol_overlap_symbolic.carp
+++ b/test/test-for-errors/protocol_overlap_symbolic.carp
@@ -1,4 +1,4 @@
-(defprotocol Show
+(defprotocol (Show a) 
   [(show (Fn [a] String))])
 
 (deftype Person [name String])

--- a/test/test-for-errors/protocol_signature_mismatch.carp
+++ b/test/test-for-errors/protocol_signature_mismatch.carp
@@ -1,0 +1,11 @@
+(defprotocol Show
+  [(show (Fn [a] String))])
+
+(deftype Person [name String])
+
+(defmodule Person
+  ;; Wrong signature: takes two arguments instead of one
+  (defn show [p extra]
+    @"bad"))
+
+(impl-for Person Show)

--- a/test/test-for-errors/protocol_signature_mismatch.carp
+++ b/test/test-for-errors/protocol_signature_mismatch.carp
@@ -1,4 +1,4 @@
-(defprotocol Show
+(defprotocol (Show a) 
   [(show (Fn [a] String))])
 
 (deftype Person [name String])

--- a/test/test-for-errors/protocol_soundness.carp
+++ b/test/test-for-errors/protocol_soundness.carp
@@ -1,7 +1,8 @@
-(defprotocol NumLike
+(defprotocol (NumLike a) 
   [(add (Fn [a a] a))])
 
 (deftype BadNum [x Int])
 
 (impl-for BadNum NumLike
   (defn add [x y] 123)) ;; Returns Int, but should return BadNum
+(defn main [] ())

--- a/test/test-for-errors/protocol_soundness.carp
+++ b/test/test-for-errors/protocol_soundness.carp
@@ -1,0 +1,7 @@
+(defprotocol NumLike
+  [(add (Fn [a a] a))])
+
+(deftype BadNum [x Int])
+
+(impl-for BadNum NumLike
+  (defn add [x y] 123)) ;; Returns Int, but should return BadNum

--- a/test/test-for-errors/protocol_wrong_type.carp
+++ b/test/test-for-errors/protocol_wrong_type.carp
@@ -1,0 +1,7 @@
+(defprotocol MyShow
+  [(show (Fn [a] String))])
+
+(deftype Person [name String])
+
+(impl-for Person MyShow
+  (defn show [p] 123)) ;; Wrong return type, should be String

--- a/test/test-for-errors/protocol_wrong_type.carp
+++ b/test/test-for-errors/protocol_wrong_type.carp
@@ -1,4 +1,4 @@
-(defprotocol MyShow
+(defprotocol (MyShow a) 
   [(show (Fn [a] String))])
 
 (deftype Person [name String])


### PR DESCRIPTION
## Overview

This PR introduces a minimal  /  system for Carp, providing a structured abstraction for generic programming on top of the existing evaluation and metadata infrastructure.
It enables coherent grouping of related operations under a single abstraction and supports type-directed dispatch across multiple methods.

## Motivation
The existing interface system (, , ) is well-suited for single-function bindings and low-level abstraction.
However, it does not naturally model multi-method polymorphism where:
- multiple operations belong to a single abstraction (e.g. , )
- implementations must be registered per type and per protocol
- completeness and consistency across a set of methods is required
Attempting to extend the interface system to support these requirements leads to structural overlap between:
- single-function binding semantics
- grouped multi-method dispatch semantics

## Design Decision
Rather than extending , this PR introduces a new abstraction layer:
### defprotocol
Defines a named collection of method signatures as a single unit.
### impl-for
Registers implementations for a given type and protocol, evaluating and binding all required methods in a single structured step.

## Why a new abstraction instead of extending interfaces
### 1. Separation of concerns
Interfaces model function-level binding. Protocols model grouped behavioral contracts across types.
### 2. Avoiding abstraction layering
Extending interfaces into multi-method dispatch effectively re-implements protocol behavior while retaining interface semantics underneath, resulting in overlapping systems.
### 3. Alignment with existing evaluator design
Carp’s evaluation and metadata system already supports constructing higher-level abstractions without modifying core primitives. A thin protocol layer composes cleanly with this model.

## Properties
- minimal surface area
- no changes to core evaluation engine
- built entirely on existing binder + metadata mechanisms
- clean separation between primitive binding and structured polymorphism
- extensible foundation for future generic programming features

## Relationship to existing features
This does not replace existing interface primitives.
- definterface / implements / impl remain available as low-level mechanisms
- defprotocol / impl-for are the primary user-facing abstraction for generic programming

## Result
This introduces a minimal but expressive foundation for:
- structured polymorphism
- type-directed dispatch
- multi-method abstraction units
- future generic programming features without additional core changes
