### PR TITLE
Fix Map.put-! duplicate length increment

### DIFF
--- a/core/Map.carp
+++ b/core/Map.carp
@@ -197,7 +197,8 @@
     (let-do [idx (Int.positive-mod (hash k) @(n-buckets m))
              b (buckets m)
              n (Array.unsafe-nth b idx)]
-      (set-len! m (Int.inc @(len m)))
+      (when (= (Bucket.find n k) -1)
+        (set-len! m (Int.inc @(len m))))
       (Bucket.put! n k v)))
 
   (doc resize "Resize a map `m` to size `s`.")


### PR DESCRIPTION
Fixes a bug where Map.put-! unconditionally incremented the length field even when updating an existing key. This caused the length counter to become incorrect over time.