### PR TITLE
fix(expand): resolve qualified symbols absolutely, not via bare-name fallback

### DIFF
--- a/src/Expand.hs
+++ b/src/Expand.hs
@@ -384,9 +384,12 @@ expand mode eval ctx xobj =
           where
             qpath = qualifyPath ctx (SymPath [] name)
             searchForBinder =
-              case lookupBinderInGlobalEnv ctx path <> lookupBinderInGlobalEnv ctx qpath of
+              case lookupBinderInGlobalEnv ctx path <> fallbackLookup of
                 Right (Binder meta found) -> isPrivate meta (matchDef found) (getPath found)
                 Left _ -> pure (ctx, Right xobj) -- symbols that are not found are left as-is
+            fallbackLookup
+              | null p = lookupBinderInGlobalEnv ctx qpath
+              | otherwise = lookupBinderInGlobalEnv ctx (markQualified path)
             isPrivate m x (SymPath p' _) =
               pure $
                 if (metaIsTrue m "private") && (not (null p') && p' /= contextPath ctx)

--- a/test/expand_qualified_shadow.carp
+++ b/test/expand_qualified_shadow.carp
@@ -1,0 +1,33 @@
+(load "Test.carp")
+(use Test)
+
+; Regression test: a module-level macro with the same name as a function in a
+; sibling submodule used to hijack qualified references to that function
+; during expansion (in call position this produced an "unexpected static
+; call" error, in value position an infinite expansion loop).
+
+(defmodule M
+  (deftype T (A [Long]) (B []))
+  (defmodule T
+    (defn str [t]
+      (match @t
+        (T.A i) (Long.str i)
+        (T.B) @"b"))
+    (implements str M.T.str))
+
+  (defmacro str [a] a)
+
+  (defn describe [t] (M.T.str t))
+
+  (defn join-all [o]
+    (Array.join ", " &(Array.copy-map &M.T.str o))))
+
+(deftest test
+  (assert-equal test
+                "1"
+                &(M.describe &(M.T.A 1l))
+                "qualified call isn't hijacked by a same-named sibling macro")
+  (assert-equal test
+                "1, b"
+                &(M.join-all &[(M.T.A 1l) (M.T.B)])
+                "qualified reference isn't hijacked by a same-named sibling macro"))


### PR DESCRIPTION
**DISCLOSURE**: Completely AI-generated.

Fixes #1343.

When a qualified symbol (e.g. `M.T.str` inside module `M`) isn't found relative to the current context, expansion fell back to stripping the path and trying just the unqualified name in the current context. A same-named sibling binding could then hijack the reference:

```clojure
(defmodule M
  (defmodule T
    (defn str [t] ...))
  (defmacro str [a] a)
  (defn describe [t] (M.T.str t)))            ; => error: unexpected static call
  (defn join-all [o] (copy-map &M.T.str o)))  ; => error: expansion loops forever
```

The fallback for qualified symbols is now an absolute lookup of the path as written. The unqualified name contextual fallback remains for unqualified symbols only.

Found while porting `carpentry-org/cli.car (which has a `CLI.str` macro next to `CLI.Type.str`) to current master. Includes a regression test, and full test suite passes.

Cheers