### PR TITLE
fix(expand): don't substitute macros and dynamic functions in value positions

### DIFF
--- a/src/Expand.hs
+++ b/src/Expand.hs
@@ -73,9 +73,14 @@ symsOf :: XObj -> [XObj]
 symsOf (XObj (Arr xs) _ _) = xs
 symsOf _ = []
 
+data SymbolPosition = HeadPosition | ValuePosition deriving (Eq)
+
 -- | Macro expansion of a single form
 expand :: ExpansionMode -> DynamicEvaluator -> Context -> XObj -> IO (Context, Either EvalError XObj)
-expand mode eval ctx xobj =
+expand = expandAt ValuePosition
+
+expandAt :: SymbolPosition -> ExpansionMode -> DynamicEvaluator -> Context -> XObj -> IO (Context, Either EvalError XObj)
+expandAt pos mode eval ctx xobj =
   case xobjObj xobj of
     Lst _ -> expandList xobj
     Arr _ -> expandArray xobj
@@ -306,7 +311,7 @@ expand mode eval ctx xobj =
             Right sym -> expand mode eval ctx' (XObj (Lst (sym : args)) (xobjInfo xobj) (xobjTy xobj))
             Left err -> pure (ctx', Left err)
         else do
-          (_, expandedF) <- expand mode eval ctx f
+          (_, expandedF) <- expandAt HeadPosition mode eval ctx f
           (ctx'', expandedArgs) <- expandMany ctx args
           case expandedF of
             Right (XObj (Lst [XObj Dynamic _ _, _, XObj (Arr _) _ _, _]) _ _) ->
@@ -378,18 +383,23 @@ expand mode eval ctx xobj =
               case getBinder (contextEnv ctx :: Env) name of
                 -- A locally-scoped name shadows globals: keep it as-is rather than substituting.
                 Right (Binder _ (XObj (Sym _ _) _ _)) -> pure (ctx, Right xobj)
-                Right (Binder _ found) -> pure (ctx, Right (matchDef found))
+                Right (Binder _ found) -> pure (ctx, Right (substitute found))
                 _ -> searchForBinder
             _ -> searchForBinder
           where
             qpath = qualifyPath ctx (SymPath [] name)
             searchForBinder =
               case lookupBinderInGlobalEnv ctx path <> fallbackLookup of
-                Right (Binder meta found) -> isPrivate meta (matchDef found) (getPath found)
+                Right (Binder meta found) -> isPrivate meta (substitute found) (getPath found)
                 Left _ -> pure (ctx, Right xobj) -- symbols that are not found are left as-is
             fallbackLookup
               | null p = lookupBinderInGlobalEnv ctx qpath
               | otherwise = lookupBinderInGlobalEnv ctx (markQualified path)
+            substitute found =
+              let result = matchDef found
+               in if pos == ValuePosition && (isMacroCallable result || isDynamicCallable result)
+                    then xobj
+                    else result
             isPrivate m x (SymPath p' _) =
               pure $
                 if (metaIsTrue m "private") && (not (null p') && p' /= contextPath ctx)

--- a/test/expand_value_position_macro.carp
+++ b/test/expand_value_position_macro.carp
@@ -1,0 +1,27 @@
+(load "Test.carp")
+(use Test)
+
+; Regression test: an unqualified reference to an interface in value position
+; (e.g. `&str` passed to a higher-order function) used to get the binding of
+; a same-named macro in the enclosing module substituted for it, which made
+; expansion loop forever.
+
+(defmodule M
+  (deftype T (A [Long]) (B []))
+  (defmodule T
+    (defn str [t]
+      (match @t
+        (T.A i) (Long.str i)
+        (T.B) @"b"))
+    (implements str M.T.str))
+
+  (defmacro str [a] a)
+
+  (defn join-all [o]
+    (Array.join ", " &(Array.copy-map &str o))))
+
+(deftest test
+  (assert-equal test
+                "1, b"
+                &(M.join-all &[(M.T.A 1l) (M.T.B)])
+                "interface references in value positions aren't shadowed by macros"))


### PR DESCRIPTION
**DISCLOSURE:** Completely AI-generated.

Expansion substituted the resolved binding for every symbol it could look up, including when the binding was a macro or dynamic function and the symbol sat in a value position, e.g. an interface reference like `&str` with a same-named macro in the enclosing module:

```clojure
(defmodule M
  (defmodule T
    (defn str [t] ...)
    (implements str M.T.str))
  (defmacro str [a] a)
  (defn join-all [o] (Array.join ", " &(Array.copy-map &str o))))  ; expansion never terminates
```

Macro objects in the AST are never valid static code, and because their captured closure contexts never compare equal, `expandAll` looped forever.

Symbol substitution is now position-aware: only head-position symbols may expand to macro/dynamic objects (used solely to classify the call, the whole form is re-evaluated afterwards). Value-position symbols are left as-is for the type checker. Same loop shape as #1560, this covers the macro-binder variant.

Found while porting carpentry-org/cli.carp to current master. Includes a regression test, full test suite passes.

Cheers