### PR TITLE
fix(memory): refs to globals are not inside-function ref sources

### DIFF
--- a/src/Memory.hs
+++ b/src/Memory.hs
@@ -715,7 +715,7 @@ addToLifetimesMappingsIfRef internal xobj =
       pure ()
   where
     makeLifetimeMode =
-      if internal
+      if internal && not refTargetIsGlobal
         then
           LifetimeInsideFunction $
             Set.fromList
@@ -724,6 +724,13 @@ addToLifetimesMappingsIfRef internal xobj =
                   _ -> varOfXObj xobj
               ]
         else LifetimeOutsideFunction
+    refTargetIsGlobal =
+      case xobj of
+        XObj (Lst [XObj Ref _ _, target]) _ _ ->
+          isGlobalFunc target || isGlobalVariable target
+        _ -> False
+    isGlobalVariable (XObj (Sym _ (LookupGlobal _ _)) _ _) = True
+    isGlobalVariable _ = False
     mergeLifetimeMode LifetimeOutsideFunction LifetimeOutsideFunction = LifetimeOutsideFunction
     mergeLifetimeMode (LifetimeInsideFunction a) (LifetimeInsideFunction b) = LifetimeInsideFunction (Set.union a b)
     mergeLifetimeMode (LifetimeInsideFunction a) LifetimeOutsideFunction = LifetimeMixed a

--- a/test/memory_global_ref_in_loop.carp
+++ b/test/memory_global_ref_in_loop.carp
@@ -1,0 +1,26 @@
+(load "Test.carp")
+(use Test)
+
+; Regression test: a reference to a global function (e.g. `&str` passed to
+; copy-map) inside a while/for body used to fail the memory checker's second
+; pass over the loop with "reference isn't alive".
+
+(deftype T (A [Long]) (B []))
+(defmodule T
+  (defn str [t]
+    (match @t
+      (T.A i) (Long.str i)
+      (T.B) @"b"))
+  (implements str T.str))
+
+(defn join-in-loop []
+  (let-do [acc []]
+    (for [i 0 2]
+      (set! acc (Array.push-back acc (Array.join ", " &(Array.copy-map &str &[(T.A 1l) (T.B)])))))
+    (Array.join "; " &acc)))
+
+(deftest test
+  (assert-equal test
+                "1, b; 1, b"
+                &(join-in-loop)
+                "refs to global functions inside loops stay alive"))


### PR DESCRIPTION
**DISCLOSURE**: Fully AI-generated.

This PR fixes an issue where global functions were reported as dead by the borrow-checker when used repeatedly. It’s global and doesn’t die, so that shouldn’t happen.

Cheers