### PR TITLE
fix(eval): evaluate macro bodies in their defining module

### DIFF
--- a/src/Context.hs
+++ b/src/Context.hs
@@ -31,6 +31,7 @@ module Context
 where
 
 import Data.Bifunctor
+import Data.List (stripPrefix)
 import Debug.Trace
 import qualified Env as E
 import Obj
@@ -309,11 +310,18 @@ lookupBinderInTypeEnv ctx path =
   let typeEnv = contextTypeEnv ctx
       global = contextGlobalEnv ctx
       fullPath@(SymPath qualification name) = contextualize path ctx
-      theType =
-        ( case qualification of
-            [] -> E.getBinder typeEnv name
-            _ -> E.searchTypeBinder global fullPath
-        )
+      lookup' (SymPath [] n) = E.getBinder typeEnv n
+      lookup' p = E.searchTypeBinder global p
+      theType = case stripPrefix (contextPath ctx) qualification of
+        Just stripped
+          | not (null (contextPath ctx)) ->
+            case lookup' fullPath of
+              Right b -> Right b
+              Left err ->
+                case lookup' (SymPath stripped name) of
+                  Right b | isType (binderXObj b) -> Right b
+                  _ -> Left err
+        _ -> lookup' fullPath
    in replaceLeft (NotFoundType fullPath) theType
 
 -- | Lookup a binder in a context's global environment.

--- a/src/EvalVM.hs
+++ b/src/EvalVM.hs
@@ -381,9 +381,11 @@ resolveSymbol ctx spath@(SymPath p n) info preference =
           )
             <|> lookupInUsedModules rest
     checkPrivate meta found =
-      if metaIsTrue meta "private"
+      if metaIsTrue meta "private" && not (privateAccessible (getPath found))
         then pure (throwErr (PrivateBinding (getPath found)) ctx info)
         else resolveFound found
+    privateAccessible (SymPath modulePath _) =
+      null modulePath || modulePath == contextPath ctx
     lookupInternalBinder = E.lookupBinderInParentChain
     resolveDef (XObj (Lst [XObj DefDynamic _ _, _, value]) _ _) = value
     resolveDef (XObj (Lst [XObj LocalDef _ _, _, value]) _ _) = value
@@ -917,7 +919,7 @@ dispatchCallableBC phase appCtx preference fun args argCodes info ty funXObj =
     dispatchCompiledClosure mode capturedCtx cid proper rest =
       case mode of
         CallAsMacro ->
-          runCompiledMacroClosureCallBC phase appCtx preference cid proper rest args
+          runCompiledMacroClosureCallBC phase appCtx preference capturedCtx cid proper rest args
         CallAsDynamic ->
           runCompiledDynamicClosureCallBC phase appCtx cid proper rest argCodes
         CallAsFunction ->
@@ -1012,9 +1014,11 @@ runCompiledDynamicClosureCallBC phase appCtx cid proper restName argCodes = do
       pure (replaceInternalEnvMaybe ctx' (contextInternalEnv ctxWithArgs), res)
     Left err -> pure (ctxWithArgs, Left err)
 
-runCompiledMacroClosureCallBC :: EvalPhase -> Context -> LookupPreference -> Int -> [String] -> Maybe String -> [EvalIR] -> IO (Context, Either EvalError XObj)
-runCompiledMacroClosureCallBC phase appCtx preference cid proper restName argsToCall = do
-  (ctx', res) <- applyCompiledBC phase CompileModeMacro appCtx cid proper restName (map raiseExpr argsToCall)
+runCompiledMacroClosureCallBC :: EvalPhase -> Context -> LookupPreference -> Context -> Int -> [String] -> Maybe String -> [EvalIR] -> IO (Context, Either EvalError XObj)
+runCompiledMacroClosureCallBC phase appCtx preference capturedCtx cid proper restName argsToCall = do
+  let macroCtx = replacePath appCtx (contextPath capturedCtx)
+  (bodyCtx, res) <- applyCompiledBC phase CompileModeMacro macroCtx cid proper restName (map raiseExpr argsToCall)
+  let ctx' = replacePath bodyCtx (contextPath appCtx)
   case res of
     Right xobj' -> do
       (expandedCtx, expandedRes) <- macroExpandVM ctx' xobj'

--- a/test/macro_private_helper.carp
+++ b/test/macro_private_helper.carp
@@ -1,0 +1,17 @@
+(load "Test.carp")
+(use Test)
+
+; Regression test: a macro must be able to use private dynamic helpers from
+; its own module, both via qualified and unqualified references, no matter
+; where it is invoked from.
+
+(defmodule M
+  (hidden helper)
+  (private helper)
+  (defndynamic helper [x] x)
+  (defmacro qualified [] (M.helper 1))
+  (defmacro unqualified [] (helper 2)))
+
+(deftest test
+  (assert-equal test 1 (M.qualified) "macro can call a private same-module helper (qualified)")
+  (assert-equal test 2 (M.unqualified) "macro can call a private same-module helper (unqualified)"))

--- a/test/typeenv_lookup_fallback.carp
+++ b/test/typeenv_lookup_fallback.carp
@@ -1,0 +1,23 @@
+(load "Test.carp")
+(use Test)
+
+; Regression test: the root fallback for context-relative type lookups must
+; only return actual type definitions. Interfaces also live in the type env,
+; and falling back to them hijacked same-named value lookups inside modules,
+; e.g. breaking lifetime inference for this implementation of `=`.
+
+(deftype MiniT [count Long])
+
+(defmodule MiniT
+  (sig call (Fn [(Ref (Fn [a] a) q) a (Ref MiniT r)] a))
+  (defn call [f init t-ref] (do (ignore t-ref) (~f init)))
+
+  (sig = (Fn [(Ref MiniT q) (Ref MiniT q)] Bool))
+  (defn = [a-ref b-ref]
+    (call &(fn [acc] (and acc (> @(MiniT.count b-ref) 0l))) true a-ref))
+  (implements = MiniT.=))
+
+(deftest test
+  (assert-false test
+                (= &(MiniT.init 0l) &(MiniT.init 0l))
+                "same-named interfaces don't hijack module value lookups"))


### PR DESCRIPTION
This PR fixes a bug where macro bodies were evaluated with the caller's context path.

Since lookups inside macro bodies now run relative to the defining module, context-relative type lookups gain a root fallback (the path as written, resolved from the root). Otherwise things break, e.g. `derive`'s call to `(members t)` could no longer see the caller's root-level types.

Cheers