### PR TITLE
fix(eval): don't leak the implicit 'use Dynamic' into the global env

### DIFF
--- a/src/Env.hs
+++ b/src/Env.hs
@@ -40,6 +40,7 @@ module Env
     deleteBinding,
     addListOfBindings,
     addUsePath,
+    removeUsePath,
     -------------------------
     -- finds
     findPoly,
@@ -425,6 +426,9 @@ addListOfBindings e bindings =
 -- | Add a module path to an environment's list of used modules.
 addUsePath :: Environment e => e -> SymPath -> e
 addUsePath e path = inj ((prj e) {envUseModules = Set.insert path (envUseModules (prj e))})
+
+removeUsePath :: Environment e => e -> SymPath -> e
+removeUsePath e path = inj ((prj e) {envUseModules = Set.delete path (envUseModules (prj e))})
 
 --------------------------------------------------------------------------------
 -- Additional binding lookup functions

--- a/src/EvalVM.hs
+++ b/src/EvalVM.hs
@@ -189,21 +189,34 @@ runEvalIRVMWithPhase phase ctx ir preference =
                 runEvalCodeWithPhase phase ctx preference compiled
 
 evalDynamicVM :: Context -> XObj -> IO (Context, Either EvalError XObj)
-evalDynamicVM ctx xobj =
-  let ctx' = ensureDynamicUse ctx
-   in runEvalIRVMWithPhase PhaseExecute ctx' (lowerExpr ctx' xobj) PreferDynamic
+evalDynamicVM ctx xobj = do
+  let hadDynamicUse = Set.member dynamicUsePath (envUseModules (contextGlobalEnv ctx))
+      ctx' = ensureDynamicUse ctx
+  (resCtx, res) <- runEvalIRVMWithPhase PhaseExecute ctx' (lowerExpr ctx' xobj) PreferDynamic
+  pure (scrubDynamicUse hadDynamicUse resCtx, res)
 
 evalExpandVM :: Context -> XObj -> IO (Context, Either EvalError XObj)
-evalExpandVM ctx xobj =
-  let ctx' = ensureDynamicUse ctx
-   in runEvalIRVMWithPhase PhaseExpand ctx' (lowerExpr ctx' xobj) PreferDynamic
+evalExpandVM ctx xobj = do
+  let hadDynamicUse = Set.member dynamicUsePath (envUseModules (contextGlobalEnv ctx))
+      ctx' = ensureDynamicUse ctx
+  (resCtx, res) <- runEvalIRVMWithPhase PhaseExpand ctx' (lowerExpr ctx' xobj) PreferDynamic
+  pure (scrubDynamicUse hadDynamicUse resCtx, res)
 
 macroExpandVM :: Context -> XObj -> IO (Context, Either EvalError XObj)
 macroExpandVM ctx xobj = expand MacroExpandOnly evalExpandVM ctx xobj
 
+dynamicUsePath :: SymPath
+dynamicUsePath = SymPath [] "Dynamic"
+
 ensureDynamicUse :: Context -> Context
 ensureDynamicUse ctx =
-  replaceGlobalEnv ctx (E.addUsePath (contextGlobalEnv ctx) (SymPath [] "Dynamic"))
+  replaceGlobalEnv ctx (E.addUsePath (contextGlobalEnv ctx) dynamicUsePath)
+
+scrubDynamicUse :: Bool -> Context -> Context
+scrubDynamicUse hadDynamicUse ctx =
+  if hadDynamicUse
+    then ctx
+    else replaceGlobalEnv ctx (E.removeUsePath (contextGlobalEnv ctx) dynamicUsePath)
 
 data VMClosurePayload
   = VMPrecompiled EvalCode
@@ -408,19 +421,18 @@ specialCommandDefineVM ctx xobj = do
 
 annotateWithinContextVM :: Context -> XObj -> IO (Context, Either EvalError (XObj, [XObj]))
 annotateWithinContextVM ctx xobj = do
-  let ctxDyn = ensureDynamicUse ctx
-      globalEnv = contextGlobalEnv ctxDyn
-      typeEnv = contextTypeEnv ctxDyn
-      sig = getSigFromDefnOrDefVM ctxDyn xobj
+  let globalEnv = contextGlobalEnv ctx
+      typeEnv = contextTypeEnv ctx
+      sig = getSigFromDefnOrDefVM ctx xobj
       fppl = projectFilePathPrintLength (contextProj ctx)
   case sig of
     Left err -> pure (ctx, Left err)
     Right okSig -> do
-      (_, expansionResult) <- expandAll evalExpandVM ctxDyn xobj
+      (_, expansionResult) <- expandAll evalExpandVM ctx xobj
       case expansionResult of
         Left err -> pure (ctx, Left err)
         Right expanded ->
-          let xobjFullSymbols = qualify ctxDyn expanded
+          let xobjFullSymbols = qualify ctx expanded
            in case xobjFullSymbols of
                 Left err -> pure (evalError ctx (show err) (xobjInfo xobj))
                 Right xs ->

--- a/test/nested_module_multisym.carp
+++ b/test/nested_module_multisym.carp
@@ -1,0 +1,26 @@
+(load "Test.carp")
+(use Test)
+
+; Regression test: the implicit `use Dynamic` that macro expansion installs
+; used to leak into the global env, which made unqualified multisym calls
+; (like `reduce` under `(use Array)`) inside nested modules pick up Dynamic
+; module candidates and stay generic instead of resolving concretely.
+
+(defmodule O
+  (deftype CM [values (Array (Pair String String))])
+  (defmodule CM
+    (use Array)
+    (defn to-map [m]
+      (reduce
+        &(fn [a v] (Map.put a (Pair.a v) (Pair.b v)))
+        {}
+        (CM.values m)))))
+
+(defn stringify []
+  (str &(Map.get &(O.CM.to-map &(O.CM.init [(Pair.init @"k" @"v")])) "k")))
+
+(deftest test
+  (assert-equal test
+                "v"
+                &(stringify)
+                "unqualified multisym calls in nested modules resolve concretely"))


### PR DESCRIPTION
Ths PR fixes an issue where `evalDynamicVM`, `evalExpandVM` and `annotateWithinContextVM` did an implicit `(use Dynamic)` on the global env so unqualified dynamic calls resolve during evaluation, but the modified env escaped through the returned context and stuck around permanently. Static symbol qualification then saw the `Dynamic` module used, and it just got super messy.

The implicit use path is now scrubbed from result contexts, and qualification in `annotateWithinContextVM` runs on the regular context.

Cheers