### PR TITLE
fix(emit): order module-nested types correctly in emitted C

### DIFF
--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -1330,7 +1330,7 @@ typeEnvToDeclarations typeEnv global =
             allScoredBinders
         pure (forwardDecls ++ concat okDecls)
   where
-    addEnvToScore tyE = (sortDeclarationBinders tyE global (map snd (Map.toList (binders tyE))))
+    addEnvToScore tyE = (sortDeclarationBinders typeEnv tyE global (map snd (Map.toList (binders tyE))))
     go sorted (XObj (Mod e t) _ _) = sorted ++ (foldl go (addEnvToScore t) (findModules e))
     go xs _ = xs
 
@@ -1366,7 +1366,7 @@ forwardDeclFromBinder _ = Nothing
 
 envToDeclarations :: TypeEnv -> Env -> Either ToCError String
 envToDeclarations typeEnv env =
-  let bindersWithScore = sortDeclarationBinders typeEnv env (map snd (Map.toList (envBindings env)))
+  let bindersWithScore = sortDeclarationBinders typeEnv typeEnv env (map snd (Map.toList (envBindings env)))
    in do
         okDecls <-
           mapM
@@ -1381,10 +1381,10 @@ envToDeclarations typeEnv env =
 -- debugScorePair :: (Int, Binder) -> (Int, Binder)
 -- debugScorePair (s,b) = trace ("Scored binder: " ++ show b ++ ", score: " ++ show s) (s,b)
 
-sortDeclarationBinders :: TypeEnv -> Env -> [Binder] -> [(Int, Binder)]
-sortDeclarationBinders typeEnv env binders' =
+sortDeclarationBinders :: TypeEnv -> TypeEnv -> Env -> [Binder] -> [(Int, Binder)]
+sortDeclarationBinders rootTypeEnv typeEnv env binders' =
   --trace ("\nSORTED: " ++ (show (sortOn fst (map (scoreBinder typeEnv) binders))))
-  sortOn fst (map (scoreTypeBinder typeEnv env) binders')
+  sortOn fst (map (scoreTypeBinder rootTypeEnv typeEnv env) binders')
 
 sortGlobalVariableBinders :: Env -> [Binder] -> [(Int, Binder)]
 sortGlobalVariableBinders globalEnv binders' =

--- a/src/Scoring.hs
+++ b/src/Scoring.hs
@@ -11,54 +11,54 @@ import TypesToC
 -- | Scoring of types.
 -- | The score is used for sorting the bindings before emitting them.
 -- | A lower score means appearing earlier in the emitted file.
-scoreTypeBinder :: TypeEnv -> Env -> Binder -> (Int, Binder)
-scoreTypeBinder typeEnv env b@(Binder _ (XObj (Lst (XObj x _ _ : XObj (Sym _ _) _ _ : _)) _ _)) =
+scoreTypeBinder :: TypeEnv -> TypeEnv -> Env -> Binder -> (Int, Binder)
+scoreTypeBinder rootTypeEnv typeEnv env b@(Binder _ (XObj (Lst (XObj x _ _ : XObj (Sym _ _) _ _ : _)) _ _)) =
   case x of
     Defalias aliasedType ->
       let selfName = ""
        in -- we add 1 here because deftypes generate aliases that
           -- will at least have the same score as the type, but
           -- need to come after. The increment represents this dependency
-          (depthOfType typeEnv Set.empty selfName aliasedType + 1, b)
+          (depthOfType rootTypeEnv typeEnv env Set.empty selfName aliasedType + 1, b)
     Deftype s -> depthOfStruct s
     DefSumtype s -> depthOfStruct s
     ExternalType _ -> (0, b)
     _ -> (500, b)
   where
     depthOfStruct (StructTy (ConcreteNameTy path@(SymPath _ name)) varTys) =
-      case E.getBinder typeEnv name <> E.searchTypeDef (TypeEnv env) path of
-        Right (Binder _ typedef) -> (depthOfDeftype typeEnv Set.empty typedef varTys + 1, b)
+      case E.getBinder typeEnv name <> E.getBinder rootTypeEnv name <> E.searchTypeDef (TypeEnv env) path of
+        Right (Binder _ typedef) -> (depthOfDeftype rootTypeEnv typeEnv env Set.empty typedef varTys + 1, b)
         -- TODO: This function should return (Either ScoringError (Int,
         -- Binder)) instead of calling error.
         Left e -> error (show e)
     depthOfStruct _ = error "depthofstruct"
-scoreTypeBinder _ _ b@(Binder _ (XObj (Mod _ _) _ _)) =
+scoreTypeBinder _ _ _ b@(Binder _ (XObj (Mod _ _) _ _)) =
   (1000, b)
-scoreTypeBinder _ _ b = (500, b)
+scoreTypeBinder _ _ _ b = (500, b)
 
-depthOfDeftype :: TypeEnv -> Set.Set Ty -> XObj -> [Ty] -> Int
-depthOfDeftype typeEnv visited (XObj (Lst (_ : XObj (Sym (SymPath path selfName) _) _ _ : rest)) _ _) varTys =
+depthOfDeftype :: TypeEnv -> TypeEnv -> Env -> Set.Set Ty -> XObj -> [Ty] -> Int
+depthOfDeftype rootTypeEnv typeEnv env visited (XObj (Lst (_ : XObj (Sym (SymPath path selfName) _) _ _ : rest)) _ _) varTys =
   case concatMap expandCase rest of
     [] -> 100
     xs -> maximum xs
   where
-    depthsFromVarTys = map (depthOfType typeEnv visited (concat (path ++ [selfName]))) varTys
+    depthsFromVarTys = map (depthOfType rootTypeEnv typeEnv env visited (concat (path ++ [selfName]))) varTys
     expandCase :: XObj -> [Int]
     expandCase (XObj (Arr arr) _ _) =
       let members = memberXObjsToPairs arr
-          depthsFromMembers = map (depthOfType typeEnv visited (concat (path ++ [selfName])) . snd) members
+          depthsFromMembers = map (depthOfType rootTypeEnv typeEnv env visited (concat (path ++ [selfName])) . snd) members
        in depthsFromMembers ++ depthsFromVarTys
     expandCase (XObj (Lst [XObj {}, XObj (Arr sumtypeCaseTys) _ _]) _ _) =
-      let depthsFromCaseTys = map (depthOfType typeEnv visited (concat (path ++ [selfName])) . fromJust . xobjToTy) sumtypeCaseTys
+      let depthsFromCaseTys = map (depthOfType rootTypeEnv typeEnv env visited (concat (path ++ [selfName])) . fromJust . xobjToTy) sumtypeCaseTys
        in depthsFromCaseTys ++ depthsFromVarTys
     expandCase (XObj (Sym _ _) _ _) =
       []
     expandCase _ = error "Malformed case in typedef."
-depthOfDeftype _ _ xobj _ =
+depthOfDeftype _ _ _ _ xobj _ =
   error ("Can't get dependency depth from " ++ show xobj)
 
-depthOfType :: TypeEnv -> Set.Set Ty -> String -> Ty -> Int
-depthOfType typeEnv visited selfName theType =
+depthOfType :: TypeEnv -> TypeEnv -> Env -> Set.Set Ty -> String -> Ty -> Int
+depthOfType rootTypeEnv typeEnv env visited selfName theType =
   if theType `elem` visited
     then 0
     else visitType theType + 1
@@ -103,11 +103,11 @@ depthOfType typeEnv visited selfName theType =
             | otherwise ->
               case concreteBinder of
                 Just (Right (Binder _ typedef)) ->
-                  depthOfDeftype typeEnv (Set.insert theType visited) typedef varTys
+                  depthOfDeftype rootTypeEnv typeEnv env (Set.insert theType visited) typedef varTys
                 _ ->
-                  case E.getBinder typeEnv s of
+                  case E.getBinder typeEnv s <> E.getBinder rootTypeEnv s <> E.searchTypeDef (TypeEnv env) (getStructPath struct) of
                     Right (Binder _ typedef) ->
-                      depthOfDeftype typeEnv (Set.insert theType visited) typedef varTys
+                      depthOfDeftype rootTypeEnv typeEnv env (Set.insert theType visited) typedef varTys
                     Left _ ->
                       --trace ("Unknown type: " ++ name) $
                       -- Two problems here:
@@ -122,10 +122,10 @@ depthOfType typeEnv visited selfName theType =
         s = getNameFromStructName (getStructName struct)
         concreteBinder =
           if (not (null varTys)) && (not (isTypeGeneric struct))
-            then Just (E.getBinder typeEnv (getNameFromStructName (tyToC struct)))
+            then Just (E.getBinder typeEnv (getNameFromStructName (tyToC struct)) <> E.getBinder rootTypeEnv (getNameFromStructName (tyToC struct)))
             else Nothing
         depthOfVarTys =
-          case fmap (depthOfType typeEnv visited (getStructName struct)) varTys of
+          case fmap (depthOfType rootTypeEnv typeEnv env visited (getStructName struct)) varTys of
             [] -> 1
             xs -> maximum xs + 1
 

--- a/test/emit_module_type_order.carp
+++ b/test/emit_module_type_order.carp
@@ -1,0 +1,20 @@
+(load "Test.carp")
+(use Test)
+
+; Regression test: a generic type instantiated with a module-nested type used
+; to be emitted before that type's struct definition in the generated C. The
+; dependency scorer couldn't resolve types inside modules (nor root types
+; referenced from module type members), so emission order degenerated to
+; accidental fallback scores.
+
+(defmodule M
+  (deftype Q (Lo []) (Hi []))
+  (deftype P [desc String inner (Maybe M.Q)])
+  (defn whole []
+    (the (Result M.P String) (Result.Success (P.init @"fine" (Maybe.Nothing))))))
+
+(deftest test
+  (assert-equal test
+                "fine"
+                (M.P.desc &(Result.unsafe-from-success (M.whole)))
+                "module-nested types are emitted before generic types embedding them"))


### PR DESCRIPTION
Closes #1344 

This PR fixes an issue where scoring type dependencies inside modules where resolved incorrectly and we added `500` to everything (because of the unknown type fallback).

The root type environment is now threaded through the scorer alongside the local one, and unresolved member types additionally get a full-path `searchTypeDef` lookup, so dependency depths are computed correctly.

Cheers