### PR TITLE
feat(core): add assert-near function to Test module

### DIFF
--- a/core/Test.carp
+++ b/core/Test.carp
@@ -65,6 +65,10 @@ Example:
   (defn assert-ref-equal [state x y descr]
     (handler state &x &y descr "value" =))
 
+  (doc assert-near "Assert that x and y are approximately equal within a specified margin.")
+  (defn assert-near [state x y margin descr]
+    (assert-op state x y descr (fn [a b] (Generics.approx-margin a b margin))))
+
   (doc assert-just "Assert that x is a `Just`.")
   (defn assert-just [state x descr]
     (assert-true state (Maybe.just? x) descr))

--- a/test/prototype_assert_near.carp
+++ b/test/prototype_assert_near.carp
@@ -6,6 +6,4 @@
   
   (assert-near near-tests 1.0 1.1 0.2 "doubles are near with large margin")
   
-  ;; This should fail (difference is 0.1, margin is 0.01)
-  (assert-near near-tests 1.0 1.1 0.01 "this failure is expected")
 )

--- a/test/prototype_assert_near.carp
+++ b/test/prototype_assert_near.carp
@@ -1,0 +1,11 @@
+(load-and-use Test)
+
+(deftest near-tests
+  (assert-near near-tests 1.0f 1.000001f 0.0001f "floats are near with float margin")
+  (assert-near near-tests 1.0 1.000001 0.0001 "doubles are near with double margin")
+  
+  (assert-near near-tests 1.0 1.1 0.2 "doubles are near with large margin")
+  
+  ;; This should fail (difference is 0.1, margin is 0.01)
+  (assert-near near-tests 1.0 1.1 0.01 "this failure is expected")
+)


### PR DESCRIPTION
Adds the assert-near function to core/Test.carp to assert approximate equality of floats/doubles within a specified margin.