### PR TITLE
stdlib: add cmul and neg to Vector2 to reach parity with Vector3

### DIFF
--- a/core/Vector.carp
+++ b/core/Vector.carp
@@ -25,6 +25,14 @@
   (defn sub [a b]
     (zip - a b))
 
+  (doc cmul "Get the component-wise product of two vectors.")
+  (defn cmul [a b]
+    (zip * a b))
+
+  (doc neg "Negate all components of a vector.")
+  (defn neg [a]
+    (map neg a))
+
   (defn mul [a n]
     (init (* @(x a) n)
           (* @(y a) n)))

--- a/test/vector2.carp
+++ b/test/vector2.carp
@@ -24,6 +24,14 @@
                 &(sub &(init 2.0 1.0) &(init 1.0 2.0))
                 "sub operator works")
   (assert-equal test
+                &(init 2.0 2.0)
+                &(Vector2.cmul &(init 2.0 1.0) &(init 1.0 2.0))
+                "cmul works")
+  (assert-equal test
+                &(init -2.0 -1.0)
+                &(Vector2.neg &(init 2.0 1.0))
+                "neg works")
+  (assert-equal test
                 &(init 4.0 2.0)
                 &(mul &(init 2.0 1.0) 2.0)
                 "mul operator works")


### PR DESCRIPTION
This PR adds the missing cmul (component-wise multiplication) and neg (negation) operations to Vector2 in core/Vector.carp to achieve parity with Vector3. It also adds matching test coverage to test/vector2.carp.