### PR TITLE
Add docexample and print-docexample to compiler and stdlib

### DIFF
--- a/core/Macros.carp
+++ b/core/Macros.carp
@@ -96,6 +96,14 @@
 (defmacro print-sig [name]
   (list 'macro-log (list 'meta name "sig")))
 
+(doc docexample "Annotate a binding with a code example.")
+(defmacro docexample [name example-string]
+  (list 'meta-set! name "docexample" example-string))
+
+(doc print-docexample "Print the annotated example for a binding.")
+(defmacro print-docexample [name]
+  (list 'macro-log (list 'meta name "docexample")))
+
 (doc hidden "Mark a binding as hidden, this will make it not print with the 'info' command.")
 (defmacro hidden [name]
   (list 'meta-set! name "hidden" true))

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -352,6 +352,7 @@ primitiveInfo _ ctx target@(XObj (Sym path@(SymPath _ name) _) _ _) =
         >> maybe (pure ()) (printMetaBool "Private") (Meta.get "private" metaData)
         >> maybe (pure ()) (printMetaBool "Hidden") (Meta.get "hidden" metaData)
         >> maybe (pure ()) (printMetaVal "Signature" pretty) (Meta.get "sig" metaData)
+        >> maybe (pure ()) (printMetaVal "Example" (either (const "") id . unwrapStringXObj)) (Meta.get "docexample" metaData)
         >> maybe (pure ()) printDeprecated (Meta.get "deprecated" metaData)
         >> when (projectPrintTypedAST proj) (putStrLnWithColor Yellow (prettyTyped x))
     printMetaBool :: String -> XObj -> IO ()

--- a/src/Primitives.hs
+++ b/src/Primitives.hs
@@ -352,7 +352,7 @@ primitiveInfo _ ctx target@(XObj (Sym path@(SymPath _ name) _) _ _) =
         >> maybe (pure ()) (printMetaBool "Private") (Meta.get "private" metaData)
         >> maybe (pure ()) (printMetaBool "Hidden") (Meta.get "hidden" metaData)
         >> maybe (pure ()) (printMetaVal "Signature" pretty) (Meta.get "sig" metaData)
-        >> maybe (pure ()) (printMetaVal "Example" (either (const "") id . unwrapStringXObj)) (Meta.get "docexample" metaData)
+        >> maybe (pure ()) (\xobj -> putStr ("  Example:\n" ++ (unlines . map ("    " ++) . lines $ either (const "") id (unwrapStringXObj xobj)))) (Meta.get "docexample" metaData)
         >> maybe (pure ()) printDeprecated (Meta.get "deprecated" metaData)
         >> when (projectPrintTypedAST proj) (putStrLnWithColor Yellow (prettyTyped x))
     printMetaBool :: String -> XObj -> IO ()

--- a/test/docexample_check.carp
+++ b/test/docexample_check.carp
@@ -6,9 +6,12 @@
 (docexample my-add "(my-add 10 20)")
 (defn my-add [a b] (+ a b))
 
+(defmacro get-my-add-docexample []
+  (meta my-add "docexample"))
+
 (deftest docexample-test
   (assert-dynamic-equal docexample-test
-                        (meta my-add "docexample")
+                        (get-my-add-docexample)
                         "(my-add 10 20)"
                         "docexample metadata is resolved correctly at compile-time")
 )

--- a/test/docexample_check.carp
+++ b/test/docexample_check.carp
@@ -1,0 +1,14 @@
+;; This file verifies the 'docexample' macro and metadata in core/Test.carp
+(load-and-use Test)
+
+(sig my-add (Fn [Int Int] Int))
+(doc my-add "Adds two integers.")
+(docexample my-add "(my-add 10 20)")
+(defn my-add [a b] (+ a b))
+
+(deftest docexample-test
+  (assert-dynamic-equal docexample-test
+                        (meta my-add "docexample")
+                        "(my-add 10 20)"
+                        "docexample metadata is resolved correctly at compile-time")
+)


### PR DESCRIPTION
Introduces 'docexample' metadata support for documenting code examples. Defines the 'docexample' macro in Macros.carp and updates the compiler's 'info' command to display it.