### PR TITLE
Treat flagged recursive types as generic to prevent infinite instantiation recursion

### DIFF
--- a/src/Deftype.hs
+++ b/src/Deftype.hs
@@ -239,7 +239,7 @@ binderForStrOrPrn strOrPrn candidate =
   let binderP = SymPath (TC.getFullPath candidate) strOrPrn
       binderT = (FuncTy [RefTy (TC.toType candidate) (VarTy "q")] StringTy StaticLifetimeTy)
       doc = "converts a `" ++ TC.getName candidate ++ "` to a string."
-   in if isTypeGeneric (TC.toType candidate)
+   in if isTypeGeneric (TC.toType candidate) || flagged (TC.getTypeEnv candidate) (TC.getValueEnv candidate) (TC.toType candidate)
         then Right $ (defineTypeParameterizedTemplate (TG.generateGenericTypeTemplate candidate strGenerator) binderP binderT doc, [])
         else Right $ instanceBinderWithDeps binderP binderT (TG.generateConcreteTypeTemplate candidate strGenerator) doc
 
@@ -249,7 +249,7 @@ binderForDelete candidate =
   let doc = "deletes a `" ++ TC.getName candidate ++ "`. Should usually not be called manually."
       binderP = SymPath (TC.getFullPath candidate) "delete"
       binderT = FuncTy [(TC.toType candidate)] UnitTy StaticLifetimeTy
-   in if isTypeGeneric (TC.toType candidate)
+   in if isTypeGeneric (TC.toType candidate) || flagged (TC.getTypeEnv candidate) (TC.getValueEnv candidate) (TC.toType candidate)
         then Right $ (defineTypeParameterizedTemplate (TG.generateGenericTypeTemplate candidate deleteGenerator) binderP binderT doc, [])
         else Right $ instanceBinderWithDeps binderP binderT (TG.generateConcreteTypeTemplate candidate deleteGenerator) doc
 
@@ -259,7 +259,7 @@ binderForCopy candidate =
   let doc = "copies a `" ++ TC.getName candidate ++ "`."
       binderP = SymPath (TC.getFullPath candidate) "copy"
       binderT = FuncTy [RefTy (TC.toType candidate) (VarTy "q")] (TC.toType candidate) StaticLifetimeTy
-   in if isTypeGeneric (TC.toType candidate)
+   in if isTypeGeneric (TC.toType candidate) || flagged (TC.getTypeEnv candidate) (TC.getValueEnv candidate) (TC.toType candidate)
         then Right $ (defineTypeParameterizedTemplate (TG.generateGenericTypeTemplate candidate copyGenerator) binderP binderT doc, [])
         else Right $ instanceBinderWithDeps binderP binderT (TG.generateConcreteTypeTemplate candidate copyGenerator) doc
 

--- a/src/Sumtypes.hs
+++ b/src/Sumtypes.hs
@@ -182,7 +182,7 @@ binderForStrOrPrn candidate strOrPrn =
       binderP = SymPath (TC.getFullPath candidate) strOrPrn
       binderT = FuncTy [RefTy (TC.toType candidate) (VarTy "q")] StringTy StaticLifetimeTy
    in Right $
-        if isTypeGeneric (TC.toType candidate)
+        if isTypeGeneric (TC.toType candidate) || flagged (TC.getTypeEnv candidate) (TC.getValueEnv candidate) (TC.toType candidate)
           then (defineTypeParameterizedTemplate (TG.generateGenericTypeTemplate candidate strGenerator) binderP binderT doc, [])
           else instanceBinderWithDeps binderP binderT (TG.generateConcreteTypeTemplate candidate strGenerator) doc
   where
@@ -212,7 +212,7 @@ binderForDelete candidate =
       binderT = FuncTy [t] UnitTy StaticLifetimeTy
       binderP = SymPath (TC.getFullPath candidate) "delete"
    in Right $
-        if isTypeGeneric t
+        if isTypeGeneric t || flagged (TC.getTypeEnv candidate) (TC.getValueEnv candidate) t
           then defineTypeParameterizedTemplate (TG.generateGenericTypeTemplate candidate generator) binderP binderT doc
           else instanceBinder binderP binderT (TG.generateConcreteTypeTemplate candidate generator) doc
   where
@@ -239,7 +239,7 @@ binderForCopy candidate =
       binderT = FuncTy [RefTy t (VarTy "q")] t StaticLifetimeTy
       binderP = SymPath (TC.getFullPath candidate) "copy"
    in Right $
-        if isTypeGeneric (TC.toType candidate)
+        if isTypeGeneric (TC.toType candidate) || flagged (TC.getTypeEnv candidate) (TC.getValueEnv candidate) (TC.toType candidate)
           then (defineTypeParameterizedTemplate (TG.generateGenericTypeTemplate candidate generator) binderP binderT doc, [])
           else instanceBinderWithDeps binderP binderT (TG.generateConcreteTypeTemplate candidate generator) doc
   where


### PR DESCRIPTION
### Summary
This PR prevents infinite recursion during type instantiation and template generation (e.g. `copy`, `delete`, and `str`/`prn` instances) for recursive sumtypes and deftypes.

### Problem
When a type includes a recursive reference to itself (such as a recursive `Box` type), the compiler's concrete template generator would recursively attempt to instantiate copies and deletes of the inner recursive member. This would result in an infinite loop during compilation, eventually crashing the compiler.

### Solution
In `src/Deftype.hs` and `src/Sumtypes.hs`, we update the instantiation functions (`binderForStrOrPrn`, `binderForDelete`, `binderForCopy`) to check if the type is recursive using the `flagged` helper:
- If a type is recursive/flagged, we treat it as a **generic type** during template instantiation.
- This instructs the compiler to generate a parameterized template instead of a concrete instance, successfully breaking the cycle and preventing the infinite copy/instantiation loops.
