### PR TITLE
Add result-do macro for flat Result pipelines

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -194,6 +194,33 @@ Example:
     (list 'let [name form]
       (case-internal name branches))))
 
+(hidden result-do-internal)
+(defndynamic result-do-internal [bindings body]
+  (if (= (length bindings) 0)
+    body
+    (let [name (car bindings)
+          expr (cadr bindings)
+          err-name (gensym)]
+      `(match %expr
+         (Result.Success %name) %(result-do-internal (cddr bindings) body)
+         (Result.Error %err-name) (Result.Error %err-name)))))
+
+(hidden result-do-arity-check)
+(defndynamic result-do-arity-check [bindings]
+  (if (= (mod (length bindings) 2) 1)
+    (macro-error "result-do requires an even number of forms in bindings (name/expr pairs)")
+    true))
+
+(doc result-do
+  "Flattens nested Result operations.
+  Takes an array of binding pairs `[name expr]` and a `body`.
+  If any `expr` evaluates to `(Result.Error e)`, it immediately short-circuits and returns that error.
+  Otherwise, it binds the unwrapped Success value to `name` and continues to the next step.")
+(defmacro result-do [bindings body]
+  (do
+    (result-do-arity-check bindings)
+    (result-do-internal bindings body)))
+
 (defmodule Dynamic
   (doc flip
        "Flips the arguments of a function `f`."

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -8,8 +8,39 @@
              (set! test-string @"new-string") ;; ignored, but side-effect performed
              (- 4 4)))
 
+(sig test-result-do-success (Fn [] (Result Int String)))
+(defn test-result-do-success []
+  (result-do [a (Result.Success 1)
+              b (Result.Success (+ a 1))
+              c (Result.Success (+ b 1))]
+    (Result.Success c)))
+
+(sig test-result-do-error (Fn [] (Result Int String)))
+(defn test-result-do-error []
+  (result-do [a (Result.Success 1)
+              b (the (Result Int String) (Result.Error @"error!"))
+              c (Result.Success (+ a 1))]
+    (Result.Success c)))
+
+(sig test-result-do-zero (Fn [] (Result Int String)))
+(defn test-result-do-zero []
+  (result-do []
+    (Result.Success 1)))
+
 (deftest test
   (assert-true test
     (and (= () (test-ignore-do)) (= &test-string "new-string"))
     "ignore-do performs side effects and ignores all results")
+  (assert-equal test
+    &(Result.Success 3)
+    &(test-result-do-success)
+    "result-do successfully returns unwrapped success")
+  (assert-equal test
+    &(Result.Error @"error!")
+    &(test-result-do-error)
+    "result-do correctly short-circuits on error")
+  (assert-equal test
+    &(Result.Success 1)
+    &(test-result-do-zero)
+    "result-do works with zero bindings")
 )


### PR DESCRIPTION
This PR adds the `result-do` macro to flatten nested `Result` operations (similar to Haskell's `do` notation or Rust's `?` operator). Includes an arity check for the bindings array, and corresponding unit tests.