### PR TITLE
Add maybe-do macro for flat Maybe pipelines

### DIFF
--- a/core/ControlMacros.carp
+++ b/core/ControlMacros.carp
@@ -194,6 +194,32 @@ Example:
     (list 'let [name form]
       (case-internal name branches))))
 
+(hidden maybe-do-internal)
+(defndynamic maybe-do-internal [bindings body]
+  (if (= (length bindings) 0)
+    body
+    (let [name (car bindings)
+          expr (cadr bindings)]
+      `(match %expr
+         (Maybe.Just %name) %(maybe-do-internal (cddr bindings) body)
+         (Maybe.Nothing) (Maybe.Nothing)))))
+
+(hidden maybe-do-arity-check)
+(defndynamic maybe-do-arity-check [bindings]
+  (if (= (mod (length bindings) 2) 1)
+    (macro-error "maybe-do requires an even number of forms in bindings (name/expr pairs)")
+    true))
+
+(doc maybe-do
+  "Flattens nested Maybe operations.
+  Takes an array of binding pairs `[name expr]` and a `body`.
+  If any `expr` evaluates to `(Maybe.Nothing)`, it immediately short-circuits and returns `(Maybe.Nothing)`.
+  Otherwise, it binds the unwrapped Just value to `name` and continues to the next step.")
+(defmacro maybe-do [bindings body]
+  (do
+    (maybe-do-arity-check bindings)
+    (maybe-do-internal bindings body)))
+
 (defmodule Dynamic
   (doc flip
        "Flips the arguments of a function `f`."

--- a/test/control_macros.carp
+++ b/test/control_macros.carp
@@ -8,8 +8,39 @@
              (set! test-string @"new-string") ;; ignored, but side-effect performed
              (- 4 4)))
 
+(sig test-maybe-do-success (Fn [] (Maybe Int)))
+(defn test-maybe-do-success []
+  (maybe-do [a (Maybe.Just 1)
+             b (Maybe.Just (+ a 1))
+             c (Maybe.Just (+ b 1))]
+    (Maybe.Just c)))
+
+(sig test-maybe-do-error (Fn [] (Maybe Int)))
+(defn test-maybe-do-error []
+  (maybe-do [a (Maybe.Just 1)
+             b (the (Maybe Int) (Maybe.Nothing))
+             c (Maybe.Just (+ a 1))]
+    (Maybe.Just c)))
+
+(sig test-maybe-do-zero (Fn [] (Maybe Int)))
+(defn test-maybe-do-zero []
+  (maybe-do []
+    (Maybe.Just 1)))
+
 (deftest test
   (assert-true test
     (and (= () (test-ignore-do)) (= &test-string "new-string"))
     "ignore-do performs side effects and ignores all results")
+  (assert-equal test
+    &(Maybe.Just 3)
+    &(test-maybe-do-success)
+    "maybe-do successfully returns unwrapped success")
+  (assert-equal test
+    &(the (Maybe Int) (Maybe.Nothing))
+    &(test-maybe-do-error)
+    "maybe-do correctly short-circuits on Nothing")
+  (assert-equal test
+    &(Maybe.Just 1)
+    &(test-maybe-do-zero)
+    "maybe-do works with zero bindings")
 )


### PR DESCRIPTION
This PR adds the `maybe-do` macro to flatten nested `Maybe` operations. Includes an arity check for the bindings array, and corresponding unit tests.